### PR TITLE
Show a scan-vs-reconstruction demo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 LiteReality-Agent turns a RoomPlan capture into an editable `Room.py`, a compiled `Room.glb`, and a
 self-contained viewer.
 
+![RGBD scan on the left, agentic reconstruction on the right](assets/demo.gif)
+
 ```text
 capture → scene_init (ingest → reconstruct → seed)
         → realism_authoring (author → publish)


### PR DESCRIPTION
Adds `assets/demo.gif` at the top of the README — RGBD scan on the left, agentic reconstruction on the right, panning through the room.

Encoded from the 1080p30 source at 800x450 / 15fps, full 256-colour palette, no dithering, then `gifsicle -O3 --lossy=60`.

On the size: GIF can't compress a continuous full-frame camera pan — every one of the 101 frames is effectively a new image, so lossy optimisation and dithering tricks buy very little. Measured floors were 19 MB at 1280px and 12 MB at 960px. 800px lands at 8.8 MB, and since the README column renders at roughly 900px the visible difference is small. Dropping dithering was free here: it was indistinguishable from bayer on the smooth wall gradients but much smaller.

The 1080p source `github.mp4` is deliberately not committed.