### PR TITLE
Make Modal the default runtime and drop the Hugging Face requirement

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,17 +10,22 @@ BLENDER_PATH=
 # Folder holding your scans. Each <scan>/ = frame_*.jpg + frame_*.json + room.usdz.
 LR_SCANS_DIR=
 
-# --- TRELLIS, image -> 3D (required: pick ONE of the two blocks below) ---
-# A. Modal (recommended when the pipeline machine has no NVIDIA GPU).
-#    Deployment details: deploy/modal/README.md
-MODAL_TRELLIS_APP=
-MODAL_TRELLIS_FUNCTION=generate
-MODAL_DINO_APP=
-MODAL_DINO_FUNCTION=infer
-MODAL_ENVIRONMENT=main
+# --- hosted models on Modal (the default runtime) ---
+# Setting MODAL_PROFILE is the whole opt-in: it names a profile in ~/.modal.toml and selects
+# hosted TRELLIS (image -> 3D) plus hosted GroundingDINO + DINOv2, so the pipeline process never
+# loads torch and needs no NVIDIA GPU. Deploy first — see deploy/modal/README.md. No Hugging Face
+# account or token is required.
 MODAL_PROFILE=
 
-# B. …or a local GPU TRELLIS install (Linux + NVIDIA only) — that env's python interpreter.
+# Only needed when a workspace deploys the apps under non-default names.
+MODAL_TRELLIS_APP=litereality-trellis
+MODAL_TRELLIS_FUNCTION=generate
+MODAL_DINO_APP=litereality-dino
+MODAL_DINO_FUNCTION=infer
+MODAL_ENVIRONMENT=main
+
+# --- local runtimes (fallbacks, only used when MODAL_PROFILE is unset) ---
+# A local GPU TRELLIS install (Linux + NVIDIA only) — that env's python interpreter.
 TRELLIS_PYTHON=
 
 # --- isolated detection runtime ---

--- a/deploy/modal/README.md
+++ b/deploy/modal/README.md
@@ -3,30 +3,28 @@
 Modal hosts the GPU-backed model functions while the pipeline stays on the calling machine. The
 apps remain deployed between calls, but their containers scale to zero when idle.
 
+Modal is rented compute, not a model API: a Modal token gives you GPUs, not models, so nothing is
+callable until you deploy these apps into your own workspace.
+
 ## One-time setup
 
-1. Join the intended shared Modal workspace.
+1. Join the intended Modal workspace, or use your own — nothing is pinned to a particular one.
 2. Install the client with `uv sync --extra modal`.
 3. Authenticate and select an explicit local profile:
 
    ```bash
    uv run modal setup
    uv run modal profile list
-   uv run modal profile activate <shared-profile>
-   export MODAL_PROFILE=<shared-profile>
+   uv run modal profile activate <profile>
+   export MODAL_PROFILE=<profile>
    uv run modal profile current
    ```
 
    `MODAL_PROFILE` is required by the application. No workspace profile is hardcoded in source.
 
-4. For TRELLIS only, obtain access to
-   `facebook/dinov3-vitl16-pretrain-lvd1689m` on Hugging Face and create the workspace secret:
-
-   ```bash
-   uv run modal secret create --env main huggingface HF_TOKEN="$HF_TOKEN"
-   ```
-
-DINO uses public weights and does not need the Hugging Face secret.
+**No Hugging Face account or token is required for either app.** DINO's weights are public.
+TRELLIS.2-4B is MIT and ungated, and TRELLIS.2's gated DINOv3 image encoder is baked into the image
+from a digest-verified ungated mirror — see [`trellis/README.md`](trellis/README.md).
 
 ## Deploy
 
@@ -37,21 +35,38 @@ uv run modal deploy --env main deploy/modal/dino/app.py
 uv run modal deploy --env main deploy/modal/trellis/app.py
 ```
 
-Then configure the pipeline:
+Then configure the pipeline. Modal is the default runtime, so `MODAL_PROFILE` alone is enough —
+the app names, function names, and environment already default:
 
 ```dotenv
