### PR TITLE
Attach gate images inline, stop re-deriving references, fix the report race

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ __MACOSX
 
 # retired code, kept locally for reference only (recoverable), not pushed
 /legacy/
+# scratch measurement runs (run-measure, run-measure2, ...)
+/run-measure*

--- a/src/litereality_agent/models/object_generation/README.md
+++ b/src/litereality_agent/models/object_generation/README.md
@@ -51,7 +51,8 @@ procedural/glb/<scan>/<name>/
     object.md             how to edit it (constants, joints, rebuild)
     previews/             render-check (open/closed for movers, iso/front for static)
     textures/
-procedural/glb/procedural_report.json
+procedural/glb/procedural_report.json   objects pass
+procedural/glb/openings_report.json     doors/windows pass (--openings)
 ```
 
 Each moving part carries glTF node extras `articulation_type`

--- a/src/litereality_agent/models/object_generation/articulated-glb-agent/.claude/skills/image-to-articulated-glb/scripts/completeness_check.py
+++ b/src/litereality_agent/models/object_generation/articulated-glb-agent/.claude/skills/image-to-articulated-glb/scripts/completeness_check.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import base64
 import json
 import os
 import re
@@ -38,27 +39,61 @@ PROMPT = (
 )
 
 
+_MIME = {".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg", ".webp": "image/webp"}
+
+
+def _blocks(images: list[Path]) -> list[dict]:
+    """The images as Messages-API content blocks, each labelled so the prompt can refer to it."""
+    out: list[dict] = []
+    for i, p in enumerate(images):
+        out.append({"type": "text", "text": f"IMAGE {i + 1} ({'REFERENCE' if i == 0 else p.name}):"})
+        out.append({
+            "type": "image",
+            "source": {
+                "type": "base64",
+                "media_type": _MIME.get(p.suffix.lower(), "image/png"),
+                "data": base64.b64encode(p.read_bytes()).decode(),
+            },
+        })
+    out.append({"type": "text", "text": PROMPT})
+    return out
+
+
 async def _ask(images: list[Path]) -> str:
+    """Ask the judge in ONE turn, with the images attached to the prompt.
+
+    They used to be named as paths and pulled in with the `Read` tool — one model round-trip per
+    image before the question could even be answered, five for a reference plus three renders, on
+    every build attempt of every object, on the critical path. `query()` also accepts a streamed
+    user message whose content is Messages-API blocks, so the images can ride along with the
+    prompt: same logged-in-CLI auth (no ANTHROPIC_API_KEY, still unmetered), one turn instead of
+    five. Measured on one reference image: 9.2s/2 turns -> 3.8s/1 turn.
+    """
     from claude_agent_sdk import ClaudeAgentOptions, ResultMessage, query
 
     opts = ClaudeAgentOptions(
-        cwd=str(images[0].parent),
-        add_dirs=sorted({str(p.parent) for p in images}),
         system_prompt={"type": "preset", "preset": "claude_code"},
         setting_sources=[],
-        allowed_tools=["Read"],
+        allowed_tools=[],  # nothing to fetch — the images are already in the prompt
         permission_mode="bypassPermissions",
-        max_turns=len(images) + 3,
+        max_turns=2,
         # Its own knob, defaulting to the harness model (unchanged behaviour). This gate decides
         # whether to throw a build away and rebuild it from scratch, so a cheaper judge is not a
         # free win: too lenient ships an object missing parts, too strict costs a full agent
         # rebuild. Worth measuring per-tier against known-good builds before moving the default.
         model=os.environ.get("LR_COMPLETENESS_MODEL") or os.environ.get("HARNESS_MODEL", "claude-opus-5"),
     )
-    listing = "\n".join(f"- IMAGE {i + 1}: {p}" for i, p in enumerate(images))
-    full = f"First Read (view) EVERY image below, then answer.\n{listing}\n\n{PROMPT}"
+
+    async def stream():
+        yield {
+            "type": "user",
+            "message": {"role": "user", "content": _blocks(images)},
+            "parent_tool_use_id": None,
+            "session_id": "completeness",
+        }
+
     out = ""
-    async for m in query(prompt=full, options=opts):
+    async for m in query(prompt=stream(), options=opts):
         if isinstance(m, ResultMessage):
             out = m.result or ""
     return out

--- a/src/litereality_agent/models/object_generation/generate.py
+++ b/src/litereality_agent/models/object_generation/generate.py
@@ -309,6 +309,31 @@ def completeness_feedback(report: dict) -> str:
     return "\n".join(lines)
 
 
+def resume_note(job: Job) -> str:
+    """Point a retry at the previous attempt's artifacts instead of letting it start over.
+
+    The base prompt says "build ONE procedural 3D GLB", and a retry re-sends it to a FRESH session
+    that has no memory of the last attempt — so a gate rejecting one missing handle threw away a
+    correct build and paid for the whole thing again (the window rebuild cost ~600s and a second
+    full agent session). The recipe, object.py and previews are all still on disk; `object.py` only
+    gets swept away by drop_build_recipe once the object PASSES. Naming those files turns the retry
+    into an edit. Only the listed files are mentioned, so a genuinely empty directory still
+    produces a from-scratch build.
+    """
+    d = job.glb.parent
+    existing = [p.name for p in sorted(d.glob("build_*.py"))]
+    existing += [n for n in ("object.py",) if (d / n).is_file()]
+    if not existing:
+        return ""
+    return (
+        f"\n\n## PREVIOUS ATTEMPT — do NOT start from scratch.\n"
+        f"Attempt {job.attempts} of this object is already on disk in {d}:\n"
+        + "".join(f"  - {n}\n" for n in existing)
+        + "Read the build recipe, make the SMALLEST change that fixes the issues below, then "
+        "re-run it, re-render and re-check. Keep everything that is already correct."
+    )
+
+
 def verify_reasons(job: Job) -> list[str]:
     """Why this object is NOT considered built. Empty means it is.
 
@@ -515,7 +540,8 @@ async def process(job: Job, sem: asyncio.Semaphore, args) -> None:
                     break
                 job.status = "failed"
                 job.error = "incomplete: " + "; ".join(comp.get("missing") or [])[:150]
-                feedback = completeness_feedback(comp)  # retry to ADD the missing features
+                # retry to ADD the missing features, editing the build already on disk
+                feedback = resume_note(job) + completeness_feedback(comp)
                 print(f"[fail] {job.scan}/{job.name}: {job.error}", file=sys.stderr)
                 continue
             job.status = "failed"
@@ -525,7 +551,7 @@ async def process(job: Job, sem: asyncio.Semaphore, args) -> None:
                 f"QC failed: {'; '.join(v['check'] + ':' + v['part'] for v in hard)}"
                 if hard else (job.error or "GLB/previews/deliverables missing")
             )
-            feedback = probe_feedback(job.probe)
+            feedback = resume_note(job) + probe_feedback(job.probe)
             print(f"[fail] {job.scan}/{job.name}: {job.error}", file=sys.stderr)
         job.seconds = time.time() - t0
         mark = "ok  " if job.status == "ok" else "FAIL"
@@ -578,7 +604,11 @@ async def main_async(args) -> int:
         "out": str(out_root),
         "jobs": [vars(j) | {"image": str(j.image), "glb": str(j.glb)} for j in jobs],
     }
-    (out_root / "procedural_report.json").write_text(
+    # Per-branch filename. The objects pass and the openings pass share one `out_root` and used to
+    # write the same `procedural_report.json`, so whichever finished last silently replaced the
+    # other's report — the last run's file listed only the two openings, with Table0/Table1 gone.
+    # Serially that was a deterministic overwrite; now that the branches run together it is a race.
+    (out_root / f"{'openings' if args.openings else 'procedural'}_report.json").write_text(
         json.dumps(report, indent=2, default=str), encoding="utf-8"
     )
     ok = sum(1 for j in jobs if j.status == "ok")

--- a/src/litereality_agent/pipeline/scene_init/flow.py
+++ b/src/litereality_agent/pipeline/scene_init/flow.py
@@ -58,6 +58,34 @@ def resolve_scan(value: str, name: str | None) -> tuple[Path, str]:
     return raw, scan_name
 
 
+def _references_on_disk(scan: str) -> bool:
+    """True when a previous run left the reference manifests `--skip-references` would reuse.
+
+    Falls back to regenerating rather than proceeding on a partial tree: a missing manifest means
+    the routing and the reconstruction would disagree about which objects exist.
+    """
+    return (
+        (config.object_refs_root() / scan / "object_references.json").is_file()
+        and (config.chair_clusters_root() / scan / "chair_clusters.json").is_file()
+    )
+
+
+def _load_reference_json(path: Path, default: dict) -> dict:
+    """Read a reference manifest, falling back to `default` when it is absent or unreadable.
+
+    Openings legitimately have no manifest on a room without doors or windows, so a miss here is
+    not an error — but a CORRUPT manifest silently becoming an empty object list would drop every
+    object from the run, so say so rather than swallowing it.
+    """
+    if not path.is_file():
+        return dict(default)
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except ValueError as exc:
+        print(f"[references] {path} is unreadable ({exc}); regenerating instead", flush=True)
+        raise
+
+
 def process_scan(raw: Path, scan: str, args: argparse.Namespace) -> dict:
     print(console.rule(f"scene_init · {scan}"))
     print(f"   {console.colour('dim')}capture: {raw}{console.colour('off')}", flush=True)
@@ -157,41 +185,70 @@ def _process_scan(scan: str, raw: Path, args: argparse.Namespace) -> dict:
             "openings": op["openings"],
         }
 
+    # 3-5. references. `--skip-references` reuses what is already on disk. The reconstruct stage
+    # passes it: it re-enters this module only to reach classify/build, and re-deriving references
+    # over crops that --skip-crop has already frozen is not merely wasted time. Chair grouping is
+    # an LLM judgment, so it returns a DIFFERENT answer often enough to matter (2/3/3/2 clusters
+    # across four runs of the same five chairs) and `cluster_and_generate` rewrites
+    # chair_clusters.json unconditionally — so the later stage can overwrite the grouping that
+    # ingest committed to and that the references and routing were built against.
+    reuse = args.skip_references and _references_on_disk(scan)
+
     # 3. object references (non-chair objects)
     telemetry.stage("object_references", scan, "start")
-    obj_result = object_references.generate_for_scan(
-        scan,
-        config.object_refs_root(),
-        skip_image_generation=args.skip_image_generation,
-        force_image_generation=args.force_image_generation,
-        model=args.image_model,
-        max_images=args.max_images,
-        only=only,
-        include_openings=args.include_openings,
-    )
-    telemetry.stage("object_references", scan, "done", n_objects=len(obj_result["objects"]))
+    if reuse:
+        obj_result = _load_reference_json(
+            config.object_refs_root() / scan / "object_references.json",
+            {"scan": scan, "objects": []},
+        )
+        telemetry.stage("object_references", scan, "reused")
+    else:
+        obj_result = object_references.generate_for_scan(
+            scan,
+            config.object_refs_root(),
+            skip_image_generation=args.skip_image_generation,
+            force_image_generation=args.force_image_generation,
+            model=args.image_model,
+            max_images=args.max_images,
+            only=only,
+            include_openings=args.include_openings,
+        )
+        telemetry.stage("object_references", scan, "done", n_objects=len(obj_result["objects"]))
 
     # 4. chair grouping + per-cluster reference
     telemetry.stage("chair_clusters", scan, "start")
-    chair_result = chair_clusters.cluster_and_generate(
-        scan,
-        config.chair_clusters_root(),
-        skip_image_generation=args.skip_image_generation,
-        force_image_generation=args.force_image_generation,
-        model=args.image_model,
-        use_dino=use_dino,
-    )
-    telemetry.stage(
-        "chair_clusters",
-        scan,
-        "done",
-        chairs=chair_result["chair_count"],
-        clusters=len(chair_result["clusters"]),
-    )
+    if reuse:
+        chair_result = _load_reference_json(
+            config.chair_clusters_root() / scan / "chair_clusters.json",
+            {"chair_count": 0, "clusters": []},
+        )
+        telemetry.stage("chair_clusters", scan, "reused")
+    else:
+        chair_result = chair_clusters.cluster_and_generate(
+            scan,
+            config.chair_clusters_root(),
+            skip_image_generation=args.skip_image_generation,
+            force_image_generation=args.force_image_generation,
+            model=args.image_model,
+            use_dino=use_dino,
+        )
+        telemetry.stage(
+            "chair_clusters",
+            scan,
+            "done",
+            chairs=chair_result["chair_count"],
+            clusters=len(chair_result["clusters"]),
+        )
 
     # 5. door/window references (projected 3D opening boxes → clean hosted references)
     opening_result = {"openings": []}
-    if not args.skip_openings:
+    if reuse:
+        telemetry.stage("opening_references", scan, "start")
+        opening_result = _load_reference_json(
+            config.opening_refs_root() / scan / "opening_references.json", {"openings": []}
+        )
+        telemetry.stage("opening_references", scan, "reused")
+    elif not args.skip_openings:
         telemetry.stage("opening_references", scan, "start")
         opening_result = opening_references.generate_for_scan(
             scan,
@@ -531,6 +588,13 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument(
         "--skip-crop", action="store_true", help="Reuse existing crops, never crop."
+    )
+    parser.add_argument(
+        "--skip-references",
+        action="store_true",
+        help="Reuse the references already on disk instead of regenerating them. The reconstruct "
+        "stage passes this: crops are frozen by then, so re-deriving them re-runs the chair "
+        "judge and can reshuffle the clustering ingest already committed to.",
     )
     parser.add_argument(
         "--use-dino",

--- a/src/litereality_agent/pipeline/scene_init/reconstruct/__init__.py
+++ b/src/litereality_agent/pipeline/scene_init/reconstruct/__init__.py
@@ -14,7 +14,8 @@ def run(context: RunContext, options: dict) -> StageResult:
     args: list[object] = [
         "--scan", context.capture_dir, "--name", context.scan,
         "--output-root", context.output_root,
-        "--skip-extract", "--skip-crop", "--classify", "--reconstruct",
+        "--skip-extract", "--skip-crop", "--skip-references",
+        "--classify", "--reconstruct",
         "--procedural", "--build-openings",
         "--agent-model", context.settings.procedural_model,
     ]

--- a/tests/test_reference_reuse.py
+++ b/tests/test_reference_reuse.py
@@ -1,0 +1,102 @@
+"""`--skip-references` must reuse the reference manifests, not silently empty them.
+
+The reconstruct stage re-enters scene_init.flow only to reach classify/build, and used to
+re-derive all three reference sets over crops that `--skip-crop` had already frozen. Chair grouping
+is an LLM judgment, so it comes back different often enough to matter — four runs of the same five
+chairs gave 2/3/3/2 clusters — and `cluster_and_generate` rewrites chair_clusters.json
+unconditionally, so the later stage could overwrite the grouping ingest committed to.
+
+The failure mode of the fix is worse than the bug: if the reuse path returned empty results the
+run would proceed with ZERO objects and look like a clean no-op. So both directions are pinned —
+reuse loads what is on disk, and a missing manifest falls back to regenerating.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from litereality_agent.pipeline.scene_init import flow
+
+CLUSTERS = {
+    "chair_count": 5,
+    "clusters": [
+        {"cluster_id": "ChairCluster0", "members": ["Chair0", "Chair2"], "representative": "Chair0"},
+        {"cluster_id": "ChairCluster1", "members": ["Chair1"], "representative": "Chair1"},
+    ],
+}
+OBJECTS = {"scan": "Room", "objects": [{"object": "Table0"}, {"object": "Table1"}]}
+OPENINGS = {"scan": "Room", "openings": [{"opening": "Wall1_Door_0"}]}
+
+
+def _write(tmp_path, *, openings=True):
+    """Lay out the three manifests the way a completed ingest leaves them."""
+    obj = tmp_path / "object_refs" / "Room"
+    chair = tmp_path / "chair_clusters" / "Room"
+    op = tmp_path / "opening_refs" / "Room"
+    for d in (obj, chair, op):
+        d.mkdir(parents=True)
+    (obj / "object_references.json").write_text(json.dumps(OBJECTS))
+    (chair / "chair_clusters.json").write_text(json.dumps(CLUSTERS))
+    if openings:
+        (op / "opening_references.json").write_text(json.dumps(OPENINGS))
+    return obj, chair, op
+
+
+def _point_config_at(monkeypatch, tmp_path):
+    monkeypatch.setattr(flow.config, "object_refs_root", lambda: tmp_path / "object_refs")
+    monkeypatch.setattr(flow.config, "chair_clusters_root", lambda: tmp_path / "chair_clusters")
+    monkeypatch.setattr(flow.config, "opening_refs_root", lambda: tmp_path / "opening_refs")
+
+
+def test_reuses_manifests_on_disk(monkeypatch, tmp_path):
+    _write(tmp_path)
+    _point_config_at(monkeypatch, tmp_path)
+
+    assert flow._references_on_disk("Room") is True
+
+    objects = flow._load_reference_json(
+        tmp_path / "object_refs" / "Room" / "object_references.json", {"scan": "Room", "objects": []}
+    )
+    chairs = flow._load_reference_json(
+        tmp_path / "chair_clusters" / "Room" / "chair_clusters.json", {"chair_count": 0, "clusters": []}
+    )
+
+    # The whole point: the reused grouping is the one ingest committed to, not a fresh judgment.
+    assert [o["object"] for o in objects["objects"]] == ["Table0", "Table1"]
+    assert chairs["chair_count"] == 5
+    assert [c["cluster_id"] for c in chairs["clusters"]] == ["ChairCluster0", "ChairCluster1"]
+
+
+def test_missing_manifest_falls_back_to_regenerating(monkeypatch, tmp_path):
+    """A partial tree must NOT be reused — routing and reconstruction would disagree."""
+    _write(tmp_path)
+    _point_config_at(monkeypatch, tmp_path)
+    (tmp_path / "chair_clusters" / "Room" / "chair_clusters.json").unlink()
+
+    assert flow._references_on_disk("Room") is False
+
+
+def test_room_without_openings_reuses_cleanly(monkeypatch, tmp_path):
+    """No doors or windows is legitimate — an absent openings manifest is not an error."""
+    _write(tmp_path, openings=False)
+    _point_config_at(monkeypatch, tmp_path)
+
+    assert flow._references_on_disk("Room") is True
+    assert flow._load_reference_json(
+        tmp_path / "opening_refs" / "Room" / "opening_references.json", {"openings": []}
+    ) == {"openings": []}
+
+
+def test_corrupt_manifest_raises_rather_than_emptying_the_run(monkeypatch, tmp_path):
+    """Swallowing a parse error would drop every object and read as a clean no-op."""
+    _write(tmp_path)
+    _point_config_at(monkeypatch, tmp_path)
+    (tmp_path / "object_refs" / "Room" / "object_references.json").write_text("{not json")
+
+    with pytest.raises(ValueError):
+        flow._load_reference_json(
+            tmp_path / "object_refs" / "Room" / "object_references.json",
+            {"scan": "Room", "objects": []},
+        )


### PR DESCRIPTION
Stacked on #21 — review that first. Everything here came out of measuring #21 on real runs.

## 1. Completeness gate: 5 model round-trips → 1

The gate named its images as paths and pulled each in with the `Read` tool — one round-trip per image before the question could be answered, on every build attempt of every object, on the critical path.

I previously claimed the only alternative was the metered API. **That was wrong.** `query()` accepts `AsyncIterable[dict]` whose `content` takes Messages-API blocks, so images ride along with the prompt. Same logged-in-CLI auth, still unmetered, no `ANTHROPIC_API_KEY`.

Probed on one reference image: `9.2s / 2 turns` → `3.8s / 1 turn`. On the real 4-image gate with identical input: `15.7s` → `12.0s`. Turn count drops deterministically 5→1; wall time varies with the network, so don't over-read the single sample. Verdicts unchanged and equally specific:

```
old: "3-bay frame with 3 transom lights, 3 lower sashes, head trim, sill, left blind
      stack, both sash handles and top-center latch all present."
