### PR TITLE
ci: run ruff and the offline test suite on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# A new push to a PR makes the in-flight run irrelevant.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      # --locked: CI fails rather than silently resolving a different dependency set than uv.lock.
+      - run: uv sync --all-groups --locked
+
+      - run: uv run ruff check .
+
+      # The default marker filter in pyproject already excludes anything needing Blender, a real
+      # scan, or a paid model call, so this run is offline and needs no secrets.
+      - run: uv run pytest -n auto

--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,8 @@ __MACOSX
 
 # retired code, kept locally for reference only (recoverable), not pushed
 /legacy/
-# scratch measurement runs (run-measure, run-measure2, ...)
-/run-measure*
+# scratch run dirs beside run/ (run-measure, run-measure2, run-e2e, ...) — pipeline output
+/run-*
 
 # macOS finder junk
 .DS_Store

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ markers = [
 [tool.ruff]
 line-length = 100
 target-version = "py310"
-extend-exclude = ["data", "run", "output_objinit_test", "scans_uploaded", "weights",
+extend-exclude = ["data", "run", "run-*", "output_objinit_test", "scans_uploaded", "weights",
                    "src/litereality_agent/pipeline/scene_init/ingest/preprocessing/vendor",
                    "third_party", "legacy"]
 

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -863,8 +863,13 @@ def test_polish_reuses_a_recorded_run(tmp_path, monkeypatch):
     assert out["reused"] is True and out["refined_total"] == 29
 
 
+@pytest.mark.live
 def test_force_ignores_the_marker(tmp_path, monkeypatch):
-    """After new crops or a different detector, the recorded run is stale."""
+    """After new crops or a different detector, the recorded run is stale.
+
+    Marked live: unlike the reuse case above, force=True skips the marker and runs the real
+    detector, which needs the Modal extra and Modal credentials.
+    """
     pytest.importorskip("cv2")
     import json as _json
     import sys


### PR DESCRIPTION
No CI existed — `.github/workflows/` was an empty directory. This adds one workflow, since everything it needs was already configured in `pyproject.toml`.

## What runs

One job, on PRs and pushes to `main`: `uv sync --all-groups --locked` → `ruff check .` → `pytest -n auto`. Roughly 6s of actual work after the install; no secrets, no GPU, no network calls. The existing marker filter (`-m 'not blender and not scan and not live'`) already keeps the paid and hardware-dependent tests out of the default run, so CI just inherits it.

`--locked` means a PR that edits `pyproject.toml` without refreshing `uv.lock` fails instead of silently resolving a different dependency set.

## Fixes needed to make a clean checkout pass

- **`test_force_ignores_the_marker` marked `live`.** Unlike the reuse case above it, `force=True` skips the marker and runs the real detector through Modal. It passes locally only if you have the `modal` extra installed and Modal credentials in `.env` — exactly what the `live` marker is for.
- **`/run-*` added to `.gitignore`** (replacing `/run-measure*`). `run-e2e/` is pipeline output that was sitting untracked in the working tree. Its generated `Room.py` / `build_room.py` files were the sole source of the 32 `E401`/`I001` errors that `ruff check .` reported locally — no committed source was ever unclean.
- **Same `run-*` glob in ruff's `extend-exclude`,** so linting skips generated output even when those dirs are present.

## Deliberately left out

- **`ruff format --check`.** 133 of 258 files would reformat; enforcing it belongs in its own commit, not bundled with CI setup.
- **A Python version matrix.** Single 3.12 runner. `requires-python` claims 3.10–3.12, so add 3.10 if that floor is real.
- **CD.** Nothing in the repo publishes or deploys; `deploy/modal/*` is run by hand through the Modal CLI.