-MODAL_PROFILE=<shared-profile>
-MODAL_ENVIRONMENT=main
-MODAL_DINO_APP=litereality-dino
-MODAL_DINO_FUNCTION=infer
-MODAL_TRELLIS_APP=litereality-trellis
-MODAL_TRELLIS_FUNCTION=generate
+MODAL_PROFILE=<profile>
 ```
 
 The first deployment builds the images, and the first invocation downloads model weights into
 persistent Modal Volumes. DINO runs on an L4. TRELLIS runs on one H100 with zero application
 retries and a ten-second idle scale-down window. A deployed app with zero active containers does
 not consume GPU compute, though its stored image and Volume data remain.
+
+## What deployment costs
+
+Measured on a fresh workspace, 2026-08-06. The DINO image builds entirely on CPU. The TRELLIS image
+took 11.3 minutes and about $0.45, split almost evenly in time between the CPU dependency layers
+(318.0s) and the H100 extension compile (318.4s), with the GPU layer carrying roughly 78% of the
+cost. A redeploy after a source-only change took 2.8 seconds. The first request returned a valid
+512-texture GLB from `ChairCluster0` — 33,898 vertices, 47,793 faces — in 295.7s including the
+one-time weights download.
+
+Two known inefficiencies, both worth fixing before running this at volume:
+
+1. **Every workspace rebuilds the image.** Modal caches built images per workspace with no
+   cross-workspace sharing, so each deployer pays the same ~11 minutes and ~$0.45 to compile
+   identical extensions. Publishing the built image to a public registry and switching to
+   `modal.Image.from_registry(...)` would reduce a first deploy to a pull. The build needs an
+   NVIDIA GPU only because upstream's `setup.sh` checks `nvidia-smi` — `nvcc` itself compiles
+   without one, and `TORCH_CUDA_ARCH_LIST` is already pinned, so CI could build and publish it.
+2. **Weights download on the H100.** `_load_pipeline()` runs inside the `gpu="H100"` function, so
+   the first call transfers several GB at H100 prices (~$0.32 of that first request). A CPU-only
+   function populating the same Volume would cost about a cent.
 
 See [`dino/README.md`](dino/README.md) and [`trellis/README.md`](trellis/README.md) for model-specific
 details.

--- a/deploy/modal/dino/README.md
+++ b/deploy/modal/dino/README.md
@@ -4,17 +4,12 @@ This scale-to-zero app serves both GroundingDINO detection and DINOv2 embeddings
 canonical model code. Its image is CPU-built from precompiled wheels; an L4 is attached only while
 requests run. Public Hugging Face weights are cached in the `litereality-dino-models` Volume.
 
-Deploy only through the shared `huangzhening` profile:
+Deploy into whichever workspace the active profile names:
 
 ```bash
-MODAL_PROFILE=huangzhening modal deploy --env main deploy/modal/dino/app.py
+MODAL_PROFILE=<profile> modal deploy --env main deploy/modal/dino/app.py
 ```
 
-Configure the pipeline with:
-
-```dotenv
-MODAL_DINO_APP=litereality-dino
-MODAL_DINO_FUNCTION=infer
-MODAL_ENVIRONMENT=main
-MODAL_PROFILE=huangzhening
-```
+Configure the pipeline by setting `MODAL_PROFILE` to that same profile; `MODAL_DINO_APP`,
+`MODAL_DINO_FUNCTION`, and `MODAL_ENVIRONMENT` already default. No Hugging Face token is needed —
+both models are public.

--- a/deploy/modal/trellis/README.md
+++ b/deploy/modal/trellis/README.md
@@ -4,28 +4,36 @@ This is a deployment wrapper around
 `litereality_agent.models.trellis.inference`; model inference remains in `src/` and the Modal
 runtime only supplies a GPU, parallel execution, and a persistent weight cache.
 
-Before deploying, authenticate a profile whose workspace is **huangzhening** (the workspace at
-<https://modal.com/apps/huangzhening/main>) and verify it explicitly:
+Modal associates a deployment with the workspace belonging to the active profile; the workspace
+cannot be selected by app source code. Confirm which one you are about to bill, then deploy into
+its `main` environment:
 
 ```bash
 modal profile list
