### PR TITLE
Reject missing Room.glb builds

### DIFF
--- a/src/litereality_agent/agent/tools/compile/tool.py
+++ b/src/litereality_agent/agent/tools/compile/tool.py
@@ -6,6 +6,8 @@ the harness can watch it to update build freshness / write revisions. Lazy impor
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from litereality_agent.agent.tools._scene import room_dir_from
 from litereality_agent.agent.tools.base import (
     BaseDeclarativeTool,
@@ -60,9 +62,9 @@ class CompileInvocation(SceneToolInvocation):
                 error=f"compile raised {type(e).__name__}: {e}",
                 build={"status": "error", "error": str(e)},
             )
-        if glb is None:
+        if glb is None or not Path(glb).is_file():
             return ToolResult(
-                error="compile failed — Room.py did not assemble (see build errors).",
+                error="compile failed — Room.py did not produce Room.glb (see build errors).",
                 build={"status": "error", "glb_path": None},
             )
         _write_compile_stamp(room_dir)

--- a/src/litereality_agent/room_ops/api.py
+++ b/src/litereality_agent/room_ops/api.py
@@ -81,6 +81,8 @@ def compile_room(
     if subprocess.run(cmd).returncode != 0:
         return None
     glb = preview / "Room.glb"
+    if not glb.is_file():
+        return None
     if bake:
         bake_room(preview / "Room.blend", glb, blender=blender)
     return glb

--- a/src/litereality_agent/room_ops/compile/build_from_room.py
+++ b/src/litereality_agent/room_ops/compile/build_from_room.py
@@ -177,6 +177,7 @@ def main() -> int:
     scan_dir = scan_frames if (scan_frames / "room.usdz").exists() else roomdir
 
     out_glb = preview / "Room.glb"
+    out_glb.unlink(missing_ok=True)
     # Run Room/<scan>/Room.py (its own copy of the SHELL); the shell rebuilds from SHELL, no usdz
     cmd = [
         blender,
@@ -202,7 +203,11 @@ def main() -> int:
         print(f"     {console.colour('dim')}… full log: {console.short(log)}{console.colour('off')}")
         return r.returncode
 
-    size = console.human_bytes(out_glb.stat().st_size) if out_glb.is_file() else "missing"
+    if not out_glb.is_file():
+        print(console.row("error", "Room.glb", f"missing   {detail}", "yellow"))
+        return 1
+
+    size = console.human_bytes(out_glb.stat().st_size)
     print(f"{console.row('done' if not failed else 'error', 'Room.glb', f'{size:<9} {detail}', 'yellow')}{took}")
     mark = "done" if built == len(manifest["assets"]) else "error"
     summary = f"{built}/{len(manifest['assets'])} objects" + (f"  ✗ {', '.join(failed)}" if failed else "")

--- a/tests/test_tool_compile.py
+++ b/tests/test_tool_compile.py
@@ -11,6 +11,7 @@ The Blender build itself is `-m blender`.
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 
 import pytest
 
@@ -74,6 +75,26 @@ def test_stamp_never_raises_on_an_unwritable_room(room, monkeypatch):
 
 def test_missing_room_py_is_not_fresh_rather_than_an_error(tmp_path):
     assert compile_is_fresh(tmp_path / "no-such-room") is False
+
+
+def test_compile_api_rejects_a_missing_glb(room, tmp_path, monkeypatch):
+    from litereality_agent.room_ops import api
+
+    monkeypatch.setattr(api.subprocess, "run", lambda _cmd: SimpleNamespace(returncode=0))
+    assert api.compile_room(room, out_dir=tmp_path / "preview", bake=False) is None
+
+
+def test_compile_tool_does_not_stamp_a_missing_glb(room, tmp_path, monkeypatch):
+    missing = tmp_path / "preview" / "Room.glb"
+    monkeypatch.setattr("litereality_agent.room_ops.compile_room", lambda *_a, **_k: missing)
+
+    inv = CompileInvocation(CompileParams(regenerate=False))
+    inv.bind(str(room), None)
+    result = asyncio.run(inv.execute())
+
+    assert not result.is_success()
+    assert result.build == {"status": "error", "glb_path": None}
+    assert not (room / ".compile_stamp").exists()
 
 
 @pytest.mark.blender


### PR DESCRIPTION
## What changed

The compiler now checks that `Room.glb` exists before it reports success. The Blender build command returns an error when the file is missing, and the compile tool no longer writes a freshness stamp for a missing file.

The build removes the prior generated GLB before assembly, so an old file cannot hide a failed build.

## Why

The build process could exit with code 0 without producing `Room.glb`. The API returned the expected path anyway, and callers marked the build as successful.

## Checks

`uv run pytest -q`

`uv run ruff check src tests sanity.py scripts`

The full test suite and lint checks pass.
