### PR TITLE
Generate reference images on Gemini as well as OpenAI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # --- reference image generation (required) ---
-# Hosted OpenAI reference images.
+# One of these, matching $LR_IMAGE_PROVIDER in models.env (openai by default).
 OPENAI_API_KEY=
+# Only needed when LR_IMAGE_PROVIDER=gemini (or --image-model gemini-*). Get one at
+# https://aistudio.google.com/apikey
+GEMINI_API_KEY=
 
 # --- Blender (required) ---
 # Your Blender INSTALL DIR — the folder containing the `blender` binary, not the binary itself.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Tested on **macOS** (Apple Silicon) and **Linux** (with a >=24 GB GPU).
 
 1. [`uv`](https://docs.astral.sh/uv/)
 2. **Blender 5.x** (tested on 5.1). `BLENDER_PATH` points at the install *directory*, not the binary.
-3. **OpenAI API key** for reference image generation — typically under $1 per scene.
+3. **An image-generation API key** for reference images — typically under $1 per scene.
+   `OPENAI_API_KEY` by default, or `GEMINI_API_KEY` with `LR_IMAGE_PROVIDER=gemini`.
 4. **A logged-in agent CLI on your `PATH`** — this drives all reasoning. `claude`
    (Claude Code) is the default; `codex` (OpenAI Codex) is also supported, selected with
    `LR_AGENT_PROVIDER` in `models.env`.
@@ -65,6 +66,7 @@ cp .env.example .env
 | variable | where it comes from |
 |---|---|
 | `OPENAI_API_KEY` | reference image generation — typically under $1 per scene |
+| `GEMINI_API_KEY` | only for `LR_IMAGE_PROVIDER=gemini` → [aistudio.google.com/apikey](https://aistudio.google.com/apikey) |
 | `MODAL_TOKEN_ID` · `MODAL_TOKEN_SECRET` | a free [Modal](https://modal.com) account → [modal.com/settings/tokens](https://modal.com/settings/tokens) |
 | `BLENDER_PATH` | your Blender install **directory**, not the binary |
 | `LR_SCANS_DIR` | the folder holding your scans |

--- a/models.env
+++ b/models.env
@@ -69,6 +69,12 @@ export LR_COMPLETENESS_MODEL="${LR_COMPLETENESS_MODEL:-$HARNESS_MODEL}"
 # faithful object renders; gpt-image-1 kept only as a fallback.
 export LR_OPENAI_IMAGE_MODEL="${LR_OPENAI_IMAGE_MODEL:-gpt-image-2}"
 
+# Which backend generates reference images: openai (default) or gemini. Naming a gemini-* model
+# via --image-model switches on its own, so this is for pinning the choice across a whole run.
+# Gemini needs $GEMINI_API_KEY and is roughly half the cost per reference (~$0.04 vs ~$0.08).
+export LR_IMAGE_PROVIDER="${LR_IMAGE_PROVIDER:-openai}"
+export LR_GEMINI_IMAGE_MODEL="${LR_GEMINI_IMAGE_MODEL:-gemini-2.5-flash-image}"
+
 # ── Detection / embedding — HuggingFace checkpoints (local, CPU/GPU) ─────────
 export LR_DINO_MODEL="${LR_DINO_MODEL:-IDEA-Research/grounding-dino-tiny}"    # GroundingDINO (detect)
 export LR_DINO_EMBED_MODEL="${LR_DINO_EMBED_MODEL:-facebook/dinov2-small}"    # DINOv2 (grouping embeddings)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     # model providers
     "anthropic>=0.40.0",
     "openai>=1.40.0",
+    "google-genai>=1.0.0",
     "claude-agent-sdk",
     # init / preprocessing (DINO, projection, meshes)
     "trimesh>=4.0",

--- a/src/litereality_agent/pipeline/scene_init/ingest/references/image_gen.py
+++ b/src/litereality_agent/pipeline/scene_init/ingest/references/image_gen.py
@@ -194,6 +194,11 @@ def _call_gemini(sheet_path, full_prompt, img_model, key, timeout):
             full_prompt,
             types.Part.from_bytes(data=Path(sheet_path).read_bytes(), mime_type=mime),
         ],
+        # We pass no tools, and leaving AFC on makes the SDK warn once per call — one line of noise
+        # per object, so a 20-object room buries its own progress output.
+        config=types.GenerateContentConfig(
+            automatic_function_calling=types.AutomaticFunctionCallingConfig(disable=True),
+        ),
     )
     png = None
     for candidate in (result.candidates or []):

--- a/src/litereality_agent/pipeline/scene_init/ingest/references/image_gen.py
+++ b/src/litereality_agent/pipeline/scene_init/ingest/references/image_gen.py
@@ -1,4 +1,10 @@
-"""Hosted OpenAI reference-image generation."""
+"""Hosted reference-image generation, on OpenAI or Gemini.
+
+One call per object: the evidence sheet plus the prompt go up, one clean object render comes back.
+Pick the backend with ``$LR_IMAGE_PROVIDER`` (``openai`` by default, or ``gemini``); naming a
+``gemini-*`` model is enough on its own. The retry ladder, telemetry, and black-background
+normalisation are shared, so the rest of the pipeline cannot tell which one produced a reference.
+"""
 
 from __future__ import annotations
 
@@ -15,6 +21,21 @@ from PIL import Image
 from litereality_agent import telemetry
 
 DEFAULT_IMAGE_MODEL = "gpt-image-1"
+DEFAULT_GEMINI_IMAGE_MODEL = "gemini-2.5-flash-image"
+
+
+def resolve_provider(model: str | None = None) -> str:
+    """Which backend to call: explicit ``$LR_IMAGE_PROVIDER`` wins, else infer from the model name.
+
+    Inferring matters because the model is what callers actually pass around (``--image-model``),
+    so naming a ``gemini-*`` model without also setting the provider should just work rather than
+    sending a Gemini model id to OpenAI and failing on an unhelpful 404.
+    """
+    explicit = (os.environ.get("LR_IMAGE_PROVIDER") or "").strip().lower()
+    if explicit in ("openai", "gemini"):
+        return explicit
+    name = (model or os.environ.get("LR_OPENAI_IMAGE_MODEL") or "").lower()
+    return "gemini" if name.startswith("gemini") else "openai"
 
 # Reference generation is one hosted image call per object, ~45s each, and every caller had it in
 # a serial loop. The ceiling is OpenAI's rate limit, not local CPU, so the cap is about not opening
@@ -52,7 +73,14 @@ def _retry_after_seconds(exc: Exception) -> float | None:
 
 
 def _is_rate_limit(exc: Exception) -> bool:
-    return getattr(exc, "status_code", None) == 429 or type(exc).__name__ == "RateLimitError"
+    # google-genai raises ClientError with `.code`, and says RESOURCE_EXHAUSTED rather than 429 in
+    # the body, so neither of the OpenAI tests alone catches a throttled Gemini call.
+    return (
+        getattr(exc, "status_code", None) == 429
+        or getattr(exc, "code", None) == 429
+        or type(exc).__name__ == "RateLimitError"
+        or "RESOURCE_EXHAUSTED" in str(exc)
+    )
 
 
 # OpenAI answers 429 for two unrelated conditions: "you are going too fast" and "your balance is
@@ -110,6 +138,18 @@ def _cost_usd(usage: dict) -> float:
     )
 
 
