### PR TITLE
Reject missing capture paths

### DIFF
--- a/src/litereality_agent/pipeline/context.py
+++ b/src/litereality_agent/pipeline/context.py
@@ -18,6 +18,16 @@ def _looks_like_scan(path: Path) -> bool:
     )
 
 
+def _looks_like_path(value: str | os.PathLike[str]) -> bool:
+    text = os.fspath(value)
+    return (
+        Path(text).expanduser().is_absolute()
+        or "/" in text
+        or "\\" in text
+        or text.startswith((".", "~"))
+    )
+
+
 @dataclass(frozen=True, slots=True)
 class RunContext:
     scan: str
@@ -63,6 +73,8 @@ class RunContext:
                 raise ValueError(f"{candidate} is neither a RoomPlan capture nor a scene package")
             scan, capture = candidate.name, candidate
         else:
+            if _looks_like_path(target):
+                raise ValueError(f"no such capture or scene path: {raw}")
             scan = str(target)
             capture = settings.resolved_scans_dir() / scan
 

--- a/tests/test_run_layout.py
+++ b/tests/test_run_layout.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from litereality_agent.pipeline.context import RunContext
 from litereality_agent.settings import LiteRealitySettings
 
@@ -30,3 +32,41 @@ def test_context_has_one_canonical_output_tree(tmp_path):
     assert ctx.scene_dir == tmp_path / "run" / "Office"
     assert ctx.object_root == ctx.scene_dir / "scene_init" / "obj_stage"
     assert ctx.seed_room == ctx.scene_dir / "scene_init" / "scene_stage" / "room_init" / "room"
+
+
+def test_missing_capture_path_is_rejected_before_output_is_created(tmp_path):
+    missing = tmp_path / "missing capture"
+    output = tmp_path / "run"
+    settings = LiteRealitySettings(
+        repo_root=tmp_path,
+        scans_dir=tmp_path / "captures",
+        output_root=output,
+    )
+
+    with pytest.raises(ValueError, match="no such capture or scene path"):
+        RunContext.resolve(missing, settings=settings)
+
+    assert not missing.exists()
+    assert not output.exists()
+
+
+def test_missing_relative_capture_path_is_rejected(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    settings = LiteRealitySettings(repo_root=tmp_path, output_root=tmp_path / "run")
+
+    with pytest.raises(ValueError, match="no such capture or scene path"):
+        RunContext.resolve("captures/missing", settings=settings)
+
+
+def test_bare_scan_name_still_resolves_under_the_scan_root(tmp_path):
+    settings = LiteRealitySettings(
+        repo_root=tmp_path,
+        scans_dir=tmp_path / "captures",
+        output_root=tmp_path / "run",
+    )
+
+    ctx = RunContext.resolve("Office", settings=settings)
+
+    assert ctx.scan == "Office"
+    assert ctx.capture_dir == (tmp_path / "captures" / "Office").resolve()
+    assert ctx.scene_dir == (tmp_path / "run" / "Office").resolve()


### PR DESCRIPTION
## What changed

`RunContext.resolve` now distinguishes a missing path from a bare scan name. It rejects missing absolute and relative paths before any pipeline output is created.

Bare scan names still resolve under the configured scan directory.

## Why

A missing path was treated as the scan name. An absolute value then replaced the configured output root during path joining, so one run could write state in two locations.

## Checks

`uv run pytest -q`

`uv run ruff check src tests sanity.py scripts`

The full test suite and lint checks pass.
