### PR TITLE
Isolate ported preprocessing code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ markers = [
 line-length = 100
 target-version = "py310"
 extend-exclude = ["data", "run", "output_objinit_test", "scans_uploaded", "weights",
-                   "src/litereality_agent/pipeline/scene_init/ingest/extract/lr_preprocessing",
+                   "src/litereality_agent/pipeline/scene_init/ingest/preprocessing/vendor",
                    "third_party", "legacy"]
 
 [tool.ruff.lint]

--- a/src/litereality_agent/agent/tools/shared/image_selection/README.md
+++ b/src/litereality_agent/agent/tools/shared/image_selection/README.md
@@ -29,7 +29,7 @@ What remains is the part that is *not* frame selection: surface geometry, and co
 
 Three implementations of "how well does this frame see this target" still exist:
 `select_views.quality`, `surface_views.analyze`/`select`, and a hand-maintained copy in the init
-preprocessing (`pipeline/scene_init/ingest/extract/lr_preprocessing/utils/extract_image.py`, whose
+preprocessing (`pipeline/scene_init/ingest/preprocessing/vendor/litereality/object_image_extraction.py`, whose
 comment asks you to keep it consistent with `select_views.quality` by hand). Worth unifying, but
 it spans `agent` and `pipeline`, so it needs a shared home first.
 

--- a/src/litereality_agent/pipeline/scene_init/ingest/crop/crop_objects.py
+++ b/src/litereality_agent/pipeline/scene_init/ingest/crop/crop_objects.py
@@ -15,9 +15,7 @@ import pickle
 import time
 
 from litereality_agent.pipeline.scene_init import paths as config
-
-config.ensure_lr_on_path()
-from preprocessing import (  # noqa: E402
+from litereality_agent.pipeline.scene_init.ingest.preprocessing.object_images import (
     Colors,
     prepare_camera_data_for_retrieval,
     process_all_folders,

--- a/src/litereality_agent/pipeline/scene_init/ingest/extract/extract_scene.py
+++ b/src/litereality_agent/pipeline/scene_init/ingest/extract/extract_scene.py
@@ -9,8 +9,8 @@ door/window openings from the wall-child USDAs. Writes, relative to the work roo
     input/rgbd/<scan>/...
     input/scene_data/<scan>/{walls,objects,wall_holes,floor}.pkl
 
-Heavy USD/torch/GroundingDINO code is NOT needed here — RoomPlan USDZ is parsed by
-unzipping + reading the USDA text (see lr_preprocessing/utils/utils.py).
+Heavy USD/torch/GroundingDINO code is NOT needed here. RoomPlan USDZ is parsed by
+the ported implementation under ``ingest/preprocessing/vendor``.
 """
 
 from __future__ import annotations
@@ -24,15 +24,28 @@ import numpy as np
 from PIL import Image
 
 from litereality_agent.pipeline.scene_init import paths as config
-
-config.ensure_lr_on_path()
-from preprocessing import Colors, extract_scene_data, save_scene_data  # noqa: E402
-from utils.utils import extract_rgbd, get_object_pose, get_scene_usda  # noqa: E402
+from litereality_agent.pipeline.scene_init.ingest.preprocessing.scene_data import (
+    Colors,
+    extract_rgbd,
+    extract_scene_data,
+    get_object_pose,
+    get_scene_usda,
+    save_scene_data,
+)
 
 # ── point-cloud helpers (a scan may ship pointcloud.pcd, an OBJ, or only depth) ──
-_PCD_DTYPES = {("I", 1): "i1", ("I", 2): "i2", ("I", 4): "i4", ("I", 8): "i8",
-               ("U", 1): "u1", ("U", 2): "u2", ("U", 4): "u4", ("U", 8): "u8",
-               ("F", 4): "f4", ("F", 8): "f8"}
+_PCD_DTYPES = {
+    ("I", 1): "i1",
+    ("I", 2): "i2",
+    ("I", 4): "i4",
+    ("I", 8): "i8",
+    ("U", 1): "u1",
+    ("U", 2): "u2",
+    ("U", 4): "u4",
+    ("U", 8): "u8",
+    ("F", 4): "f4",
+    ("F", 8): "f8",
+}
 
 
 def _parse_pcd_header(raw: bytes) -> tuple[dict, int]:

--- a/src/litereality_agent/pipeline/scene_init/ingest/preprocessing/README.md
+++ b/src/litereality_agent/pipeline/scene_init/ingest/preprocessing/README.md
@@ -1,0 +1,22 @@
+# Preprocessing
+
+This package keeps the ported preprocessing code separate from the current
+pipeline.
+
+The project owns `scene_data.py` and `object_images.py`. These modules provide
+the small interface used by the extract and crop stages. Project settings, such
+as `LR_ENLARGED_CROP_OBJECTS`, belong in these adapters.
+
+The `vendor/litereality` package contains code ported from earlier LiteReality
+implementations. Its module names state what each file does:
+
+| Module | Role |
+| --- | --- |
+| `scene_preprocessing.py` | Parses scenes, crops object images, and prepares camera data. |
+| `object_image_extraction.py` | Projects point clouds, ranks views, and writes object crops. |
+| `roomplan.py` | Reads RoomPlan USD files and extracts RGBD data. |
+| `scanner_capture.py` | Loads ScannerApp frames and camera data. |
+
+Keep pipeline control flow and project settings outside `vendor`. Keep fixes to
+the ported algorithms small so they remain easy to compare with the earlier
+code.

--- a/src/litereality_agent/pipeline/scene_init/ingest/preprocessing/__init__.py
+++ b/src/litereality_agent/pipeline/scene_init/ingest/preprocessing/__init__.py
@@ -1,0 +1,1 @@
+"""Project adapters for the ported scene preprocessing implementation."""

--- a/src/litereality_agent/pipeline/scene_init/ingest/preprocessing/object_images.py
+++ b/src/litereality_agent/pipeline/scene_init/ingest/preprocessing/object_images.py
@@ -1,0 +1,34 @@
+"""Object image operations used by the ingest crop stage."""
+
+from __future__ import annotations
+
+import os
+
+from .vendor.litereality.scene_preprocessing import (
+    Colors,
+    prepare_camera_data_for_retrieval,
+    process_all_folders,
+)
+from .vendor.litereality.scene_preprocessing import (
+    process_object_images as _process_object_images,
+)
+
+__all__ = [
+    "Colors",
+    "prepare_camera_data_for_retrieval",
+    "process_all_folders",
+    "process_object_images",
+]
+
+
+def process_object_images(scan, walls, objects, wall_holes, *, include_walls=False):
+    """Apply project crop settings and call the ported implementation."""
+    enlarged_crop_objects = filter(None, os.environ.get("LR_ENLARGED_CROP_OBJECTS", "").split(","))
+    return _process_object_images(
+        scan,
+        walls,
+        objects,
+        wall_holes,
+        include_walls=include_walls,
+        enlarged_crop_objects=enlarged_crop_objects,
+    )

--- a/src/litereality_agent/pipeline/scene_init/ingest/preprocessing/scene_data.py
+++ b/src/litereality_agent/pipeline/scene_init/ingest/preprocessing/scene_data.py
@@ -1,0 +1,13 @@
+"""Scene data operations used by the ingest extraction stage."""
+
+from .vendor.litereality.roomplan import extract_rgbd, get_object_pose, get_scene_usda
+from .vendor.litereality.scene_preprocessing import Colors, extract_scene_data, save_scene_data
+
+__all__ = [
+    "Colors",
+    "extract_rgbd",
+    "extract_scene_data",
+    "get_object_pose",
+    "get_scene_usda",
+    "save_scene_data",
+]

--- a/src/litereality_agent/pipeline/scene_init/ingest/preprocessing/vendor/__init__.py
+++ b/src/litereality_agent/pipeline/scene_init/ingest/preprocessing/vendor/__init__.py
@@ -1,0 +1,1 @@
+"""Code ported from earlier LiteReality implementations."""

--- a/src/litereality_agent/pipeline/scene_init/ingest/preprocessing/vendor/litereality/__init__.py
+++ b/src/litereality_agent/pipeline/scene_init/ingest/preprocessing/vendor/litereality/__init__.py
@@ -1,0 +1,5 @@
+"""Ported LiteReality preprocessing implementation.
+
+Keep project settings and pipeline control flow outside this package. Local fixes to
+the ported algorithms should stay small so changes can be compared with upstream.
+"""

--- a/src/litereality_agent/pipeline/scene_init/ingest/preprocessing/vendor/litereality/object_image_extraction.py
+++ b/src/litereality_agent/pipeline/scene_init/ingest/preprocessing/vendor/litereality/object_image_extraction.py
@@ -1,3 +1,5 @@
+"""Object point cloud projection, ranking, and crop helpers from LiteReality."""
+
 import pickle
 import open3d as o3d
 import numpy as np
@@ -406,7 +408,7 @@ def crop_and_save_new(scan_path, pcd_input, semantic, eight_points, top_k):
         _, _, eight_point_mapping = compute_mapping_for_3D_bbox(scene_name, eight_points, i)
         # bbox3d = geometric 2D extent of the FULL projected 3D box (depth-independent), so an
         # under-scanned unit (e.g. a sink whose base cabinet has few points) still spans the whole
-        # object. The crop step opts into it per object via LR_ENLARGED_CROP_OBJECTS.
+        # object. The caller decides whether to use it for a given object.
         bbox3d = project_bbox_2d(scene_name, eight_points, i, W, H)
         if bbox is not None and (bbox[2] > bbox[0]) and (bbox[3] > bbox[1]):
             bbox = [int(x) for x in bbox]
@@ -732,4 +734,3 @@ def get_wall_hole_points(wall_holes, rotation_y_list, bbox_walls, obj_points):
 
     obj_pcd_list = crop_objs_with_bbox(window_eight_points, obj_points, rotation_y_only_holes)
     return obj_pcd_list
-

--- a/src/litereality_agent/pipeline/scene_init/ingest/preprocessing/vendor/litereality/roomplan.py
+++ b/src/litereality_agent/pipeline/scene_init/ingest/preprocessing/vendor/litereality/roomplan.py
@@ -1,3 +1,5 @@
+"""RoomPlan USD parsing and RGBD extraction helpers from LiteReality."""
+
 import ast
 import filecmp
 import os
@@ -7,7 +9,7 @@ from typing import Any, Dict, List, Tuple
 from zipfile import ZipFile
 
 import numpy as np
-import utils.scannerapp_utils as scannerapp_utils
+from . import scanner_capture
 from trimesh import Trimesh
 
 
@@ -328,7 +330,7 @@ def get_objects(object_files):
 
 
 def extract_rgbd(scan_path, folder):
-    frames = scannerapp_utils.load_scan_frames_no_video(scan_path, scale_intrinsics_to_depth=True)
+    frames = scanner_capture.load_scan_frames_no_video(scan_path, scale_intrinsics_to_depth=True)
 
     subfolders = ["image", "depth", "intrinsic", "extrinsic"]
 

--- a/src/litereality_agent/pipeline/scene_init/ingest/preprocessing/vendor/litereality/scanner_capture.py
+++ b/src/litereality_agent/pipeline/scene_init/ingest/preprocessing/vendor/litereality/scanner_capture.py
@@ -1,3 +1,5 @@
+"""ScannerApp frame loading and RGBD conversion helpers from LiteReality."""
+
 import os
 
 

--- a/src/litereality_agent/pipeline/scene_init/ingest/preprocessing/vendor/litereality/scene_preprocessing.py
+++ b/src/litereality_agent/pipeline/scene_init/ingest/preprocessing/vendor/litereality/scene_preprocessing.py
@@ -32,7 +32,7 @@ class Colors:
     RESET = '\033[0m'
     BOLD = '\033[1m'
 
-from utils.extract_image import (
+from .object_image_extraction import (
     get_pcd_from_obj, 
     get_pcd_objs, 
     crop_and_save_new, 
@@ -42,7 +42,7 @@ from utils.extract_image import (
     get_wall_hole_points
 )
 
-from utils.utils import (
+from .roomplan import (
     get_scene_usda,
     get_wall_and_object_floor_files,
     get_line_segments_and_walls,
@@ -342,7 +342,14 @@ def save_scene_data(name_of_scan, walls, objects, wall_holes_result, floor):
     return output_folder
 
 
-def process_object_images(name_of_scan, walls, objects, wall_holes_result, include_walls=False):
+def process_object_images(
+    name_of_scan,
+    walls,
+    objects,
+    wall_holes_result,
+    include_walls=False,
+    enlarged_crop_objects=(),
+):
     """
     Process and extract 2D images for objects from point cloud.
     
@@ -357,9 +364,7 @@ def process_object_images(name_of_scan, walls, objects, wall_holes_result, inclu
         None
     """
     start_time = time.time()
-    # objects that should be cropped to their FULL projected 3D box instead of just their visible
-    # points (comma-separated ids, e.g. "Sink_Storage0"). Used for merged sink+storage sets.
-    _ENLARGED_CROP_OBJECTS = set(filter(None, os.environ.get("LR_ENLARGED_CROP_OBJECTS", "").split(",")))
+    enlarged_crop_objects = set(enlarged_crop_objects)
     print(f"{Colors.BLUE}🖼️{Colors.RESET} Starting to obtain 2D images for objects...")
     
     # Update wall corners data
@@ -441,8 +446,8 @@ def process_object_images(name_of_scan, walls, objects, wall_holes_result, inclu
             # ENLARGED CROP: for merged sets (e.g. a sink + its base-cabinet "Sink_Storage" unit),
             # the visible-points bbox only covers the well-scanned part (the sink). Crop instead to
             # the full projected 3D box so the evidence — and the generated reference — captures the
-            # WHOLE unit. Opt-in per object via LR_ENLARGED_CROP_OBJECTS; a small margin guards edges.
-            if object_id in _ENLARGED_CROP_OBJECTS and image_info.get("bbox3d"):
+            # WHOLE unit. Callers opt in per object; a small margin guards edges.
+            if object_id in enlarged_crop_objects and image_info.get("bbox3d"):
                 b = image_info["bbox3d"]
                 mx = int((b[2] - b[0]) * 0.06); my = int((b[3] - b[1]) * 0.06)
                 bbox = [max(0, b[0] - mx), max(0, b[1] - my), min(256, b[2] + mx), min(192, b[3] + my)]

--- a/src/litereality_agent/pipeline/scene_init/paths.py
+++ b/src/litereality_agent/pipeline/scene_init/paths.py
@@ -25,8 +25,8 @@ folders:
 
 Override the output root with ``--output-root`` / ``$LITEREALITY_OUTPUT``.
 
-The ported preprocessing (``lr_preprocessing/``) uses **relative** ``input/...``
-paths, so the stages that drive it ``chdir`` into the per-scan work root first
+The ported preprocessing uses **relative** ``input/...`` paths, so the stages
+that drive it ``chdir`` into the per-scan work root first
 (:func:`enter_work_root`). The reference/cluster stages use the absolute helpers
 below. Because the work root is per-scan, callers must select the scan with
 :func:`set_scan` (``enter_work_root(scan)`` does this) before using the helpers.
@@ -35,12 +35,9 @@ below. Because the work root is per-scan, callers must select the scan with
 from __future__ import annotations
 
 import os
-import sys
 from pathlib import Path
 
 from litereality_agent.settings import load_settings
-
-LR_PREPROC_DIR = Path(__file__).resolve().parent / "ingest" / "extract" / "lr_preprocessing"
 
 # Raw RoomPlan scans. Defaults to <repo>/scans_uploaded; point at the old repo (or anywhere)
 # via $LR_SCANS_DIR so init can run on existing scan data without copying it.
@@ -59,9 +56,9 @@ _CURRENT_SCAN: str | None = None
 # `gemini_input.jpg` / `nano_banana_raw.png` — provider names, from before image-gen moved to
 # OpenAI, describing who made the file rather than what it is. Readers still accept the old
 # spellings so a tree from an earlier run keeps working without a costly re-init.
-INPUT_SHEET = "input2imagegen.jpg"        # the evidence sheet handed TO the image model
+INPUT_SHEET = "input2imagegen.jpg"  # the evidence sheet handed TO the image model
 CLEAN_REFERENCE = "clean_obj_reference.png"  # the model's raw output, before crop/recentre
-FINAL_REFERENCE = "reference_1024.png"    # the cropped, recentred reference the pipeline uses
+FINAL_REFERENCE = "reference_1024.png"  # the cropped, recentred reference the pipeline uses
 
 _LEGACY = {INPUT_SHEET: "gemini_input.jpg", CLEAN_REFERENCE: "nano_banana_raw.png"}
 
@@ -135,13 +132,12 @@ def work_root() -> Path:
 
 def enter_work_root(scan: str | None = None) -> Path:
     """Select ``scan``, mkdir + chdir into its work root (the ported preprocessing
-    reads/writes CWD-relative ``input/...`` paths), and put lr_preprocessing on path."""
+    reads/writes CWD-relative ``input/...`` paths)."""
     if scan is not None:
         set_scan(scan)
     root = work_root()
     root.mkdir(parents=True, exist_ok=True)
     os.chdir(root)
-    ensure_lr_on_path()
     return root
 
 
@@ -189,12 +185,3 @@ def parsed_images_dir(scan: str) -> Path:
 def scene_data_complete(scan: str) -> bool:
     d = scene_data_dir(scan)
     return all((d / f"{name}.pkl").exists() for name in ("walls", "objects", "wall_holes", "floor"))
-
-
-# ── importing the ported preprocessing package ───────────────────────────────
-def ensure_lr_on_path() -> None:
-    """Put ``lr_preprocessing/`` on sys.path so ``import preprocessing`` and its
-    internal ``from utils.X import ...`` resolve to the vendored copy."""
-    p = str(LR_PREPROC_DIR)
-    if p not in sys.path:
-        sys.path.insert(0, p)

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -46,7 +46,29 @@ def test_layer_imports_only_point_inward():
 
 def test_only_supported_package_areas_exist():
     retired = {"adapters", "services", "shared"}
-    present = {
-        path.name for path in PACKAGE.iterdir() if path.is_dir() and any(path.rglob("*.py"))
-    }
+    present = {path.name for path in PACKAGE.iterdir() if path.is_dir() and any(path.rglob("*.py"))}
     assert not present & retired
+
+
+def test_ported_preprocessing_stays_behind_project_adapters():
+    preprocessing = PACKAGE / "pipeline" / "scene_init" / "ingest" / "preprocessing"
+    vendor = preprocessing / "vendor" / "litereality"
+    assert {path.name for path in preprocessing.glob("*.py")} == {
+        "__init__.py",
+        "object_images.py",
+        "scene_data.py",
+    }
+    assert not (
+        PACKAGE / "pipeline" / "scene_init" / "ingest" / "extract" / "lr_preprocessing"
+    ).exists()
+
+    violations = []
+    for path in vendor.glob("*.py"):
+        for imported in imports(path):
+            if imported.startswith("litereality_agent"):
+                violations.append(f"{path.name}: {imported}")
+        if "LR_ENLARGED_CROP_OBJECTS" in path.read_text(encoding="utf-8"):
+            violations.append(f"{path.name}: project environment setting")
+    assert not violations, "project logic found in preprocessing vendor code:\n" + "\n".join(
+        violations
+    )

--- a/tests/test_preprocessing_adapters.py
+++ b/tests/test_preprocessing_adapters.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from litereality_agent.pipeline.scene_init.ingest.preprocessing import object_images
+
+
+def test_object_image_adapter_passes_project_crop_setting(monkeypatch):
+    received = {}
+
+    def process(*args, **kwargs):
+        received["args"] = args
+        received["kwargs"] = kwargs
+        return "done"
+
+    monkeypatch.setenv("LR_ENLARGED_CROP_OBJECTS", "Sink0,Storage0")
+    monkeypatch.setattr(object_images, "_process_object_images", process)
+
+    result = object_images.process_object_images(
+        "office",
+        ["walls"],
+        ["objects"],
+        {"holes": []},
+        include_walls=True,
+    )
+
+    assert result == "done"
+    assert received["args"] == (
+        "office",
+        ["walls"],
+        ["objects"],
+        {"holes": []},
+    )
+    assert received["kwargs"]["include_walls"] is True
+    assert set(received["kwargs"]["enlarged_crop_objects"]) == {"Sink0", "Storage0"}

--- a/tests/test_projection.py
+++ b/tests/test_projection.py
@@ -24,7 +24,7 @@ import pytest
 for _heavy in ("open3d", "cv2"):
     sys.modules.setdefault(_heavy, types.ModuleType(_heavy))
 
-from litereality_agent.pipeline.scene_init.ingest.extract.lr_preprocessing.utils.extract_image import (  # noqa: E402
+from litereality_agent.pipeline.scene_init.ingest.preprocessing.vendor.litereality.object_image_extraction import (  # noqa: E402
     project_to_pixels,
     round_to_int,
 )
@@ -42,8 +42,9 @@ def visible(points: np.ndarray) -> np.ndarray:
 
 def test_points_in_front_project_where_they_always_did():
     """The fix must not move a single valid point."""
-    p, in_front = project_to_pixels(np.array([[0.0, 0.0, 3.0], [0.5, 0.3, 4.0]]),
-                                    POSE, FX, FY, CX, CY)
+    p, in_front = project_to_pixels(
+        np.array([[0.0, 0.0, 3.0], [0.5, 0.3, 4.0]]), POSE, FX, FY, CX, CY
+    )
     assert in_front.all()
     assert p[0][0] == pytest.approx(CX) and p[1][0] == pytest.approx(CY)
     assert p[0][1] == pytest.approx(CX + 0.5 * FX / 4.0)
@@ -99,11 +100,13 @@ def test_round_to_int_never_casts_nan():
 
 
 def test_mixed_batch_keeps_only_the_valid_points():
-    points = np.array([
-        [0.0, 0.0, 3.0],    # visible
-        [0.0, 0.0, 0.0],    # on the plane
-        [0.2, 0.1, -3.0],   # behind
-        [0.5, 0.3, 4.0],    # visible
-        [50.0, 0.0, 3.0],   # in front but far outside the frame
-    ])
+    points = np.array(
+        [
+            [0.0, 0.0, 3.0],  # visible
+            [0.0, 0.0, 0.0],  # on the plane
+            [0.2, 0.1, -3.0],  # behind
+            [0.5, 0.3, 4.0],  # visible
+            [50.0, 0.0, 3.0],  # in front but far outside the frame
+        ]
+    )
     assert list(visible(points)) == [True, False, False, True, False]

--- a/tests/test_rgbd_extraction.py
+++ b/tests/test_rgbd_extraction.py
@@ -5,10 +5,9 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 
-from litereality_agent.pipeline.scene_init import paths
-
-paths.ensure_lr_on_path()
-from utils import utils as ingest_utils  # noqa: E402, I001
+from litereality_agent.pipeline.scene_init.ingest.preprocessing.vendor.litereality import (
+    roomplan as ingest_utils,
+)
 
 
 def _frame(image, depth):
@@ -29,7 +28,7 @@ def test_rgbd_copy_supports_paths_with_spaces(tmp_path, monkeypatch):
     depth.write_bytes(b"depth")
     output = tmp_path / "output folder"
     monkeypatch.setattr(
-        ingest_utils.scannerapp_utils,
+        ingest_utils.scanner_capture,
         "load_scan_frames_no_video",
         lambda *_args, **_kwargs: [_frame(image, depth)],
     )
@@ -44,7 +43,7 @@ def test_rgbd_copy_reports_a_missing_source(tmp_path, monkeypatch):
     image = tmp_path / "missing image.jpg"
     depth = tmp_path / "missing depth.jpg"
     monkeypatch.setattr(
-        ingest_utils.scannerapp_utils,
+        ingest_utils.scanner_capture,
         "load_scan_frames_no_video",
         lambda *_args, **_kwargs: [_frame(image, depth)],
     )

--- a/tests/test_usda_parsing.py
+++ b/tests/test_usda_parsing.py
@@ -5,11 +5,9 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from litereality_agent.pipeline.scene_init import paths
-
-paths.ensure_lr_on_path()
-from utils.utils import get_object_pose  # noqa: E402, I001
-
+from litereality_agent.pipeline.scene_init.ingest.preprocessing.vendor.litereality.roomplan import (
+    get_object_pose,
+)
 
 IDENTITY = "[[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]"
 
@@ -17,8 +15,7 @@ IDENTITY = "[[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]"
 def test_object_pose_parses_numeric_usda_literals(tmp_path: Path):
     usda = tmp_path / "object.usda"
     usda.write_text(
-        "point3f[] points = [[0, 0, 0], [1, 2, 3]]\n"
-        f"matrix4d xformOp:transform = {IDENTITY}\n",
+        f"point3f[] points = [[0, 0, 0], [1, 2, 3]]\nmatrix4d xformOp:transform = {IDENTITY}\n",
         encoding="utf-8",
     )
 


### PR DESCRIPTION
## Summary

- Move the ported implementation under pipeline/scene_init/ingest/preprocessing/vendor/litereality and give each module a role based name.
- Add project adapters for scene data and object image processing.
- Remove the sys.path mutation and keep LR_ENLARGED_CROP_OBJECTS handling outside the vendor package.
- Add package boundary coverage and update affected imports and docs.

## Tests

- uv run pytest -q
- uv run ruff check .
- Ruff formatting check for all changed Python files

The default test run passed with 472 tests passed, 2 skipped, and 8 opt in tests deselected.