+# gemini-2.5-flash-image token pricing ($/1M); one 1024px image is ~1290 output tokens (~$0.04).
+_PRICE_GEMINI_IN = float(os.environ.get("LR_GEMINI_PRICE_IN", "0.30"))
+_PRICE_GEMINI_OUT = float(os.environ.get("LR_GEMINI_PRICE_OUT", "30.0"))
+
+
+def _gemini_cost_usd(usage: dict) -> float:
+    return round(
+        (usage.get("input_tokens", 0) * _PRICE_GEMINI_IN
+         + usage.get("output_tokens", 0) * _PRICE_GEMINI_OUT) / 1e6, 5
+    )
+
+
 def _flatten_on_black(png_bytes: bytes) -> bytes:
     """Composite a possibly-transparent render onto solid black so normalize's black-key crop works."""
     im = Image.open(io.BytesIO(png_bytes)).convert("RGBA")
@@ -118,6 +158,63 @@ def _flatten_on_black(png_bytes: bytes) -> bytes:
     out = io.BytesIO()
     canvas.convert("RGB").save(out, format="PNG")
     return out.getvalue()
+
+
+def _call_openai(sheet_path, full_prompt, img_model, key, timeout, use_transparent):
+    """One OpenAI image edit. Returns (png_bytes, usage, cost_usd, extra_response_fields)."""
+    from openai import OpenAI
+
+    quality = os.environ.get("LR_OPENAI_IMAGE_QUALITY", "medium")
+    client = OpenAI(api_key=key, timeout=timeout)
+    edit_kwargs = dict(model=img_model, prompt=full_prompt, size="1024x1024", quality=quality)
+    if use_transparent:
+        edit_kwargs["background"] = "transparent"
+    with open(sheet_path, "rb") as fh:
+        result = client.images.edit(image=fh, **edit_kwargs)
+    png = base64.b64decode(result.data[0].b64_json)
+    usage = result.usage.model_dump() if getattr(result, "usage", None) is not None else {}
+    return png, usage, _cost_usd(usage), {"quality": quality}
+
+
+def _call_gemini(sheet_path, full_prompt, img_model, key, timeout):
+    """One Gemini image edit. Returns (png_bytes, usage, cost_usd, extra_response_fields).
+
+    Gemini returns the render as an inline_data part alongside any commentary parts, so the image
+    has to be picked out rather than read off a fixed index. A response with no image part at all
+    is normally a safety block, which the retry loop should treat as a failed attempt.
+    """
+    from google import genai
+    from google.genai import types
+
+    client = genai.Client(api_key=key, http_options=types.HttpOptions(timeout=timeout * 1000))
+    mime = "image/jpeg" if Path(sheet_path).suffix.lower() in (".jpg", ".jpeg") else "image/png"
+    result = client.models.generate_content(
+        model=img_model,
+        contents=[
+            full_prompt,
+            types.Part.from_bytes(data=Path(sheet_path).read_bytes(), mime_type=mime),
+        ],
+    )
+    png = None
+    for candidate in (result.candidates or []):
+        for part in ((candidate.content.parts if candidate.content else None) or []):
+            blob = getattr(part, "inline_data", None)
+            if blob is not None and blob.data:
+                png = blob.data
+                break
+        if png:
+            break
+    if png is None:
+        reason = getattr(result, "prompt_feedback", None) or getattr(
+            (result.candidates or [None])[0], "finish_reason", None)
+        raise RuntimeError(f"Gemini returned no image part (finish_reason={reason})")
+    meta = getattr(result, "usage_metadata", None)
+    usage = {
+        "input_tokens": getattr(meta, "prompt_token_count", 0) or 0,
+        "output_tokens": getattr(meta, "candidates_token_count", 0) or 0,
+        "total_tokens": getattr(meta, "total_token_count", 0) or 0,
+    }
+    return png, usage, _gemini_cost_usd(usage), {}
 
 
 def generate_reference(
@@ -133,26 +230,34 @@ def generate_reference(
     response_dir: Path | None = None,
 ) -> dict | None:
     """Generate an isolated object reference and write it to ``out_path``."""
-    from openai import OpenAI
-
     sheet_path = Path(sheet_path)
     out_path = Path(out_path)
     call_t0 = time.time()
+    provider = resolve_provider(model)
     if out_path.exists() and not force:
-        telemetry.on_image_generation(prompt, sheet_path, out_path, "skipped_exists", model="openai")
+        telemetry.on_image_generation(prompt, sheet_path, out_path, "skipped_exists", model=provider)
         return None
 
-    key = api_key or os.environ.get("OPENAI_API_KEY")
-    if not key:
-        raise RuntimeError("OpenAI image generation needs $OPENAI_API_KEY.")
-    img_model = os.environ.get("LR_OPENAI_IMAGE_MODEL", DEFAULT_IMAGE_MODEL)
-    quality = os.environ.get("LR_OPENAI_IMAGE_QUALITY", "medium")
-    client = OpenAI(api_key=key, timeout=timeout)
-    # gpt-image-2 rejects transparent backgrounds; only the gpt-image-1 family supports them. With
-    # transparent we composite the exact object onto black; otherwise we ask the model for a solid
-    # black background (normalize keys on black either way). A generic clause kills the hallucinated
-    # hooks/posters/props gpt-image-1 tends to bolt on.
-    use_transparent = "gpt-image-2" not in img_model
+    if provider == "gemini":
+        key = api_key or os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+        if not key:
+            raise RuntimeError("Gemini image generation needs $GEMINI_API_KEY.")
+        img_model = (os.environ.get("LR_GEMINI_IMAGE_MODEL")
+                     or (model if (model or "").lower().startswith("gemini") else None)
+                     or DEFAULT_GEMINI_IMAGE_MODEL)
+        # No transparent-background option on the image models, so take the black-background path.
+        use_transparent = False
+    else:
+        key = api_key or os.environ.get("OPENAI_API_KEY")
+        if not key:
+            raise RuntimeError("OpenAI image generation needs $OPENAI_API_KEY.")
+        img_model = os.environ.get("LR_OPENAI_IMAGE_MODEL") or model or DEFAULT_IMAGE_MODEL
+        # gpt-image-2 rejects transparent backgrounds; only the gpt-image-1 family supports them.
+        # With transparent we composite the exact object onto black; otherwise we ask the model for
+        # a solid black background (normalize keys on black either way).
+        use_transparent = "gpt-image-2" not in img_model
+    label = f"{provider}:{img_model}"
+    # A generic clause kills the hallucinated hooks/posters/props gpt-image-1 tends to bolt on.
     clean = (
         "\n\nRender ONLY this single object as a clean photoreal PBR asset — remove loose clutter and "
         "scene (coats, bags, papers, people, room background, floor, added text or borders), but KEEP "
@@ -171,34 +276,30 @@ def generate_reference(
     last_err = None
     for attempt in range(retries):
         try:
-            edit_kwargs = dict(model=img_model, prompt=full_prompt, size="1024x1024", quality=quality)
-            if use_transparent:
-                edit_kwargs["background"] = "transparent"
-            with open(sheet_path, "rb") as fh:
-                result = client.images.edit(image=fh, **edit_kwargs)
-            datum = result.data[0]
-            png = base64.b64decode(datum.b64_json)
+            if provider == "gemini":
+                png, usage, cost, extra = _call_gemini(
+                    sheet_path, full_prompt, img_model, key, timeout)
+            else:
+                png, usage, cost, extra = _call_openai(
+                    sheet_path, full_prompt, img_model, key, timeout, use_transparent)
             out_path.parent.mkdir(parents=True, exist_ok=True)
             out_path.write_bytes(_flatten_on_black(png) if use_transparent else png)
-            usage = (
-                result.usage.model_dump() if getattr(result, "usage", None) is not None else {}
-            )
-            cost = _cost_usd(usage)
             if response_dir is not None:
                 response_dir.mkdir(parents=True, exist_ok=True)
-                (response_dir / f"openai_response_{attempt}.json").write_text(
-                    json.dumps({"model": img_model, "quality": quality, "usage": usage,
-                                "cost_usd": cost}, indent=2),
+                (response_dir / f"{provider}_response_{attempt}.json").write_text(
+                    json.dumps({"model": img_model, "usage": usage, "cost_usd": cost, **extra},
+                               indent=2),
                     encoding="utf-8",
                 )
             telemetry.on_image_generation(
-                prompt, sheet_path, out_path, "ok", model=f"openai:{img_model}",
+                prompt, sheet_path, out_path, "ok", model=label,
                 elapsed_sec=round(time.time() - call_t0, 3), attempt=attempt, usage=usage,
             )
-            print(f"    [openai-image] {out_path.name}  ${cost}  ({usage.get('output_tokens','?')} out tok)", flush=True)
+            print(f"    [{provider}-image] {out_path.name}  ${cost}  "
+                  f"({usage.get('output_tokens','?')} out tok)", flush=True)
             return {
                 "status": "ok",
-                "model": f"openai:{img_model}",
+                "model": label,
                 "attempt": attempt,
                 "output": str(out_path),
                 "elapsed_sec": round(time.time() - call_t0, 3),
@@ -207,9 +308,9 @@ def generate_reference(
             }
         except Exception as exc:  # noqa: BLE001
             last_err = f"{type(exc).__name__}: {exc}"
-            if is_out_of_credit(exc):
+            if provider == "openai" and is_out_of_credit(exc):
                 telemetry.on_image_generation(
-                    prompt, sheet_path, out_path, "error", model=f"openai:{img_model}",
+                    prompt, sheet_path, out_path, "error", model=label,
                     elapsed_sec=round(time.time() - call_t0, 3), error=str(last_err)[:400],
                 )
                 raise RuntimeError(
@@ -222,17 +323,17 @@ def generate_reference(
             delay = retry_delay(exc, attempt)
             if _is_rate_limit(exc):
                 print(
-                    f"    [openai-image] rate limited on {out_path.name}; "
+                    f"    [{provider}-image] rate limited on {out_path.name}; "
                     f"waiting {delay:.0f}s (attempt {attempt + 1}/{retries})",
                     flush=True,
                 )
             time.sleep(delay)
 
     telemetry.on_image_generation(
-        prompt, sheet_path, out_path, "error", model=f"openai:{img_model}",
+        prompt, sheet_path, out_path, "error", model=label,
         elapsed_sec=round(time.time() - call_t0, 3), error=str(last_err)[:400],
     )
-    raise RuntimeError(f"OpenAI image returned nothing after {retries} tries: {last_err}")
+    raise RuntimeError(f"{provider} image returned nothing after {retries} tries: {last_err}")
 
 
 def normalize_reference(

--- a/uv.lock
+++ b/uv.lock
@@ -863,6 +863,45 @@ wheels = [
 ]
 
 [[package]]
+name = "google-auth"
+version = "2.56.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/4c/fa42116a48bab3f7a143cf5042ecff7df9c8b73f8a376203cd534d1dc966/google_auth-2.56.3.tar.gz", hash = "sha256:40e229fc901f0a305b553050e5fce562d509bee0435be053abfa91582b51b90c", size = 367110, upload-time = "2026-08-06T06:24:01.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/b3/6117b2f24065cd7e2c4f140e9a193e215f089ca8ba314cf91eb9d0b7fe0a/google_auth-2.56.3-py3-none-any.whl", hash = "sha256:8ec438808f813ad034535000261eed1067475d229d05bbf4216e78c3f2362e53", size = 259116, upload-time = "2026-08-06T06:22:51.788Z" },
+]
+
+[package.optional-dependencies]
+requests = [
+    { name = "requests" },
+]
+
+[[package]]
+name = "google-genai"
+version = "2.18.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "google-auth", extra = ["requests"] },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "sniffio" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/e3/1dd592243a0dfc3487ddfff7995f12686d0557ec953173dd9bdbeba2cb96/google_genai-2.18.1.tar.gz", hash = "sha256:a1e2be75c16234adc6641afd1ad4dd44218c9eec005d938bdc428585a048918a", size = 659694, upload-time = "2026-08-13T22:13:50.226Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/7d/5310f7a1cf290a6cb22eab37059610bf338ab7595892902591d2220cf825/google_genai-2.18.1-py3-none-any.whl", hash = "sha256:36a5949233e64a60f6cc4521bff7a76b7c569d0aa227bbe9fa642213b8a3a3b2", size = 1051129, upload-time = "2026-08-13T22:13:48.083Z" },
+]
+
+[[package]]
 name = "grpclib"
 version = "0.4.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1238,6 +1277,7 @@ dependencies = [
     { name = "anthropic" },
     { name = "claude-agent-sdk" },
     { name = "fastapi" },
+    { name = "google-genai" },
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -1283,6 +1323,7 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.40.0" },
     { name = "claude-agent-sdk" },
     { name = "fastapi", specifier = ">=0.111.0" },
+    { name = "google-genai", specifier = ">=1.0.0" },
     { name = "modal", marker = "extra == 'modal'", specifier = ">=1.3,<2" },
     { name = "networkx" },
     { name = "numpy" },
@@ -2258,6 +2299,27 @@ wheels = [
 ]
 
 [[package]]
+name = "pyasn1"
+version = "0.6.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3120,6 +3182,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
 name = "threadpoolctl"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3483,6 +3554,71 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/27/0b/a54103cfd732bb703c7a749222011a0483ef3705948dae3b203158601119/watchfiles-1.2.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:094b9b70103d4e963499bdea001ee3c2697b144cd9ae6218a62c0f89ec9e31db", size = 396629, upload-time = "2026-05-18T04:32:03.268Z" },
     { url = "https://files.pythonhosted.org/packages/5e/2c/73f31a3b893886206c3f54d73e8ad8dee58cdb2f69ad2622e0a8a9e07f4e/watchfiles-1.2.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b0ef001f8c25ad0fa9529f914c1600647ecd0f542d11c19b7894768c67b6acb7", size = 457318, upload-time = "2026-05-18T04:31:01.932Z" },
     { url = "https://files.pythonhosted.org/packages/e9/f9/45d021e4a5cc7b9dd567f7cbb06d3b75f751a690063fb6cc7ec60f4e46b7/watchfiles-1.2.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a88fc94e647bc4eec523f1caa540258eb71d14278b9daf72fa1e2658a98df0f0", size = 457771, upload-time = "2026-05-18T04:30:56.331Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/f7/bc3a25c5ec26ce62ce487690becc2f3710bbc7b33338f005ad390db0b986/websockets-16.1.1.tar.gz", hash = "sha256:db234eda965dcce15df96bb9709f587cd87d4d52aaf0e80e2f34ec04c7670c57", size = 182204, upload-time = "2026-07-17T22:51:05.858Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/e7/d1671fb984f9dd844e1da5288070c7c23c9eaba3082d3871aae19c3ab8b9/websockets-16.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:49ae99bdfcae803a885c926bf14f886196e84925395bb3f568fef5c0f0979d7d", size = 179570, upload-time = "2026-07-17T22:48:24.032Z" },
+    { url = "https://files.pythonhosted.org/packages/99/f5/70df723bf571f5e0b1b845e0a4ff1c966eeb84f667599fc251caa37d15a3/websockets-16.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5bfd1ac19b1b9986a9c95a82d5e23a391ebb09e12c34d7be6094b86efcc35731", size = 177252, upload-time = "2026-07-17T22:48:25.775Z" },
+    { url = "https://files.pythonhosted.org/packages/90/72/2f14b2e167170b8bf1c8bb7f9b0d78000f470d41a2085a91f33e3917b6c9/websockets-16.1.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9246a0d063cfcbcc85f2359dd6876d681213f4790832272aa16641b4ed5d64d4", size = 177530, upload-time = "2026-07-17T22:48:27.337Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/18/a17e2f0cde02dc10154c808deed7e1d8528afff93612f70d3f0a5b19b011/websockets-16.1.1-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1214e673c404684b9bf7154f5cf43b45025b1a6160fac3a9e438e9c1a97e22cb", size = 186038, upload-time = "2026-07-17T22:48:28.756Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/b0/41de283899cf5929d637b72a508cdbc9aa40dc0f317c6b77613fd1000488/websockets-16.1.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:90001d893bc368e302ef168d82130b4e4fdd27b85fa094682df9b667c2d48838", size = 187278, upload-time = "2026-07-17T22:48:30.328Z" },
+    { url = "https://files.pythonhosted.org/packages/50/61/874aab5257e027f9f61b5004cec65e592babca7942b1bc09f38e72b7f1fd/websockets-16.1.1-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:130937b167a52af203c8d58e78d67705874e82759862e3b9671a452fec4abc87", size = 189936, upload-time = "2026-07-17T22:48:31.896Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/1a/42173913ac5519607220849ed417c864d77384e4119f06dbba964a50f096/websockets-16.1.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9c9f23004a3d40e89c01a7955d186a6cc83418d93b749701944ce2de3e95a1f3", size = 187796, upload-time = "2026-07-17T22:48:33.344Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/f4/37c1840bd89b529479aec41470b97b7c683b107ca90b6399ac5afb99dedf/websockets-16.1.1-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f55f0b01956a094c8587146d9558c91937e78789c333860ffaf35931a6e5dbc4", size = 186481, upload-time = "2026-07-17T22:48:34.843Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/70/652d9b964adcfbeb056f42e0ca6bece34d108fe75534e74df20643cae199/websockets-16.1.1-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6aaface73b9c71974c6497366d8b9628357f6c9749e09c4ea3610176c63f2ae3", size = 184351, upload-time = "2026-07-17T22:48:36.307Z" },
+    { url = "https://files.pythonhosted.org/packages/13/f1/af3850e5d48d482921985be72ebcb169c6180b3a77b57bd612deebcee23b/websockets-16.1.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:dc0fad4933f427acd5b1cec210f3ea6dce7089e1724e4b9ec6ef47c6c04d1b3b", size = 186791, upload-time = "2026-07-17T22:48:37.762Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/40/1a4e3ed4969ec378dcad337e5f1472c5e292cb3e733bc392f0dc2e230abd/websockets-16.1.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:f2769a0344a09e9ccf5b3cce538bc75a51b53eff3275d3896310c8552049195d", size = 185413, upload-time = "2026-07-17T22:48:39.127Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/3e/4e3fa1afe8f1a6a780434cd9ba8eb422632b044eff3dd73f6af67523c147/websockets-16.1.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:f70541f3104339f59f830522d94ebadb1bf47426287381623443d8bb1cdbf33d", size = 187178, upload-time = "2026-07-17T22:48:40.676Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ab/dd742766aa5dda7f349be0de49e4d565b84cf6f7f7fa02e07692f0f2bdd9/websockets-16.1.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:dc385593a42e31cd6fb60c19f0ecb015b386603818fc2c6c274fb42bd2bb4165", size = 185051, upload-time = "2026-07-17T22:48:42.098Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/f5/76438c6560f416f1c0a7f587679fb97cc6e99ed336011d43ce2002dd27c1/websockets-16.1.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:387e8e4aa5df2f90b198fa3cad3478822a89cf905b6a6d6c97dc3664689640cc", size = 185846, upload-time = "2026-07-17T22:48:43.472Z" },
+    { url = "https://files.pythonhosted.org/packages/62/12/5c0320f2127823d27b2d56d611d31b0b284ad4edcb41364d66bf4c92b537/websockets-16.1.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:fd46fff7eb62c24804d234f0051c7a8ea81285ad63e0337d3dcf33ca82aee58a", size = 186066, upload-time = "2026-07-17T22:48:44.884Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/97/875986b857b955c3f9dd192cb8a1af81254dfb2ea22cc9590f0a1e020b8b/websockets-16.1.1-cp310-cp310-win32.whl", hash = "sha256:7883388947767080f094950b342b30d35a2a06b849cd967c422fa0db72b40ea9", size = 179940, upload-time = "2026-07-17T22:48:46.481Z" },
+    { url = "https://files.pythonhosted.org/packages/54/82/1013a5fe7ddae8e102bc3b4b39db81d8d28fd02100a324ce6ede8cd832b1/websockets-16.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:d57685547e0060cc6fd90ee6a28405d6bd395e525545f13c8d7cd99c78afd79f", size = 180239, upload-time = "2026-07-17T22:48:48.043Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/03/47debfe28e9d6d354be5d777b67fd44c359b9eb299a5d103500bd7cc3e37/websockets-16.1.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d0fcf657e9f13ff4b177960ab2200237b12994232dfb6df16f1cfe1d4339f93c", size = 179566, upload-time = "2026-07-17T22:48:49.596Z" },
+    { url = "https://files.pythonhosted.org/packages/72/93/31efa1ed78c17e5cfc229fd449e3966e1b9cc15753204cd585cc8dd01f4a/websockets-16.1.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b852788aa51764e2d8e4cf5493d559326bcae5e38d16ba25ffa322b034df272a", size = 177250, upload-time = "2026-07-17T22:48:50.942Z" },
+    { url = "https://files.pythonhosted.org/packages/01/4a/542378ab3972b0c1cf1df3df3eff9591cea0d30c58c3aa3c4ddbc244e787/websockets-16.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1427fb4cf0d72f66333e2cacc3ff5f575bf2d7008166ce991a4a470b21d51a22", size = 177528, upload-time = "2026-07-17T22:48:52.59Z" },
+    { url = "https://files.pythonhosted.org/packages/33/d9/162321f63c7eed558e9e1798ed7a1e34a4f6dab51f35419e4ed7a4907979/websockets-16.1.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:da4ca1a9d72f9030b3146b8d7022719a9f3d478f61efe6f7dd51d243f61c51b2", size = 186859, upload-time = "2026-07-17T22:48:53.915Z" },
+    { url = "https://files.pythonhosted.org/packages/de/09/87df740f7430ce564bd52402e9c9458d4d0459cc7d2ee29e530c8204851b/websockets-16.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:86d7f0f8bdb25d2c632b72527325e4776430fd5bc61b9118de4e2b8ddb5f5b01", size = 188095, upload-time = "2026-07-17T22:48:55.384Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/12/3d2703af7cc095f3c81904c92208cc1ae79affbc67376944b50ee9301f73/websockets-16.1.1-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7dfcad78ea1492ee3a9ec765cb7f51bbc17d477107aaf6b22abf7b2558d1c5a0", size = 191385, upload-time = "2026-07-17T22:48:56.742Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/69/986aa0234a964a00f5149cfc46e136e96c8faad1c783474550f40d31aef4/websockets-16.1.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:fb9a0a6dc3d1b3986cb88091b6899f0396651e0f74e2c9766ab8d6ffc3842e29", size = 188653, upload-time = "2026-07-17T22:48:58.134Z" },
+    { url = "https://files.pythonhosted.org/packages/35/6b/10f9d03e3970a69ba67bd3b46b87a929b586d0300fadbfe14f57c1f85490/websockets-16.1.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:29dfa8114c4a620c69591c5973860f768eac29d3fd6904f37f34266cb219c512", size = 187426, upload-time = "2026-07-17T22:48:59.515Z" },
+    { url = "https://files.pythonhosted.org/packages/56/db/bb3aad62bf63d8bb3f0634b2eabffcfb3677a34bd19492110ff6869cf703/websockets-16.1.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6ff9417c0ada4d0f7d212f928303e5579bdf3ace4c802fa4afabb30995da58c3", size = 184882, upload-time = "2026-07-17T22:49:00.916Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/4c/c09a2ea9bfbeccce52fdc383e5f28af4bc8843338aabac28c81489af6120/websockets-16.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8fe0b50da2d84535fb4f7b4bfa951280f97ce3d558a0443b541166d609e67b57", size = 187584, upload-time = "2026-07-17T22:49:02.283Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/8b/31bb4eb4d9eaacf1fdd39d115772a8aeaedfc19b5dc262e57ffbc8a9d42c/websockets-16.1.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:34420aaa64440ebd51ac72ca8a45ef4626429438c9b02e633ae412ed43f925d3", size = 186174, upload-time = "2026-07-17T22:49:03.973Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e4/dc02d725610a1ad49e193ef91a548194d71bdc6cdf27da83067dd1f73995/websockets-16.1.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:a6a61aff018180c9c50b7b0da33bfd29d378af3497429c95006c589a23a11648", size = 187986, upload-time = "2026-07-17T22:49:05.553Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/73/30ed84c8bfd14c73d4af29d5ed9323c3073b48e0b7b23b67070f4e7fd59b/websockets-16.1.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:04fd29a0e2fe9414a95b00e92c67ae51bf900c50c0f8a4b2dafdad621f49ea1d", size = 185565, upload-time = "2026-07-17T22:49:06.959Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/d3/4be8d4959f51e31b4f8fc0ece12b45bd3b6c0d15ea23b9990d9c11fc805f/websockets-16.1.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:5c31aa7e39ee3e8a358573257f1c0bb5c52430d1b637030dd9c8cc2c282926be", size = 186598, upload-time = "2026-07-17T22:49:08.293Z" },
+    { url = "https://files.pythonhosted.org/packages/26/fa/abb38597a52d84ed9cfacadc7a0c6f2db282c0ab23cdf72b58a666a21227/websockets-16.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d14bfb217eb4701e850f1525c9d29d79c44794cdf1c299ead25f39f8c78dea81", size = 186834, upload-time = "2026-07-17T22:49:09.766Z" },
+    { url = "https://files.pythonhosted.org/packages/59/80/1119ad08a228b90c4eb77fbe48df7836731a605f5f881ba701ca826a4a65/websockets-16.1.1-cp311-cp311-win32.whl", hash = "sha256:2e28e602bb13da44fbe518c1781a88e3b9d4c3d48d02c9bad83e546164336f57", size = 179940, upload-time = "2026-07-17T22:49:11.196Z" },
+    { url = "https://files.pythonhosted.org/packages/71/b2/e511c1c6f64a95c2f3fc54bffda0e14eaa7e9442be605c29270f7589b918/websockets-16.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:7421fad442de870a8cbf2287d1cad7e706ece0dbfeba5e911df132cbdc1cb56a", size = 180239, upload-time = "2026-07-17T22:49:12.519Z" },
+    { url = "https://files.pythonhosted.org/packages/17/9d/681cda21c9eee743203a6cb79b9d3d05adad9aa60ec660c6c9bf4dd619ca/websockets-16.1.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:cc97814dfb786a83b6e2dc2e79351e1b83e6d715647d6887fcabd83026417a00", size = 179600, upload-time = "2026-07-17T22:49:13.92Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/8d/6195a88b45e8d2a8f745fc2046e36f885a3c9763e6767d2c46229bf9510c/websockets-16.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e047dc87ef7ca50f4d309bf775ad4a71711c58556d75d7bd0604b2317f43e94b", size = 177272, upload-time = "2026-07-17T22:49:15.453Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e3/fe2d498c64dea0095c9a9f9a351af4cd6eef31b618395582bc1f38ba45ff/websockets-16.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:01fbdcbac298efe19360b94bc0039c8f746f0220ba570f327577bfee81059175", size = 177542, upload-time = "2026-07-17T22:49:16.875Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ed/f1831681fce0e3242346e5458486003c5f124ed69e5e0b847fd029db4973/websockets-16.1.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0f62863e8a00a6d33c3d6566ec0b89f23787b747ffe0c3bc71ec0e76b82c94b1", size = 187137, upload-time = "2026-07-17T22:49:18.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/79/4ff9dcc1bb46f6b4c536936dde1fd60f9b564f3304307274db97f4c9496d/websockets-16.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8087e82f842609734c9b5a1330464f8e94e346ba0e18c832c08bafa4b0d63c15", size = 188374, upload-time = "2026-07-17T22:49:19.65Z" },
+    { url = "https://files.pythonhosted.org/packages/62/c3/5c49b6efb36cab733d23773f6de575e1dba65736ead17d5d2b2a1daef779/websockets-16.1.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2bb5d041a8307d2e18782e7ce777f6fdb1e8c2f5d09291484b18c294b789d9aa", size = 191155, upload-time = "2026-07-17T22:49:21.331Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f6/56ccceda3a4838d18f1d40821480da4775397e8b1eecf4031e20c50e2e90/websockets-16.1.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1db4de4a0e95673f7545d393c49eeb0c2f18ac1ef93073218c79d5cdb2ee75ab", size = 189011, upload-time = "2026-07-17T22:49:22.889Z" },
+    { url = "https://files.pythonhosted.org/packages/86/d6/ad5286241a2bce1107e2798d3bfbd62cf79aee167bdb654f8cb1e9dbf949/websockets-16.1.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f17dbe07eb3ea7f99e4df9b7e0efefe80fbf30d37a8cc4d561a0aed310bc8847", size = 187766, upload-time = "2026-07-17T22:49:24.339Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/67/d65c970b7e347fdca69479beb7811c2060529956730a7a4e3ae7c66b0e31/websockets-16.1.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4b57693728576d84ede0a77987ab16881b783d2cd9f1dc180a8fbbc3f79c4428", size = 185173, upload-time = "2026-07-17T22:49:25.743Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/5b/14af3cd4ee69d8ea9baca58f3dc3cfb1ba78332a347fd478cb096549d60e/websockets-16.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2a636ff1e7a5c4edf71ef0e79adae7f25dba93b4fcbe3dc958733477ffeb0eaf", size = 187809, upload-time = "2026-07-17T22:49:27.147Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/11/be301710d70de97e3e7b3586e6d492c9c06d6a61bf1c2202c36cf0c75607/websockets-16.1.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:d6bec75c290fe484a8ba4cacdf838501e17c06ecfbbf31eede81a9e431bd7751", size = 186412, upload-time = "2026-07-17T22:49:28.611Z" },
+    { url = "https://files.pythonhosted.org/packages/db/07/fe1435bf6fe738a3d3b54dbe0c18dabf12cba4d909ac8b58b539ce27c1f4/websockets-16.1.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:54509b8e92fee4453e152b7558ddef37ce9705a044922f2095a6105e3f80c96f", size = 188290, upload-time = "2026-07-17T22:49:29.965Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/0a/81f394aff8efcbb01208c1ced77df0a3c7fcce584a88c7273663697946c2/websockets-16.1.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:f0aa4aad3b1b69ad3fd85a0fd0952ec64331c762bd77ec51cc814170873890b2", size = 185844, upload-time = "2026-07-17T22:49:31.447Z" },
+    { url = "https://files.pythonhosted.org/packages/39/5c/dd485b995473f415510251fe9bd708f2d24458f439fce958daf8d66dc7c6/websockets-16.1.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:42290eb6db4ccaca7012656738214f8514082fb6fa40cdeb61bb9a471b52e383", size = 186823, upload-time = "2026-07-17T22:49:33.104Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/0b/f78de76ff446f1e66af12b43c48a35f31744de93cfdec2f4ea67d5d7bbf1/websockets-16.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:53260c8930da5771cec89439bff99c20c8cb03ddb9588b980697355a83cd4bd3", size = 187102, upload-time = "2026-07-17T22:49:34.616Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a1/4cf892007778eaf84ad162bfc98046e0ed89b63ac55949e3236626b2a23f/websockets-16.1.1-cp312-cp312-win32.whl", hash = "sha256:1d27fa8462ad6a1cb36206a3d0640b2333340def181fae11ed7f9adeaa5c0747", size = 179943, upload-time = "2026-07-17T22:49:36.213Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/de/6abe251d28c3a3f217096575400b27750b18e0b1d2fff3a2a239960fea07/websockets-16.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:b436f6ec4fc3a6b4237c84d3f83170ed2b40bb584222f0ac47a0c8a5921980c7", size = 180243, upload-time = "2026-07-17T22:49:37.626Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ed/71fea6e141590cafc40b14dc5943b0845606bee87bdb52a21b6a73eb4311/websockets-16.1.1-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:820fb8450edddae3812fd58cbc08e2bf22812cb248ecb5f06dbb82119a56e869", size = 177185, upload-time = "2026-07-17T22:50:56.665Z" },
+    { url = "https://files.pythonhosted.org/packages/01/ec/00e7eeca200facf9266a83e4cbbf1bed0e67fba1d4d45031d3e5b3d81b5c/websockets-16.1.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:125f22dbefaf1554fea66fc83851490edb284ce4f501d37ffed2752f418332d9", size = 177459, upload-time = "2026-07-17T22:50:58.197Z" },
+    { url = "https://files.pythonhosted.org/packages/75/fd/5774c4b33f7c0d8f0c51809c8b3a93456c48e3543579262cfa64eb5f522e/websockets-16.1.1-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:30bbe120437b5648a77d3519b7024ea09530e0b5b18d3698c5a0ae536fe0cc2e", size = 178294, upload-time = "2026-07-17T22:50:59.641Z" },
+    { url = "https://files.pythonhosted.org/packages/37/c3/48e2c03d2bd79bb45948841c592d24156312dd5f58cdf8f549febe652fb6/websockets-16.1.1-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b6b9dadbef0cccd9f4c4ee96b08898afa73e26803bbe0f6aeb5bb12b0074206d", size = 179190, upload-time = "2026-07-17T22:51:01.129Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/3f/73e511ecf2496ceac57dd4ed8388efe2bcf0769338a2dbf242c8366ae87e/websockets-16.1.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56cd5fc4f10a9ea8aa0804bddb7b42506cf9e136046f3b4c27de8fec9e2ecba5", size = 180330, upload-time = "2026-07-17T22:51:02.603Z" },
+    { url = "https://files.pythonhosted.org/packages/be/4d/2d0d67834092e354d2b0498f014a41249a89556bc406cf86f3e1557bb463/websockets-16.1.1-py3-none-any.whl", hash = "sha256:6abbd3e82c731c8e531714466acd5d87b5e88ac3243465337ba71d68e23ae7e3", size = 173814, upload-time = "2026-07-17T22:51:04.184Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Reference generation was OpenAI-only and hardcoded, so an account with no image credit stops the pipeline at ingest with nothing to fall back on. Gemini is also **54% cheaper** per reference — measured, not estimated: \$0.03901 vs \$0.08435 on the same object.

## Choosing a backend

```bash
LR_IMAGE_PROVIDER=gemini uv run litereality stage ingest <scene>      # pin for a run
uv run litereality stage ingest <scene> --image-model gemini-2.5-flash-image   # infer from model
```

Needs `GEMINI_API_KEY` ([aistudio.google.com/apikey](https://aistudio.google.com/apikey)). Default is unchanged: OpenAI.

## What changed

`generate_reference` is now a dispatcher over `_call_openai` / `_call_gemini`. The retry ladder, out-of-credit detection, telemetry, cost logging and black-background normalisation stay shared, so nothing downstream can tell which backend produced a reference. The only renamed artifact is the response sidecar, now `<provider>_response_N.json`.

Details the shared paths needed:

- **Rate limits.** google-genai reports throttling as `RESOURCE_EXHAUSTED` on `.code`, which neither OpenAI 429 test caught — a throttled Gemini call would have skipped the 20s backoff ladder and burned all three attempts immediately.
- **Out-of-credit.** That branch is OpenAI-specific and now only runs for OpenAI, so a Gemini failure can't be mistranslated into OpenAI billing advice.
- **Response shape.** Gemini returns the render as an `inline_data` part among commentary parts, so the image is searched for rather than read off a fixed index. No image part at all (usually a safety block) raises and is retried.
- **AFC warning.** We pass no tools, and leaving automatic function calling on makes the SDK warn once per call — one line of noise per object.

## Drive-by fix

`generate_reference` accepted `model=` and then ignored it, reading `$LR_OPENAI_IMAGE_MODEL` only — so `--image-model` never did anything. It now falls back to the passed model when the env var is unset. The env var still wins, so existing runs are unaffected.

## Verification — live API, two objects

| object | result |
|---|---|
| Meeting Room `Table0` (light oak) | **good** — correct panel-end base, both cable grommets, well exposed, no chairs |
| Panda-2 `Table0` (near-black) | **poor** — see below |

Also: provider resolution across every env/model combination; missing key fails with `Gemini image generation needs $GEMINI_API_KEY.`; the refactored OpenAI path reproduces Panda-2's `Table0` at the same \$0.08435 and log format; `uv sync --all-groups --locked`, `ruff check .`, `pytest -n auto` → 539 passed, 2 skipped.

## Known quality gap on dark objects

On Panda-2's near-black table Gemini produced a materially worse reference than OpenAI:

- **Underexposed** — mean pixel 4.3 vs OpenAI's 10.2, nearly invisible against the mandated pure-black background
- **Kept the tablet** on the tabletop, though the prompt says to remove everything resting on it
- **Wrong support structure** — flat panel ends instead of the real black trapezoidal loop legs

`normalize_reference`'s black-key crop still coped (84%-wide bbox), so nothing downstream breaks — the reference is just a poorer likeness. The dark-object-on-black-background combination looks like the trigger. Reasonable to merge as an opt-in alternative and keep OpenAI as the default, which is what this PR does.