new: "All salient parts present: 3-bay frame with transom row, 2 casement handles,
      center top latch, left pleated blind, sill and head trim."
```

`classify_claude.py` and `chair_type_judge.py` use the same pattern but are no longer on the critical path (classify is 14s after #21). Left alone.

## 2. `--skip-references` — a consistency fix that also saves time

The reconstruct stage re-enters `scene_init.flow` only to reach classify/build, and re-derived all three reference sets over crops `--skip-crop` had already frozen.

The wasted time was modest (~15s). The real problem: chair grouping is an LLM judgment and `cluster_and_generate` rewrites `chair_clusters.json` unconditionally. Same five chairs, four runs: **2 / 3 / 3 / 2 clusters.** So the later stage could overwrite the grouping ingest committed to — the one the references and routing were built against.

Verified end to end: **30s → 1.1s**, and `chair_clusters.json` now byte-identical across the re-entry. Falls back to regenerating on a partial tree rather than proceeding with a half-populated one.

## 3. `procedural_report.json` race

The objects pass and the openings pass share one `out_root` and wrote the same filename. A measurement run's report listed only the two openings — Table0/Table1 gone. Pre-existing, but #21 turns a deterministic overwrite into a race. One file per branch.

## 4. Retries no longer start from zero

A retry re-sent *"build ONE procedural 3D GLB"* to a **fresh** session with no memory of the previous attempt, so a gate rejecting one missing handle discarded an otherwise-correct build and paid for the whole thing again (~600s). The recipe and `object.py` are still on disk (`drop_build_recipe` only runs on success); naming them turns the retry into an edit. Guarded so an empty directory still builds from scratch.

**Not verified on a live retry** — no object failed its gates in any measurement run, so this path hasn't executed end to end. It's a prompt change, so the risk is that it's inert rather than harmful, but it's unproven.

## Verification

`tests/test_reference_reuse.py` pins both directions of the reuse path. The failure mode of the fix is worse than the bug: if reuse returned empty results the run would proceed with **zero objects and look like a clean no-op**. Covers reuse-loads-from-disk, missing manifest falls back, room-without-openings, and corrupt manifest raises rather than silently emptying the run.

401 passed. `ruff` clean. Rebased on main (a95e39d).

## Full pipeline after both PRs

First complete five-stage run (cold, nothing cached, TRELLIS live on Modal):

| stage | before | after |
|---|---|---|
| ingest | 383s | 189s |
| reconstruct | 2267s | 1048s |
| seed | 24s | 37s |
| author | never measured | **1081s** |
| publish | 10s | — |

**`author` is now the joint-largest stage and is completely unoptimised** — neither PR touches it. That's the obvious next target.