### PR TITLE
Unblock the QC gates and parallelise the per-object hosted calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ __MACOSX
 
 # retired code, kept locally for reference only (recoverable), not pushed
 /legacy/
+# scratch measurement runs (run-measure, run-measure2, ...)
+/run-measure*

--- a/models.env
+++ b/models.env
@@ -59,6 +59,11 @@ export LR_CHAIR_JUDGE_MODEL="${LR_CHAIR_JUDGE_MODEL:-claude-opus-5}"
 # Same options as HARNESS_MODEL above.
 export LR_PROCEDURAL_MODEL="${LR_PROCEDURAL_MODEL:-claude-opus-5}"
 
+# Completeness gate (reference-vs-render "is anything missing"). Runs once per build attempt per
+# object and sits on the critical path. Defaults to HARNESS_MODEL. Lowering it is tempting but
+# two-sided: too lenient ships objects missing parts, too strict costs a full agent rebuild.
+export LR_COMPLETENESS_MODEL="${LR_COMPLETENESS_MODEL:-$HARNESS_MODEL}"
+
 # ── OpenAI — reference image generation only ────────────────────────────────
 # Options: gpt-image-2 (default, latest) · gpt-image-1 (legacy). Latest gives sharper, more
 # faithful object renders; gpt-image-1 kept only as a fallback.

--- a/src/litereality_agent/models/object_generation/README.md
+++ b/src/litereality_agent/models/object_generation/README.md
@@ -51,7 +51,8 @@ procedural/glb/<scan>/<name>/
     object.md             how to edit it (constants, joints, rebuild)
     previews/             render-check (open/closed for movers, iso/front for static)
     textures/