-modal profile activate <the-profile-for-huangzhening>
+modal profile activate <name>
 modal profile current
-```
 
-Modal associates deployments with the workspace belonging to the active profile; the workspace
-cannot be selected by app source code. Do not deploy from a personal-workspace profile.
-
-Then create/deploy into its `main` environment:
-
-```bash
-modal secret create huggingface HF_TOKEN=<token-with-facebook-dinov3-access>
 modal deploy --env main deploy/modal/trellis/app.py
 ```
 
-The `huggingface` secret is required because TRELLIS.2 uses the gated
-`facebook/dinov3-vitl16-pretrain-lvd1689m` image encoder. Store it only as a Modal secret; never
-put the token in the image or repository.
+## No Hugging Face account is needed
+
+TRELLIS.2's image encoder is the gated `facebook/dinov3-vitl16-pretrain-lvd1689m`, which is why
+this app previously required a `huggingface` Modal secret. It no longer does. The DINOv3 licence
+grants the right to "distribute, copy" the trained weights to third parties provided a copy of the
+licence travels with them, so the image bakes in an ungated mirror instead:
+
+- repo `camenduru/dinov3-vitl16-pretrain-lvd1689m`
+- revision `3c276edd87d6f6e569ff0c4400e086807d0f3881`
+- `model.safetensors` sha256 `dcb2e45127cccbf1601e5f42fef165eea275c8e5213197e8dcf3f48822718179`
+
+The build verifies that digest and fails if it does not match, so a mirror force-push cannot
+silently swap the weights. Four independent uploaders publish byte-identical copies under that same
+digest, which is how the weights were confirmed unmodified without holding gate access. Always pin
+by revision. `resolve_dinov3()` finds the baked copy through `LITEREALITY_DINOV3` and repoints
+`pipeline.json` at it, so loading never reaches the gated repo.
+
+`microsoft/TRELLIS.2-4B` is MIT and ungated, so no token is needed for it either.
 
 The base CUDA image, OS packages, PyTorch, and Python dependencies build on CPU. Modal attaches an
 H100 only to the separately cached native-extension layer required by the upstream TRELLIS
@@ -35,15 +43,16 @@ zero application retries, and scales that container down after ten idle seconds 
 
 The weights are hosted on Hugging Face, but the model is not currently served by a Hugging Face
 Inference Provider. The first invocation downloads `microsoft/TRELLIS.2-4B` into the
-`litereality-trellis-models` Volume; later containers reuse that cache. Configure the application:
+`litereality-trellis-models` Volume; later containers reuse that cache. Note that this download
+runs inside the `gpu="H100"` function, so several GB transfer at H100 prices — see the known
+inefficiencies in `../README.md`.
 
-```dotenv
-MODAL_TRELLIS_APP=litereality-trellis
-MODAL_TRELLIS_FUNCTION=generate
-MODAL_ENVIRONMENT=main
-MODAL_PROFILE=huangzhening
-```
+Configure the application by setting `MODAL_PROFILE` to your profile name; the app name, function
+name, and environment already default. Install client support with `uv sync --extra modal`.
 
-Install client support with `uv sync --extra modal`. The first deployment builds one native
-CUDA-extension layer on an H100 and therefore incurs limited GPU build cost; inference also uses
-H100s. Neither operation is part of the offline test suite.
+Measured on a fresh workspace, 2026-08-06: the image built in 11.3 minutes for about $0.45, split
+almost evenly in time between the CPU dependency layers (318.0s) and the H100 extension compile
+(318.4s), with the GPU layer carrying roughly 78% of the cost. Redeploy after a source-only change
+took 2.8 seconds. The first request returned a valid 512-texture GLB from `ChairCluster0` — 33,898
+vertices, 47,793 faces — in 295.7s including the weights download; later requests skip it. Neither
+building nor inference is part of the offline test suite.

--- a/deploy/modal/trellis/app.py
+++ b/deploy/modal/trellis/app.py
@@ -1,6 +1,7 @@
 """Modal deployment wrapper for the canonical TRELLIS.2 implementation.
 
-Deploy only from the shared ``huangzhening`` Modal workspace profile. See README.md.
+Deploys into whichever workspace the active ``MODAL_PROFILE`` names; the weights are ungated, so
+no Hugging Face account or secret is required. See README.md.
 """
 
 from __future__ import annotations
@@ -16,6 +17,16 @@ FUNCTION_NAME = "generate"
 MODEL_VOLUME = "litereality-trellis-models"
 REMOTE_REPO_ROOT = Path("/root")
 WEIGHTS_ROOT = Path("/models")
+
+# TRELLIS.2's image encoder is the gated ``facebook/dinov3-vitl16-pretrain-lvd1689m``. The DINOv3
+# licence grants the right to redistribute the trained weights provided the licence travels with
+# them, so we bake an ungated mirror into the image instead of requiring every deployer to hold an
+# HF account. Pinned by commit and verified by digest: a mirror owner can force-push or delete the
+# repo, and four independent uploads of these weights agree on this digest.
+DINOV3_DIR = Path("/opt/dinov3")
+DINOV3_REPO = "camenduru/dinov3-vitl16-pretrain-lvd1689m"
+DINOV3_REVISION = "3c276edd87d6f6e569ff0c4400e086807d0f3881"
+DINOV3_SHA256 = "dcb2e45127cccbf1601e5f42fef165eea275c8e5213197e8dcf3f48822718179"
 
 deployment_root = Path(__file__).resolve().parent
 image = (
@@ -36,17 +47,26 @@ image = (
     # Keep this after the cached native-extension layer so the compatibility pin
     # remains a CPU-only image operation and cannot trigger another GPU build.
     .pip_install("transformers==4.57.5")
+    # CPU-only, and deliberately after the cached GPU layer so pulling 1.2GB of weights can never
+    # trigger another H100 build. Fails the build on a digest mismatch rather than at inference.
+    .run_commands(
+        f"python3.10 -c \"from huggingface_hub import snapshot_download; \
+snapshot_download('{DINOV3_REPO}', revision='{DINOV3_REVISION}', local_dir='{DINOV3_DIR}')\"",
+        f"echo '{DINOV3_SHA256}  {DINOV3_DIR}/model.safetensors' | sha256sum -c -",
+    )
     .env(
         {
             "LR_REPO_ROOT": str(REMOTE_REPO_ROOT),
             "LITEREALITY_WEIGHTS": str(WEIGHTS_ROOT),
             "HF_XET_HIGH_PERFORMANCE": "1",
+            # resolve_dinov3() reads this first; with it set, pipeline.json is repointed at the
+            # local copy and loading never reaches the gated repo, so no HF token is needed.
+            "LITEREALITY_DINOV3": str(DINOV3_DIR),
         }
     )
     .add_local_python_source("litereality_agent")
 )
 weights = modal.Volume.from_name(MODEL_VOLUME, create_if_missing=True)
-huggingface = modal.Secret.from_name("huggingface", required_keys=["HF_TOKEN"])
 app = modal.App(APP_NAME)
 _pipeline = None
 
@@ -70,7 +90,6 @@ def _load_pipeline():
     image=image,
     gpu="H100",
     volumes={str(WEIGHTS_ROOT): weights},
-    secrets=[huggingface],
     timeout=20 * 60,
     retries=0,
     scaledown_window=10,

--- a/src/litereality_agent/models/registry.py
+++ b/src/litereality_agent/models/registry.py
@@ -7,9 +7,10 @@ from litereality_agent.settings import LiteRealitySettings, load_settings
 
 def gen3d_from_settings(settings: LiteRealitySettings | None = None):
     settings = settings or load_settings()
-    if settings.modal_trellis_app:
-        if not settings.modal_profile:
-            raise RuntimeError("MODAL_PROFILE must be set when using hosted TRELLIS.")
+    # Modal is the default runtime, so a configured profile is the whole opt-in; the app name
+    # already defaults. Keying off the profile rather than the app name keeps an explicit local
+    # GPU runtime reachable now that MODAL_TRELLIS_APP is never empty.
+    if settings.modal_profile:
         from litereality_agent.models.trellis.modal import ModalTrellisService
 
         return ModalTrellisService(
@@ -23,16 +24,14 @@ def gen3d_from_settings(settings: LiteRealitySettings | None = None):
 
         return LocalTrellisService(python=str(settings.trellis_python))
     raise RuntimeError(
-        "TRELLIS is not configured: set MODAL_TRELLIS_APP for hosted execution or "
+        "TRELLIS is not configured: set MODAL_PROFILE for hosted execution (the default) or "
         "TRELLIS_PYTHON for an explicit local GPU runtime."
     )
 
 
 def detection_from_settings(settings: LiteRealitySettings | None = None):
     settings = settings or load_settings()
-    if settings.modal_dino_app:
-        if not settings.modal_profile:
-            raise RuntimeError("MODAL_PROFILE must be set when using hosted DINO.")
+    if settings.modal_profile:
         from litereality_agent.models.grounding_dino.modal import ModalDinoService
 
         return ModalDinoService(

--- a/src/litereality_agent/settings.py
+++ b/src/litereality_agent/settings.py
@@ -86,11 +86,16 @@ class LiteRealitySettings(BaseSettings):
 
     openai_api_key: SecretStr | None = Field(default=None, validation_alias="OPENAI_API_KEY")
     anthropic_api_key: SecretStr | None = Field(default=None, validation_alias="ANTHROPIC_API_KEY")
-    modal_trellis_app: str | None = Field(default=None, validation_alias="MODAL_TRELLIS_APP")
+    # Modal is the default execution runtime, so the app names carry the deployed defaults and
+    # MODAL_PROFILE alone selects hosted execution. Override these only when a workspace deploys
+    # the apps under different names.
+    modal_trellis_app: str = Field(
+        default="litereality-trellis", validation_alias="MODAL_TRELLIS_APP"
+    )
     modal_trellis_function: str = Field(
         default="generate", validation_alias="MODAL_TRELLIS_FUNCTION"
     )
-    modal_dino_app: str | None = Field(default=None, validation_alias="MODAL_DINO_APP")
+    modal_dino_app: str = Field(default="litereality-dino", validation_alias="MODAL_DINO_APP")
     modal_dino_function: str = Field(default="infer", validation_alias="MODAL_DINO_FUNCTION")
     modal_environment: str = Field(default="main", validation_alias="MODAL_ENVIRONMENT")
     modal_profile: str | None = Field(default=None, validation_alias="MODAL_PROFILE")

--- a/tests/test_modal_trellis.py
+++ b/tests/test_modal_trellis.py
@@ -173,10 +173,48 @@ def test_registry_selects_modal_trellis(monkeypatch):
 def test_registry_never_implicitly_runs_trellis_locally():
     from litereality_agent.models import registry
 
-    settings = SimpleNamespace(modal_trellis_app=None, trellis_python=None)
+    # The app name now carries a default, so an unset profile is what leaves TRELLIS unconfigured.
+    settings = SimpleNamespace(
+        modal_profile=None, modal_trellis_app="litereality-trellis", trellis_python=None
+    )
 
     with pytest.raises(RuntimeError, match="TRELLIS is not configured"):
         registry.gen3d_from_settings(settings)
+
+
+def test_registry_prefers_modal_when_only_a_profile_is_set(monkeypatch):
+    """MODAL_PROFILE alone selects hosted TRELLIS: Modal is the default runtime."""
+    from litereality_agent.models import registry
+
+    class Service:
+        def __init__(self, **options):
+            pass
+
+    monkeypatch.setattr("litereality_agent.models.trellis.modal.ModalTrellisService", Service)
+    settings = SimpleNamespace(
+        modal_profile="a-workspace",
+        modal_trellis_app="litereality-trellis",
+        modal_trellis_function="generate",
+        modal_environment="main",
+        # Set, and still not used — a configured profile wins over the local runtime.
+        trellis_python=sys.executable,
+    )
+
+    assert isinstance(registry.gen3d_from_settings(settings), Service)
+
+
+def test_registry_falls_back_to_local_trellis_without_a_profile():
+    """An explicit local GPU runtime stays reachable now that the app name always has a value."""
+    from litereality_agent.models import registry
+    from litereality_agent.models.trellis.service import LocalTrellisService
+
+    settings = SimpleNamespace(
+        modal_profile=None,
+        modal_trellis_app="litereality-trellis",
+        trellis_python=sys.executable,
+    )
+
+    assert isinstance(registry.gen3d_from_settings(settings), LocalTrellisService)
 
 
 def test_modal_client_uses_named_function_map():


### PR DESCRIPTION
Two changes on top of #8, verified end to end on a fresh Modal workspace that had never deployed
these apps.

## Serve DINOv3 from an ungated mirror

TRELLIS.2's image encoder is the gated `facebook/dinov3-vitl16-pretrain-lvd1689m`. That is why the
app carried a `huggingface` Modal secret and why `deploy/modal/README.md` step 4 told every
deployer to obtain gated access. **Neither is necessary.**

The DINOv3 licence grants a non-exclusive right to "distribute, copy" the trained weights,
including to third parties, provided a copy of the Agreement travels with them. The image now bakes
in an ungated mirror, pinned by commit and verified by digest:

```
camenduru/dinov3-vitl16-pretrain-lvd1689m
revision 3c276edd87d6f6e569ff0c4400e086807d0f3881
sha256   dcb2e45127cccbf1601e5f42fef165eea275c8e5213197e8dcf3f48822718179
```

Four independent uploaders publish byte-identical copies under that digest, which is how the
weights were confirmed unmodified without holding gate access. The build verifies it and fails
rather than letting a mirror force-push surface at inference time. The download sits after the
cached H100 layer, so it stays a CPU-only image operation.

`resolve_dinov3()` already looked for exactly this via `LITEREALITY_DINOV3` — only the slot was
empty. `microsoft/TRELLIS.2-4B` is MIT and ungated, so **no Hugging Face account is needed at all
now**, for either app.

## Make Modal the default runtime

`MODAL_TRELLIS_APP` and `MODAL_DINO_APP` carry the deployed names as defaults, so `MODAL_PROFILE`
alone selects hosted execution.

Selection had to move from the app name to `modal_profile`: with the app name never empty, keying
off it would leave an explicit local GPU runtime unreachable — anyone with `TRELLIS_PYTHON` set but
no profile would hit *"MODAL_PROFILE must be set"* instead of using their local install. Two tests
cover the new contract, and `test_registry_never_implicitly_runs_trellis_locally` still holds.

## Verification

Deployed into a workspace with **no `huggingface` secret present**, from a machine with no HF
account configured:

- image built in 11.3 min / ~$0.45 — 318.0s CPU deps, 318.4s H100 extension compile (~78% of cost)
- digest check passed in-build: `/opt/dinov3/model.safetensors: OK`
- redeploy after a source-only change: **2.8s**
- first request: valid glTF 2.0 from `ChairCluster0`, 33,898 vertices / 47,793 faces, 295.7s
  including the one-time weights download
- `modal app list` shows `deployed` with 0 tasks after the run

Face count differs from #8's reported 19,480 because `_decimation_target()` targets
`1_000_000 × (1 − simplify)`; this run used the default `simplify=0.95` (→ 50,000) rather than
≈0.98.

Offline: `pytest -q` 386 passed / 5 skipped / 8 deselected / 1 xfailed, `ruff check` clean.

## Not addressed here

Both are recorded in `deploy/modal/README.md` rather than fixed:

1. **Every workspace rebuilds the image** — Modal caches images per workspace with no
   cross-workspace sharing, so each deployer repays ~11 min and ~$0.45 compiling identical
   extensions. Publishing to a registry and using `Image.from_registry(...)` would make a first
   deploy a pull. The GPU is needed only because upstream's `setup.sh` checks `nvidia-smi`; `nvcc`
   compiles without one and `TORCH_CUDA_ARCH_LIST` is already pinned, so CI could build it.
2. **Weights download on the H100** — `_load_pipeline()` runs inside the `gpu="H100"` function, so
   several GB transfer at H100 prices (~$0.32 of that first request). A CPU-only warm function
   would cost about a cent.
