### PR TITLE
Fail incomplete reconstruction runs

### DIFF
--- a/src/litereality_agent/pipeline/scene_init/flow.py
+++ b/src/litereality_agent/pipeline/scene_init/flow.py
@@ -372,6 +372,13 @@ def _expected_by_branch(scan: str) -> dict[str, list[str]]:
     return {k: sorted(set(v)) for k, v in branches.items()}
 
 
+def _asset_is_built(recon: Path, name: str) -> bool:
+    if (recon / f"{name}.glb").is_file():
+        return True
+    d = recon / name
+    return any(d.glob("*.glb")) and (d / "object.py").is_file() and (d / "object.md").is_file()
+
+
 def _built_count(scan: str, expected: list[str]) -> int:
     """How many of `expected` are actually FINISHED.
 
@@ -385,15 +392,13 @@ def _built_count(scan: str, expected: list[str]) -> int:
     recon = config.reconstruct_dir(scan)
     if not recon.is_dir():
         return 0
-    done = 0
-    for name in expected:
-        if (recon / f"{name}.glb").is_file():  # neural: a single baked mesh, nothing else to write
-            done += 1
-            continue
-        d = recon / name
-        if any(d.glob("*.glb")) and (d / "object.py").is_file() and (d / "object.md").is_file():
-            done += 1
-    return done
+    return sum(_asset_is_built(recon, name) for name in expected)
+
+
+def _missing_assets(scan: str, expected: list[str]) -> list[str]:
+    """Expected assets that do not have a complete reconstruction on disk."""
+    recon = config.reconstruct_dir(scan)
+    return [name for name in expected if not _asset_is_built(recon, name)]
 
 
 def _reconstruction_phase(scan: str, args: argparse.Namespace, result: dict, full: bool) -> None:
@@ -746,7 +751,18 @@ def main(argv: list[str] | None = None) -> int:
         )
         for result in results
     )
-    return int(reconstruction_failed)
+    builds_requested = args.full or args.reconstruct or args.procedural or args.build_openings
+    incomplete = {}
+    if builds_requested and not args.dry_run_reconstruct:
+        incomplete = {
+            result["scan"]: _missing_assets(result["scan"], _expected_assets(result["scan"]))
+            for result in results
+        }
+        incomplete = {scan: names for scan, names in incomplete.items() if names}
+        if incomplete:
+            for scan, names in incomplete.items():
+                print(f"reconstruction incomplete for {scan}: {', '.join(names)}")
+    return int(reconstruction_failed or bool(incomplete))
 
 
 if __name__ == "__main__":

--- a/src/litereality_agent/pipeline/scene_init/reconstruct/flow.py
+++ b/src/litereality_agent/pipeline/scene_init/reconstruct/flow.py
@@ -378,8 +378,14 @@ def run_for_scan(
 
     proc = _run(cmd, cwd=str(REPO_ROOT))
     generated = sorted(p.name for p in recon_dir.glob("*.glb"))
-    plan["status"] = "ok" if proc.returncode == 0 else f"launcher_exit_{proc.returncode}"
+    failed = sorted(aid for aid, _ in refs if not (recon_dir / f"{aid}.glb").is_file())
+    if proc.returncode:
+        plan["status"] = f"launcher_exit_{proc.returncode}"
+    else:
+        plan["status"] = "failed" if failed else "ok"
     plan["generated"] = len(generated)
     plan["glb"] = generated
+    if failed:
+        plan["failed_assets"] = failed
     telemetry.event("reconstruct_done", scan=scan, status=plan["status"], generated=len(generated))
     return plan

--- a/tests/test_reconstruction_completion.py
+++ b/tests/test_reconstruction_completion.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_service_result_is_an_error_when_an_expected_glb_is_missing(tmp_path, monkeypatch):
+    from litereality_agent.pipeline.scene_init.reconstruct import flow, service
+
+    reference = tmp_path / "Chair0.png"
+    reference.write_bytes(b"reference")
+    output = tmp_path / "reconstructed"
+
+    class EmptyService:
+        name = "empty"
+
+        def reconstruct_many(self, *_args, **_kwargs):
+            return {"Chair0": str(output / "Chair0.glb")}
+
+    monkeypatch.setattr(flow.config, "reconstruct_dir", lambda _scan: output)
+    monkeypatch.setattr(flow, "collect_references", lambda _scan: [("Chair0", reference)])
+    monkeypatch.setattr(service, "_SERVICE", EmptyService())
+
+    result = flow.run_for_scan("scan")
+
+    assert result["status"] == "failed"
+    assert result["generated"] == 0
+    assert result["failed_assets"] == ["Chair0"]
+
+
+def test_flow_returns_nonzero_when_requested_assets_are_missing(monkeypatch):
+    from litereality_agent.pipeline.scene_init import flow
+
+    monkeypatch.setattr(flow, "resolve_scan", lambda *_args: (Path("capture"), "scan"))
+    monkeypatch.setattr(flow, "process_scan", lambda *_args: {"scan": "scan"})
+    monkeypatch.setattr(flow, "summarize", lambda _results: None)
+    monkeypatch.setattr(flow, "_expected_assets", lambda _scan: ["Chair0"])
+    monkeypatch.setattr(flow, "_missing_assets", lambda _scan, _expected: ["Chair0"])
+
+    assert flow.main(["--scan", "capture", "--reconstruct"]) == 1
+
+
+def test_flow_allows_a_room_with_no_expected_assets(monkeypatch):
+    from litereality_agent.pipeline.scene_init import flow
+
+    monkeypatch.setattr(flow, "resolve_scan", lambda *_args: (Path("capture"), "scan"))
+    monkeypatch.setattr(flow, "process_scan", lambda *_args: {"scan": "scan"})
+    monkeypatch.setattr(flow, "summarize", lambda _results: None)
+    monkeypatch.setattr(flow, "_expected_assets", lambda _scan: [])
+    monkeypatch.setattr(flow, "_missing_assets", lambda _scan, _expected: [])
+
+    assert flow.main(["--scan", "capture", "--reconstruct"]) == 0


### PR DESCRIPTION
## What changed

The TRELLIS service and local launcher paths now compare the requested assets with the GLBs on disk. They report missing assets instead of returning an `ok` status.

The reconstruction command now exits with an error when any expected asset is incomplete. A room with no expected assets and a dry run still succeed.

## Why

A backend could fail or return expected paths without writing any files. The reconstruction stage still returned success, so the required pipeline stage could continue with missing objects.

## Checks

`uv run pytest -q`

`uv run ruff check src tests sanity.py scripts`

The full test suite and lint checks pass.