-procedural/glb/procedural_report.json
+procedural/glb/procedural_report.json   objects pass
+procedural/glb/openings_report.json     doors/windows pass (--openings)
 ```
 
 Each moving part carries glTF node extras `articulation_type`

--- a/src/litereality_agent/models/object_generation/articulated-glb-agent/.claude/skills/image-to-articulated-glb/scripts/completeness_check.py
+++ b/src/litereality_agent/models/object_generation/articulated-glb-agent/.claude/skills/image-to-articulated-glb/scripts/completeness_check.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import base64
 import json
 import os
 import re
@@ -38,27 +39,61 @@ PROMPT = (
 )
 
 
+_MIME = {".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg", ".webp": "image/webp"}
+
+
+def _blocks(images: list[Path]) -> list[dict]:
+    """The images as Messages-API content blocks, each labelled so the prompt can refer to it."""
+    out: list[dict] = []
+    for i, p in enumerate(images):
+        out.append({"type": "text", "text": f"IMAGE {i + 1} ({'REFERENCE' if i == 0 else p.name}):"})
+        out.append({
+            "type": "image",
+            "source": {
+                "type": "base64",
+                "media_type": _MIME.get(p.suffix.lower(), "image/png"),
+                "data": base64.b64encode(p.read_bytes()).decode(),
+            },
+        })
+    out.append({"type": "text", "text": PROMPT})
+    return out
+
+
 async def _ask(images: list[Path]) -> str:
+    """Ask the judge in ONE turn, with the images attached to the prompt.
+
+    They used to be named as paths and pulled in with the `Read` tool — one model round-trip per
+    image before the question could even be answered, five for a reference plus three renders, on
+    every build attempt of every object, on the critical path. `query()` also accepts a streamed
+    user message whose content is Messages-API blocks, so the images can ride along with the
+    prompt: same logged-in-CLI auth (no ANTHROPIC_API_KEY, still unmetered), one turn instead of
+    five. Measured on one reference image: 9.2s/2 turns -> 3.8s/1 turn.
+    """
     from claude_agent_sdk import ClaudeAgentOptions, ResultMessage, query
 
     opts = ClaudeAgentOptions(
-        cwd=str(images[0].parent),
-        add_dirs=sorted({str(p.parent) for p in images}),
         system_prompt={"type": "preset", "preset": "claude_code"},
         setting_sources=[],
-        allowed_tools=["Read"],
+        allowed_tools=[],  # nothing to fetch — the images are already in the prompt
         permission_mode="bypassPermissions",
-        max_turns=len(images) + 3,
+        max_turns=2,
         # Its own knob, defaulting to the harness model (unchanged behaviour). This gate decides
         # whether to throw a build away and rebuild it from scratch, so a cheaper judge is not a
         # free win: too lenient ships an object missing parts, too strict costs a full agent
         # rebuild. Worth measuring per-tier against known-good builds before moving the default.
         model=os.environ.get("LR_COMPLETENESS_MODEL") or os.environ.get("HARNESS_MODEL", "claude-opus-5"),
     )
-    listing = "\n".join(f"- IMAGE {i + 1}: {p}" for i, p in enumerate(images))
-    full = f"First Read (view) EVERY image below, then answer.\n{listing}\n\n{PROMPT}"
+
+    async def stream():
+        yield {
+            "type": "user",
+            "message": {"role": "user", "content": _blocks(images)},
+            "parent_tool_use_id": None,
+            "session_id": "completeness",
+        }
+
     out = ""
-    async for m in query(prompt=full, options=opts):
+    async for m in query(prompt=stream(), options=opts):
         if isinstance(m, ResultMessage):
             out = m.result or ""
     return out

--- a/src/litereality_agent/models/object_generation/articulated-glb-agent/.claude/skills/image-to-articulated-glb/scripts/completeness_check.py
+++ b/src/litereality_agent/models/object_generation/articulated-glb-agent/.claude/skills/image-to-articulated-glb/scripts/completeness_check.py
@@ -49,7 +49,11 @@ async def _ask(images: list[Path]) -> str:
         allowed_tools=["Read"],
         permission_mode="bypassPermissions",
         max_turns=len(images) + 3,
-        model=os.environ.get("HARNESS_MODEL", "claude-opus-5"),
+        # Its own knob, defaulting to the harness model (unchanged behaviour). This gate decides
+        # whether to throw a build away and rebuild it from scratch, so a cheaper judge is not a
+        # free win: too lenient ships an object missing parts, too strict costs a full agent
+        # rebuild. Worth measuring per-tier against known-good builds before moving the default.
+        model=os.environ.get("LR_COMPLETENESS_MODEL") or os.environ.get("HARNESS_MODEL", "claude-opus-5"),
     )
     listing = "\n".join(f"- IMAGE {i + 1}: {p}" for i, p in enumerate(images))
     full = f"First Read (view) EVERY image below, then answer.\n{listing}\n\n{PROMPT}"

--- a/src/litereality_agent/models/object_generation/generate.py
+++ b/src/litereality_agent/models/object_generation/generate.py
@@ -309,6 +309,31 @@ def completeness_feedback(report: dict) -> str:
     return "\n".join(lines)
 
 
+def resume_note(job: Job) -> str:
+    """Point a retry at the previous attempt's artifacts instead of letting it start over.
+
+    The base prompt says "build ONE procedural 3D GLB", and a retry re-sends it to a FRESH session
+    that has no memory of the last attempt — so a gate rejecting one missing handle threw away a
+    correct build and paid for the whole thing again (the window rebuild cost ~600s and a second
+    full agent session). The recipe, object.py and previews are all still on disk; `object.py` only
+    gets swept away by drop_build_recipe once the object PASSES. Naming those files turns the retry
+    into an edit. Only the listed files are mentioned, so a genuinely empty directory still
+    produces a from-scratch build.
+    """
+    d = job.glb.parent
+    existing = [p.name for p in sorted(d.glob("build_*.py"))]
+    existing += [n for n in ("object.py",) if (d / n).is_file()]
+    if not existing:
+        return ""
+    return (
+        f"\n\n## PREVIOUS ATTEMPT — do NOT start from scratch.\n"
+        f"Attempt {job.attempts} of this object is already on disk in {d}:\n"
+        + "".join(f"  - {n}\n" for n in existing)
+        + "Read the build recipe, make the SMALLEST change that fixes the issues below, then "
+        "re-run it, re-render and re-check. Keep everything that is already correct."
+    )
+
+
 def verify_reasons(job: Job) -> list[str]:
     """Why this object is NOT considered built. Empty means it is.
 
@@ -515,7 +540,8 @@ async def process(job: Job, sem: asyncio.Semaphore, args) -> None:
                     break
                 job.status = "failed"
                 job.error = "incomplete: " + "; ".join(comp.get("missing") or [])[:150]
-                feedback = completeness_feedback(comp)  # retry to ADD the missing features
+                # retry to ADD the missing features, editing the build already on disk
+                feedback = resume_note(job) + completeness_feedback(comp)
                 print(f"[fail] {job.scan}/{job.name}: {job.error}", file=sys.stderr)
                 continue
             job.status = "failed"
@@ -525,7 +551,7 @@ async def process(job: Job, sem: asyncio.Semaphore, args) -> None:
                 f"QC failed: {'; '.join(v['check'] + ':' + v['part'] for v in hard)}"
                 if hard else (job.error or "GLB/previews/deliverables missing")
             )
-            feedback = probe_feedback(job.probe)
+            feedback = resume_note(job) + probe_feedback(job.probe)
             print(f"[fail] {job.scan}/{job.name}: {job.error}", file=sys.stderr)
         job.seconds = time.time() - t0
         mark = "ok  " if job.status == "ok" else "FAIL"
@@ -578,7 +604,11 @@ async def main_async(args) -> int:
         "out": str(out_root),
         "jobs": [vars(j) | {"image": str(j.image), "glb": str(j.glb)} for j in jobs],
     }
-    (out_root / "procedural_report.json").write_text(
+    # Per-branch filename. The objects pass and the openings pass share one `out_root` and used to
+    # write the same `procedural_report.json`, so whichever finished last silently replaced the
+    # other's report — the last run's file listed only the two openings, with Table0/Table1 gone.
+    # Serially that was a deterministic overwrite; now that the branches run together it is a race.
+    (out_root / f"{'openings' if args.openings else 'procedural'}_report.json").write_text(
         json.dumps(report, indent=2, default=str), encoding="utf-8"
     )
     ok = sum(1 for j in jobs if j.status == "ok")

--- a/src/litereality_agent/models/object_generation/generate.py
+++ b/src/litereality_agent/models/object_generation/generate.py
@@ -471,8 +471,16 @@ def _skill_instructions() -> str:
 
 
 async def process(job: Job, sem: asyncio.Semaphore, args) -> None:
+    # The QC gates below (probe_glb, completeness_report) are blocking subprocess.run calls, and
+    # one of them is a whole agent session. Called directly they stall the event loop, which
+    # freezes every OTHER job's agent session too — `--concurrency N` then buys nothing during
+    # the gates, and the gates are where most of the wall time is. Hand them to a thread.
     async with sem:
-        reasons = verify_reasons(job) if args.skip_existing else ["--skip-existing not set"]
+        reasons = (
+            await asyncio.to_thread(verify_reasons, job)
+            if args.skip_existing
+            else ["--skip-existing not set"]
+        )
         if args.skip_existing and not reasons:
             job.status = "skipped"
             drop_build_recipe(job.glb.parent)  # clean recipes left by earlier runs too
@@ -492,9 +500,14 @@ async def process(job: Job, sem: asyncio.Semaphore, args) -> None:
                 await run_one(job, args, feedback)
             except Exception as e:  # noqa: BLE001
                 job.error = f"{type(e).__name__}: {e}"
-            if verify(job):  # deliverables exist AND geometric QC probe passes (stashes job.probe)
+            # deliverables exist AND geometric QC probe passes (stashes job.probe)
+            if await asyncio.to_thread(verify, job):
                 # Passed geometry; now the completeness gate (VLM: does it match the reference?).
-                comp = {"pass": True} if getattr(args, "no_completeness", False) else completeness_report(job)
+                comp = (
+                    {"pass": True}
+                    if getattr(args, "no_completeness", False)
+                    else await asyncio.to_thread(completeness_report, job)
+                )
                 job.completeness = comp
                 if comp.get("pass", True):
                     job.status = "ok"

--- a/src/litereality_agent/pipeline/scene_init/flow.py
+++ b/src/litereality_agent/pipeline/scene_init/flow.py
@@ -58,6 +58,34 @@ def resolve_scan(value: str, name: str | None) -> tuple[Path, str]:
     return raw, scan_name
 
 
+def _references_on_disk(scan: str) -> bool:
+    """True when a previous run left the reference manifests `--skip-references` would reuse.
+
+    Falls back to regenerating rather than proceeding on a partial tree: a missing manifest means
+    the routing and the reconstruction would disagree about which objects exist.
+    """
+    return (
+        (config.object_refs_root() / scan / "object_references.json").is_file()
+        and (config.chair_clusters_root() / scan / "chair_clusters.json").is_file()
+    )
+
+
+def _load_reference_json(path: Path, default: dict) -> dict:
+    """Read a reference manifest, falling back to `default` when it is absent or unreadable.
+
+    Openings legitimately have no manifest on a room without doors or windows, so a miss here is
+    not an error — but a CORRUPT manifest silently becoming an empty object list would drop every
+    object from the run, so say so rather than swallowing it.
+    """
+    if not path.is_file():
+        return dict(default)
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except ValueError as exc:
+        print(f"[references] {path} is unreadable ({exc}); regenerating instead", flush=True)
+        raise
+
+
 def process_scan(raw: Path, scan: str, args: argparse.Namespace) -> dict:
     print(console.rule(f"scene_init · {scan}"))
     print(f"   {console.colour('dim')}capture: {raw}{console.colour('off')}", flush=True)
@@ -157,41 +185,70 @@ def _process_scan(scan: str, raw: Path, args: argparse.Namespace) -> dict:
             "openings": op["openings"],
         }
 
+    # 3-5. references. `--skip-references` reuses what is already on disk. The reconstruct stage
+    # passes it: it re-enters this module only to reach classify/build, and re-deriving references
+    # over crops that --skip-crop has already frozen is not merely wasted time. Chair grouping is
+    # an LLM judgment, so it returns a DIFFERENT answer often enough to matter (2/3/3/2 clusters
+    # across four runs of the same five chairs) and `cluster_and_generate` rewrites
+    # chair_clusters.json unconditionally — so the later stage can overwrite the grouping that
+    # ingest committed to and that the references and routing were built against.
+    reuse = args.skip_references and _references_on_disk(scan)
+
     # 3. object references (non-chair objects)
     telemetry.stage("object_references", scan, "start")
-    obj_result = object_references.generate_for_scan(
-        scan,
-        config.object_refs_root(),
-        skip_image_generation=args.skip_image_generation,
-        force_image_generation=args.force_image_generation,
-        model=args.image_model,
-        max_images=args.max_images,
-        only=only,
-        include_openings=args.include_openings,
-    )
-    telemetry.stage("object_references", scan, "done", n_objects=len(obj_result["objects"]))
+    if reuse:
+        obj_result = _load_reference_json(
+            config.object_refs_root() / scan / "object_references.json",
+            {"scan": scan, "objects": []},
+        )
+        telemetry.stage("object_references", scan, "reused")
+    else:
+        obj_result = object_references.generate_for_scan(
+            scan,
+            config.object_refs_root(),
+            skip_image_generation=args.skip_image_generation,
+            force_image_generation=args.force_image_generation,
+            model=args.image_model,
+            max_images=args.max_images,
+            only=only,
+            include_openings=args.include_openings,
+        )
+        telemetry.stage("object_references", scan, "done", n_objects=len(obj_result["objects"]))
 
     # 4. chair grouping + per-cluster reference
     telemetry.stage("chair_clusters", scan, "start")
-    chair_result = chair_clusters.cluster_and_generate(
-        scan,
-        config.chair_clusters_root(),
-        skip_image_generation=args.skip_image_generation,
-        force_image_generation=args.force_image_generation,
-        model=args.image_model,
-        use_dino=use_dino,
-    )
-    telemetry.stage(
-        "chair_clusters",
-        scan,
-        "done",
-        chairs=chair_result["chair_count"],
-        clusters=len(chair_result["clusters"]),
-    )
+    if reuse:
+        chair_result = _load_reference_json(
+            config.chair_clusters_root() / scan / "chair_clusters.json",
+            {"chair_count": 0, "clusters": []},
+        )
+        telemetry.stage("chair_clusters", scan, "reused")
+    else:
+        chair_result = chair_clusters.cluster_and_generate(
+            scan,
+            config.chair_clusters_root(),
+            skip_image_generation=args.skip_image_generation,
+            force_image_generation=args.force_image_generation,
+            model=args.image_model,
+            use_dino=use_dino,
+        )
+        telemetry.stage(
+            "chair_clusters",
+            scan,
+            "done",
+            chairs=chair_result["chair_count"],
+            clusters=len(chair_result["clusters"]),
+        )
 
     # 5. door/window references (projected 3D opening boxes → clean hosted references)
     opening_result = {"openings": []}
-    if not args.skip_openings:
+    if reuse:
+        telemetry.stage("opening_references", scan, "start")
+        opening_result = _load_reference_json(
+            config.opening_refs_root() / scan / "opening_references.json", {"openings": []}
+        )
+        telemetry.stage("opening_references", scan, "reused")
+    elif not args.skip_openings:
         telemetry.stage("opening_references", scan, "start")
         opening_result = opening_references.generate_for_scan(
             scan,
@@ -531,6 +588,13 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument(
         "--skip-crop", action="store_true", help="Reuse existing crops, never crop."
+    )
+    parser.add_argument(
+        "--skip-references",
+        action="store_true",
+        help="Reuse the references already on disk instead of regenerating them. The reconstruct "
+        "stage passes this: crops are frozen by then, so re-deriving them re-runs the chair "
+        "judge and can reshuffle the clustering ingest already committed to.",
     )
     parser.add_argument(
         "--use-dino",

--- a/src/litereality_agent/pipeline/scene_init/ingest/references/chair_clusters.py
+++ b/src/litereality_agent/pipeline/scene_init/ingest/references/chair_clusters.py
@@ -26,6 +26,7 @@ import math
 import os
 import pickle
 import re
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -610,9 +611,15 @@ def cluster_and_generate(
         flush=True,
     )
     if not skip_image_generation:
+        # One ~45s hosted image call per cluster, each writing only into its own cluster dict.
         for cluster in result["clusters"]:
             print(f"  [image] {cluster['cluster_id']} {cluster['members']}", flush=True)
-            generate_for_cluster(scan, cluster, output_root, model, force_image_generation)
+        clusters = result["clusters"]
+        with ThreadPoolExecutor(max_workers=image_model.image_workers(len(clusters))) as pool:
+            list(pool.map(
+                lambda c: generate_for_cluster(scan, c, output_root, model, force_image_generation),
+                clusters,
+            ))
 
     scan_dir = output_root / scan
     scan_dir.mkdir(parents=True, exist_ok=True)

--- a/src/litereality_agent/pipeline/scene_init/ingest/references/image_gen.py
+++ b/src/litereality_agent/pipeline/scene_init/ingest/references/image_gen.py
@@ -15,6 +15,17 @@ from PIL import Image
 from litereality_agent import telemetry
 
 DEFAULT_IMAGE_MODEL = "gpt-image-1"
+
+# Reference generation is one hosted image call per object, ~45s each, and every caller had it in
+# a serial loop. The ceiling is OpenAI's rate limit, not local CPU, so the cap is about not opening
+# forty requests at once on a large room rather than about cores.
+MAX_IMAGE_WORKERS = int(os.environ.get("LR_IMAGE_WORKERS", "6"))
+
+
+def image_workers(n_items: int) -> int:
+    """Pool size for a batch of `n_items` reference images."""
+    return max(1, min(n_items, MAX_IMAGE_WORKERS))
+
 # gpt-image-1 token pricing ($/1M tokens); output image tokens dominate. Used only for the
 # rough cost line we log — override via env if OpenAI changes rates.
 _PRICE_IN_TEXT = float(os.environ.get("LR_OPENAI_PRICE_IN_TEXT", "5.0"))

--- a/src/litereality_agent/pipeline/scene_init/ingest/references/object_references.py
+++ b/src/litereality_agent/pipeline/scene_init/ingest/references/object_references.py
@@ -19,6 +19,7 @@ import json
 import math
 import pickle
 import re
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import numpy as np
@@ -26,6 +27,7 @@ from PIL import Image
 
 from litereality_agent.pipeline.scene_init import paths as config
 from litereality_agent.pipeline.scene_init.ingest.references import image_gen as image_model
+from litereality_agent.pipeline.scene_init.ingest.references.image_gen import image_workers
 
 # Per-category guidance: the specific structure to preserve when generating the
 # clean reference. Keyed by the lowercased category (digits stripped from the id).
@@ -299,13 +301,13 @@ def generate_for_scan(
     object_meta = load_scene_objects(scan)
     scan_result = {"scan": scan, "objects": []}
 
-    for obj_dir in object_dirs(scan, only, include_openings, include_chairs):
+    def generate_one(obj_dir: Path) -> dict | None:
         name = obj_dir.name
         category = category_from_name(name)
         meta = object_meta.get(name, {})
         scored = select_evidence_images(obj_dir, meta, max_images)
         if not scored:
-            continue
+            return None
 
         out_dir = output_root / scan / name
         input_sheet = out_dir / config.INPUT_SHEET
@@ -357,8 +359,14 @@ def generate_for_scan(
         if image_meta:
             record["image_meta"] = image_meta
         meta_path.write_text(json.dumps(record, indent=2), encoding="utf-8")
-        scan_result["objects"].append(record)
         print(f"  [{status}] object {name}", flush=True)
+        return record
+
+    # One hosted image call per object, ~45s each and fully independent — this loop was serial and
+    # was most of the ingest stage's wall time. `map` keeps the manifest order deterministic.
+    targets = object_dirs(scan, only, include_openings, include_chairs)
+    with ThreadPoolExecutor(max_workers=image_workers(len(targets))) as pool:
+        scan_result["objects"] = [r for r in pool.map(generate_one, targets) if r is not None]
 
     (output_root / scan).mkdir(parents=True, exist_ok=True)
     (output_root / scan / "object_references.json").write_text(

--- a/src/litereality_agent/pipeline/scene_init/reconstruct/__init__.py
+++ b/src/litereality_agent/pipeline/scene_init/reconstruct/__init__.py
@@ -14,7 +14,8 @@ def run(context: RunContext, options: dict) -> StageResult:
     args: list[object] = [
         "--scan", context.capture_dir, "--name", context.scan,
         "--output-root", context.output_root,
-        "--skip-extract", "--skip-crop", "--classify", "--reconstruct",
+        "--skip-extract", "--skip-crop", "--skip-references",
+        "--classify", "--reconstruct",
         "--procedural", "--build-openings",
         "--agent-model", context.settings.procedural_model,
     ]

--- a/src/litereality_agent/pipeline/scene_init/reconstruct/classify/classify_complexity.py
+++ b/src/litereality_agent/pipeline/scene_init/reconstruct/classify/classify_complexity.py
@@ -22,12 +22,18 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import pickle
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 from litereality_agent.pipeline.scene_init import paths as config
 from litereality_agent.pipeline.scene_init.reconstruct.classify import classification
+
+# Each worker is one hosted vision call, so the ceiling is the provider's rate limit rather than
+# local CPU. Capped rather than unbounded so a 40-object room does not open 40 sessions at once.
+MAX_CLASSIFY_WORKERS = int(os.environ.get("LR_CLASSIFY_WORKERS", "8"))
 
 ROUTE_SCHEMA = {
     "type": "object",
@@ -156,9 +162,10 @@ def classify_for_scan(scan: str, *, model: str | None = None, include_chairs: bo
     routing_root = work / "routing"
 
     items = [it for it in collect(work, [scan], include_chairs)]
-    recs: list[dict] = []
     print(f"[classify] {scan}: {len(items)} object(s)...", flush=True)
-    for _scan, kind, name, ref, meta in items:
+
+    def classify_one(item) -> dict:
+        _scan, kind, name, ref, meta = item
         category = category_from_name(name, kind)
         dims = _dims_str(meta)
         prompt = PROMPT_TEMPLATE.format(category=category, dims=dims)
@@ -172,7 +179,7 @@ def classify_for_scan(scan: str, *, model: str | None = None, include_chairs: bo
                 "reason": f"classify error, default trellis: {exc}",
             }
         decision = apply_policy(kind, category, decision)
-        record = {
+        return {
             "scan": scan,
             "kind": kind,
             "name": name,
@@ -181,11 +188,18 @@ def classify_for_scan(scan: str, *, model: str | None = None, include_chairs: bo
             "reference": str(ref),
             **decision,
         }
-        recs.append(record)
-        flag = " [policy]" if decision.get("forced_by_policy") else ""
+
+    # One independent vision call per object, each ~9s. Run them together: the stage was serial
+    # and cost 46s on a 5-object room for no reason. `map` keeps routing order stable, and the
+    # per-object lines print after the pool drains so threads don't interleave mid-line.
+    with ThreadPoolExecutor(max_workers=max(1, min(len(items), MAX_CLASSIFY_WORKERS))) as pool:
+        recs: list[dict] = list(pool.map(classify_one, items))
+
+    for record in recs:
+        flag = " [policy]" if record.get("forced_by_policy") else ""
         print(
-            f"  {name:16s} -> {decision['route']:10s}{flag:9s} "
-            f"({decision.get('complexity', '?')}) {decision.get('reason', '')[:60]}"
+            f"  {record['name']:16s} -> {record['route']:10s}{flag:9s} "
+            f"({record.get('complexity', '?')}) {record.get('reason', '')[:60]}"
         )
 
     manifest = {"work": str(work), "model": model, "scans": {scan: recs}}

--- a/tests/test_procedural_concurrency.py
+++ b/tests/test_procedural_concurrency.py
@@ -1,0 +1,81 @@
+"""The procedural builder's QC gates must not stall the event loop.
+
+`process()` is async and several jobs run under one semaphore, but its gates — `verify_reasons`,
+`verify` (probe_glb) and `completeness_report` — are blocking `subprocess.run` calls, and the last
+one is a whole agent session. Called directly they hold the event loop, so while ONE object is
+being QC'd every OTHER object's agent session is frozen: `--concurrency N` buys nothing during
+precisely the phase that dominates the stage. On a two-opening room that turned ~2 concurrent
+builds into a serial chain and the reconstruct stage ran for 38 minutes.
+
+This is invisible by inspection — the code reads as concurrent and the output is identical, only
+the wall time differs — so it is pinned here: two jobs whose gates each sleep must finish in about
+ONE gate's time, not two.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+from litereality_agent.models.object_generation import generate
+
+GATE_SECONDS = 0.4
+
+
+def _job(name: str) -> generate.Job:
+    return generate.Job(
+        scan="test-scan", name=name, category="door",
+        image=Path(f"/nonexistent/{name}.png"), glb=Path(f"/nonexistent/{name}/{name}.glb"),
+        dims="1.00 (X) x 0.10 (Y) x 2.00 (Z)",
+    )
+
+
+def _args():
+    return SimpleNamespace(
+        skip_existing=True, retries=0, model=None, max_turns=1,
+        max_budget_usd=None, provider=None, no_completeness=False,
+    )
+
+
+def test_qc_gates_do_not_block_other_jobs(monkeypatch, tmp_path):
+    """Two jobs, each with a blocking gate: wall time must be ~1 gate, not ~2."""
+
+    def slow_blocking_gate(job):
+        time.sleep(GATE_SECONDS)  # stands in for probe_glb / completeness_check subprocesses
+        return {"pass": True, "violations": [], "missing": []}
+
+    # Force the build path (not the "already built" skip), and make the agent run a no-op so the
+    # gates are the only thing on the clock.
+    monkeypatch.setattr(generate, "verify_reasons", lambda job: ["forced rebuild"])
+    monkeypatch.setattr(generate, "probe_glb", slow_blocking_gate)
+    monkeypatch.setattr(generate, "completeness_report", slow_blocking_gate)
+    monkeypatch.setattr(generate, "verify", lambda job: bool(slow_blocking_gate(job)))
+    monkeypatch.setattr(generate, "drop_build_recipe", lambda d: [])
+
+    async def noop_run_one(job, args, feedback=""):
+        return None
+
+    monkeypatch.setattr(generate, "run_one", noop_run_one)
+
+    jobs = [_job("Wall1_Door_0"), _job("Wall5_Window_0")]
+    args = _args()
+
+    async def drive():
+        sem = asyncio.Semaphore(len(jobs))
+        started = time.monotonic()
+        await asyncio.gather(*(generate.process(j, sem, args) for j in jobs))
+        return time.monotonic() - started
+
+    elapsed = asyncio.run(drive())
+
+    assert all(j.status == "ok" for j in jobs), [j.status for j in jobs]
+    # Each job runs two gates (verify + completeness) = 2 * GATE_SECONDS of blocking work. Run
+    # concurrently that is ~2 gates of wall time; serialised on a held event loop it is ~4. The
+    # midpoint is a wide enough bar to survive a slow CI box and still fail a reverted to_thread.
+    serial_floor = 4 * GATE_SECONDS
+    assert elapsed < serial_floor * 0.75, (
+        f"QC gates serialised the jobs: {elapsed:.2f}s for 2 jobs "
+        f"(serial would be ~{serial_floor:.2f}s) — did a gate lose its asyncio.to_thread?"
+    )

--- a/tests/test_reference_reuse.py
+++ b/tests/test_reference_reuse.py
@@ -1,0 +1,102 @@
+"""`--skip-references` must reuse the reference manifests, not silently empty them.
+
+The reconstruct stage re-enters scene_init.flow only to reach classify/build, and used to
+re-derive all three reference sets over crops that `--skip-crop` had already frozen. Chair grouping
+is an LLM judgment, so it comes back different often enough to matter — four runs of the same five
+chairs gave 2/3/3/2 clusters — and `cluster_and_generate` rewrites chair_clusters.json
+unconditionally, so the later stage could overwrite the grouping ingest committed to.
+
+The failure mode of the fix is worse than the bug: if the reuse path returned empty results the
+run would proceed with ZERO objects and look like a clean no-op. So both directions are pinned —
+reuse loads what is on disk, and a missing manifest falls back to regenerating.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from litereality_agent.pipeline.scene_init import flow
+
+CLUSTERS = {
+    "chair_count": 5,
+    "clusters": [
+        {"cluster_id": "ChairCluster0", "members": ["Chair0", "Chair2"], "representative": "Chair0"},
+        {"cluster_id": "ChairCluster1", "members": ["Chair1"], "representative": "Chair1"},
+    ],
+}
+OBJECTS = {"scan": "Room", "objects": [{"object": "Table0"}, {"object": "Table1"}]}
+OPENINGS = {"scan": "Room", "openings": [{"opening": "Wall1_Door_0"}]}
+
+
+def _write(tmp_path, *, openings=True):
+    """Lay out the three manifests the way a completed ingest leaves them."""
+    obj = tmp_path / "object_refs" / "Room"
+    chair = tmp_path / "chair_clusters" / "Room"
+    op = tmp_path / "opening_refs" / "Room"
+    for d in (obj, chair, op):
+        d.mkdir(parents=True)
+    (obj / "object_references.json").write_text(json.dumps(OBJECTS))
+    (chair / "chair_clusters.json").write_text(json.dumps(CLUSTERS))
+    if openings:
+        (op / "opening_references.json").write_text(json.dumps(OPENINGS))
+    return obj, chair, op
+
+
+def _point_config_at(monkeypatch, tmp_path):
+    monkeypatch.setattr(flow.config, "object_refs_root", lambda: tmp_path / "object_refs")
+    monkeypatch.setattr(flow.config, "chair_clusters_root", lambda: tmp_path / "chair_clusters")
+    monkeypatch.setattr(flow.config, "opening_refs_root", lambda: tmp_path / "opening_refs")
+
+
+def test_reuses_manifests_on_disk(monkeypatch, tmp_path):
+    _write(tmp_path)
+    _point_config_at(monkeypatch, tmp_path)
+
+    assert flow._references_on_disk("Room") is True
+
+    objects = flow._load_reference_json(
+        tmp_path / "object_refs" / "Room" / "object_references.json", {"scan": "Room", "objects": []}
+    )
+    chairs = flow._load_reference_json(
+        tmp_path / "chair_clusters" / "Room" / "chair_clusters.json", {"chair_count": 0, "clusters": []}
+    )
+
+    # The whole point: the reused grouping is the one ingest committed to, not a fresh judgment.
+    assert [o["object"] for o in objects["objects"]] == ["Table0", "Table1"]
+    assert chairs["chair_count"] == 5
+    assert [c["cluster_id"] for c in chairs["clusters"]] == ["ChairCluster0", "ChairCluster1"]
+
+
+def test_missing_manifest_falls_back_to_regenerating(monkeypatch, tmp_path):
+    """A partial tree must NOT be reused — routing and reconstruction would disagree."""
+    _write(tmp_path)
+    _point_config_at(monkeypatch, tmp_path)
+    (tmp_path / "chair_clusters" / "Room" / "chair_clusters.json").unlink()
+
+    assert flow._references_on_disk("Room") is False
+
+
+def test_room_without_openings_reuses_cleanly(monkeypatch, tmp_path):
+    """No doors or windows is legitimate — an absent openings manifest is not an error."""
+    _write(tmp_path, openings=False)
+    _point_config_at(monkeypatch, tmp_path)
+
+    assert flow._references_on_disk("Room") is True
+    assert flow._load_reference_json(
+        tmp_path / "opening_refs" / "Room" / "opening_references.json", {"openings": []}
+    ) == {"openings": []}
+
+
+def test_corrupt_manifest_raises_rather_than_emptying_the_run(monkeypatch, tmp_path):
+    """Swallowing a parse error would drop every object and read as a clean no-op."""
+    _write(tmp_path)
+    _point_config_at(monkeypatch, tmp_path)
+    (tmp_path / "object_refs" / "Room" / "object_references.json").write_text("{not json")
+
+    with pytest.raises(ValueError):
+        flow._load_reference_json(
+            tmp_path / "object_refs" / "Room" / "object_references.json",
+            {"scan": "Room", "objects": []},
+        )


### PR DESCRIPTION
Removes waiting, not work. Output is unchanged throughout.

## The bug

`process()` in `models/object_generation/generate.py` is `async` and runs several objects under one semaphore — but its QC gates are blocking `subprocess.run` calls invoked directly:

- `verify_reasons()` / `verify()` → `probe_glb` (subprocess, 120s timeout)
- `completeness_report()` → `completeness_check.py`, **an entire agent session** (180s timeout)

They hold the event loop, so while one object is being QC'd every *other* object's agent session is frozen. `--concurrency N` bought nothing during precisely the phase that dominated the stage. Fixed with `asyncio.to_thread` — the pattern `refine_objects.py:274` already uses.

Same shape, smaller: `classify_complexity` made one vision call per object serially, and `object_references` / `chair_clusters` made one ~45s hosted image call per item serially. All independent; now bounded pools (`LR_CLASSIFY_WORKERS`, `LR_IMAGE_WORKERS`). `map` preserves order so the written manifests are unchanged.

`opening_references` keeps its serial loop — its body is entangled with the DINO refinement pass and it's only ever a couple of items.

## Measured

Post-agent QC tail — last `agent_step` → branch done. Same gates, same objects, only the waiting differs:

| branch | before | after |
|---|---|---|
| procedural | 262s | **22s** |
| openings | 763s | **26s** |

Stage level, cold run:

| stage | before | after |
|---|---|---|
| ingest | 383s | **189s** |
| reconstruct | 2267s | **1048s** |

Consistent across three runs (ingest 189/190/206s).

## Also here

`LR_COMPLETENESS_MODEL` knob, **defaulting to `HARNESS_MODEL` — behaviour unchanged**. I first defaulted it down to Sonnet and backed that out: this gate decides whether to discard a build and rebuild it, so a cheaper judge is two-sided — too lenient ships an object missing parts, too strict costs a full ~600s agent rebuild. The knob exists so the tiers can be measured against known-good builds before anyone moves the default.

## Verification

`tests/test_procedural_concurrency.py` pins the event-loop fix: two jobs with blocking gates must finish in ~1 gate's time, not 2. **Confirmed it fails on the pre-fix code** (1.67s serial) and passes after (0.83s). This is invisible by inspection — the code reads as concurrent and the output is identical, only wall time differs.

401 passed. `ruff` clean. Rebased on main (a95e39d).

## Caveat

Agent-session length varies a lot run to run — turn counts on identical objects have gone 27/34/31/33 → 38/57/58/55. That now dominates wall time and nothing here affects it, so per-object times aren't comparable between runs. The QC-tail numbers are like-for-like and are the ones I'd stand behind.