### PR TITLE
Copy RGBD files without a shell

### DIFF
--- a/src/litereality_agent/pipeline/scene_init/ingest/extract/lr_preprocessing/utils/utils.py
+++ b/src/litereality_agent/pipeline/scene_init/ingest/extract/lr_preprocessing/utils/utils.py
@@ -433,5 +433,5 @@ def extract_rgbd(scan_path, folder):
         np.save(extrinsic_name, pose)
 
         # Copy image and depth files
-        os.system(f"cp {image_path} {image_new_path}")
-        os.system(f"cp {depth_path} {depth_new_path}")
+        shutil.copyfile(image_path, image_new_path)
+        shutil.copyfile(depth_path, depth_new_path)

--- a/tests/test_rgbd_extraction.py
+++ b/tests/test_rgbd_extraction.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from litereality_agent.pipeline.scene_init import paths
+
+paths.ensure_lr_on_path()
+from utils import utils as ingest_utils  # noqa: E402, I001
+
+
+def _frame(image, depth):
+    return SimpleNamespace(
+        image_path_full=str(image),
+        depth_path=str(depth),
+        pose=np.eye(4),
+        intrinsics=np.eye(3),
+    )
+
+
+def test_rgbd_copy_supports_paths_with_spaces(tmp_path, monkeypatch):
+    source = tmp_path / "source files"
+    source.mkdir()
+    image = source / "source image.jpg"
+    depth = source / "source depth.jpg"
+    image.write_bytes(b"image")
+    depth.write_bytes(b"depth")
+    output = tmp_path / "output folder"
+    monkeypatch.setattr(
+        ingest_utils.scannerapp_utils,
+        "load_scan_frames_no_video",
+        lambda *_args, **_kwargs: [_frame(image, depth)],
+    )
+
+    ingest_utils.extract_rgbd("unused", str(output))
+
+    assert (output / "image" / "frame_0.jpg").read_bytes() == b"image"
+    assert (output / "depth" / "frame_0.jpg").read_bytes() == b"depth"
+
+
+def test_rgbd_copy_reports_a_missing_source(tmp_path, monkeypatch):
+    image = tmp_path / "missing image.jpg"
+    depth = tmp_path / "missing depth.jpg"
+    monkeypatch.setattr(
+        ingest_utils.scannerapp_utils,
+        "load_scan_frames_no_video",
+        lambda *_args, **_kwargs: [_frame(image, depth)],
+    )
+
+    with pytest.raises(FileNotFoundError):
+        ingest_utils.extract_rgbd("unused", str(tmp_path / "output"))


### PR DESCRIPTION
## What changed

RGBD extraction now copies image and depth files with `shutil.copyfile` instead of passing paths through a shell.

The tests cover paths with spaces and missing source files.

## Why

The shell command did not quote its paths or check the copy result. Paths with spaces failed silently, and shell characters in capture paths could be interpreted as commands.

## Checks

`uv run pytest -q`

`uv run ruff check src tests sanity.py scripts`

The full test suite and lint checks pass.
