### PR TITLE
Fail terminal author provider errors

### DIFF
--- a/src/litereality_agent/agent/author.py
+++ b/src/litereality_agent/agent/author.py
@@ -293,6 +293,7 @@ async def run(room: Path, surface_ref: Path, scan: Path, model: str, max_turns: 
           flush=True)
     t0 = time.monotonic()
     result_text, cost = "", None
+    terminal_error = ""
     # Names and inputs live on ToolUseBlock only; the narrator holds the id→call map so a
     # ToolResultBlock can be attributed back. See tool_narration.py for what reading them off the
     # result block cost us.
@@ -350,6 +351,8 @@ async def run(room: Path, surface_ref: Path, scan: Path, model: str, max_turns: 
             result_text = m.result or ""
             cost = m.total_cost_usd
             stopped = m.stopped
+            if m.is_error:
+                terminal_error = result_text or "provider reported a terminal error"
     except BaseException as exc:  # noqa: BLE001 — including the SDK's turn-cap Exception
         # Running out of turns is not a failed run. `Room.py` is edited IN PLACE, so by this
         # point the session's work is already on disk; raising here threw it away, because
@@ -421,4 +424,6 @@ async def run(room: Path, surface_ref: Path, scan: Path, model: str, max_turns: 
     if broken:
         print(f"  ✗ Room.py does not compile and no checkpoint could be restored: {broken}",
               flush=True)
-    return 1 if broken else 0
+    if terminal_error:
+        print(f"  ✗ authoring provider failed: {terminal_error}", flush=True)
+    return 1 if broken or terminal_error else 0

--- a/tests/test_author_resilience.py
+++ b/tests/test_author_resilience.py
@@ -11,6 +11,7 @@ builds `Room.py`, so it must be valid Python. That is what these pin.
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 import pytest
@@ -83,6 +84,52 @@ def test_the_checkpoint_lives_outside_the_room(room: Path):
     assert ckpt.is_file()
     assert ckpt.parent != room
     assert not list(room.glob("*checkpoint*"))
+
+
+class _ResultHarness:
+    name = "test"
+    supports = frozenset()
+
+    def __init__(self, result):
+        self.result = result
+
+    def effective_model(self, spec):
+        return spec.model or "test"
+
+    async def run(self, _spec):
+        yield self.result
+
+
+def _run_with_result(room, tmp_path, monkeypatch, result):
+    from litereality_agent.agent import author, providers
+
+    refs = tmp_path / "refs"
+    scan = tmp_path / "scan"
+    refs.mkdir(exist_ok=True)
+    scan.mkdir(exist_ok=True)
+    monkeypatch.setattr(author, "surfaces_for", lambda _room: [])
+    monkeypatch.setattr(providers, "resolve", lambda *_args: _ResultHarness(result))
+    monkeypatch.setattr("litereality_agent.agent.scratch.bind", lambda **_kwargs: None)
+    monkeypatch.setattr("litereality_agent.agent.scratch.prompt_line", lambda: "")
+    return asyncio.run(author.run(room, refs, scan, "test", 1))
+
+
+def test_terminal_provider_error_fails_authoring(room, tmp_path, monkeypatch):
+    from litereality_agent.agent.providers import SessionResult
+
+    before = (room / "Room.py").read_text(encoding="utf-8")
+    result = SessionResult(result="authentication failed", is_error=True)
+
+    assert _run_with_result(room, tmp_path, monkeypatch, result) == 1
+    assert (room / "Room.py").read_text(encoding="utf-8") == before
+
+
+def test_deliberate_provider_stop_keeps_partial_success(room, tmp_path, monkeypatch):
+    from litereality_agent.agent.providers import SessionResult
+
+    result = SessionResult(result="budget reached", stopped="step budget")
+
+    assert _run_with_result(room, tmp_path, monkeypatch, result) == 0
 
 
 def test_polish_passes_remain_in_the_author_flow(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
## What changed

The author stage now checks `SessionResult.is_error` and returns an error when the provider reports a terminal failure.

Deliberate budget stops still keep valid partial work and return success. The tests cover both cases.

## Why

A provider could fail before making any edits, but the stage ignored the error flag and returned success because the unchanged seed file was valid Python.

## Checks

`uv run pytest -q`

`uv run ruff check src tests sanity.py scripts`

The full test suite and lint checks pass.
