### PR TITLE
Check what holds every object up, so nothing floats

### DIFF
--- a/doc/QC/support_check.md
+++ b/doc/QC/support_check.md
@@ -1,0 +1,84 @@
+# Support check
+
+Nothing floats. In an indoor environment every object rests on something, so once the room is built
+each object has to be traced back to what holds it up.
+
+There are only four ways an object can be supported:
+
+1. **On the floor.** Standing on the ground.
+2. **Wall hanging.** Mounted on a wall.
+3. **On top of another object.** Sitting on a table, a shelf, a counter.
+4. **Ceiling hanging.** Hung from the roof.
+
+Rules:
+
+- Every object has exactly one of these four supports.
+- It touches its support — no gap, no floating.
+- It is not embedded into its support either. It sits on it, not inside it.
+- What holds it up must itself be supported, so everything traces back to the floor, a wall, or the
+  ceiling.
+
+
+We can also build a scene graph from the room.
+
+# The deterministic function
+
+For each object, cast rays straight down from its bottom face and see what they hit first.
+
+- hits the floor at zero gap → on the floor
+- hits another object at zero gap → on top of that object
+- hits nothing, or the gap is too big → floating
+- the hit is above the bottom face → embedded
+
+Wall hanging is the same test with the rays going backwards into the wall, ceiling hanging with the
+rays going up.
+
+The first hit *is* the supporter, so the scene graph falls out of the same pass — one edge per
+object, child → supporter. Then it is just a graph check: no cycles, and every chain ends at the
+floor, a wall, or the ceiling.
+
+Rays, not bounding boxes. An object's box top is not its support surface — a table's box top is the
+tabletop, fine, but a chair's box top is the backrest, and nothing rests on a backrest. Rays hit the
+real surface.
+
+Two numbers to set: how big a gap still counts as touching, and how much penetration still counts as
+sitting on rather than embedded. Both around a centimetre.
+
+Walls need a third, looser one. A bracket or a batten legitimately holds something a few
+centimetres off the wall — on Elliott-Studio a wall-hung TV and a wall cabinet both stand 6 cm
+proud, and at the resting tolerance they read as floating in mid-air. Loosening it is safe because
+the downward test runs first, so nothing standing on the floor can be captured by it.
+
+One more thing the same rays give us for free: the object should not just touch its support, it
+should be **stable on** it. Take the points where the rays land and check the object's centre sits
+inside them. That catches the mug placed half off the edge of the table.
+
+# The scene graph
+
+Whatever the rays hit is the parent, so the graph comes out of the same pass:
+
+```
+Floor
+├── Table0
+│   ├── Book0
+│   └── Cup0
+└── Sofa0
+Wall0
+└── Shelf0
+    └── Mug0
+Ceiling
+└── Lamp0
+```
+
+The shelf is the case that makes this worth having. The shelf hangs on the wall, the mug sits on
+the shelf, so the mug's chain is `Mug0 → Shelf0 → Wall0`. Nothing in that chain ever touches the
+floor and it is still correct — which is why the rule is "the chain ends at the floor, a wall or
+the ceiling", not "the object is above the floor".
+
+Two things fall out of having the graph:
+
+- Objects can rest on **more than one** thing — a plank across two boxes, a tray bridging two shelf
+  levels. Keep all of them, or the stability test looks at half the contact patch and calls a
+  perfectly steady plank unstable.
+- **Resting on something is touching it**, so the collision check would call a book on a shelf a
+  clash. Every edge in this graph is contact we expect. The graph is the allow-list.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,10 @@ dependencies = [
     # Convex pieces are closed, so the distance is real. Without this the code still runs and falls
     # back to the AABB estimate, which is the old (worse) behaviour rather than a crash.
     "coacd",
+    # QC support check. trimesh's ray caster needs an r-tree for its broad phase, and the support
+    # check is all ray casts — without this `room_qc.support` raises on the first object instead of
+    # reporting. Small pure wheel on every platform we support, no compiler.
+    "rtree>=1.4.1",
     # viewer (later)
     "fastapi>=0.111.0",
     "uvicorn>=0.30.0",

--- a/src/litereality_agent/agent/tools/check_collisions/source/support.py
+++ b/src/litereality_agent/agent/tools/check_collisions/source/support.py
@@ -1,0 +1,390 @@
+"""support.py — nothing floats: what holds every object up, from the real meshes in `Room.glb`.
+
+The collision check asks whether two things occupy the same volume. This asks the opposite question:
+does every object *touch* the thing that holds it up. In an indoor scene there are only four
+answers — the floor, a wall, the top of another object, or the ceiling — and an object that matches
+none of them is floating in mid-air.
+
+The support relation is DERIVED, never declared, so the scene graph falls out of the same pass: the
+surface an object rests on IS its parent. That makes the last rule ("everything traces back to the
+floor, a wall or the ceiling") a plain graph check rather than a separate piece of geometry.
+
+WHY RAYS, NOT BOXES. An object's bounding-box top is not its support surface. A table's box top is
+the tabletop, which is fine — but a chair's box top is the BACKREST, and nothing rests on a
+backrest. Casting rays at the real triangles is what tells the two apart. The rays start from the
+object's own extreme vertices rather than a grid over its footprint: a grid sends most of its rays
+through the empty air between a chair's legs, whereas the extreme vertices ARE the four feet.
+
+WHICH FACE PROBES WHICH SUPPORT. The bottom face only answers the DOWNWARD question. A picture on a
+wall has nothing at all beneath it, and a pendant lamp's lowest vertex is its bulb — for those the
+contact patch is the back face and the top face respectively. So each hypothesis probes the face
+that points at its own candidate support:
+
+    floor / on another object   bottom face, rays cast down       (which body is hit decides the parent)
+    wall hanging                back face  vs the wall plane      (planes — no rays needed)
+    ceiling hanging             top face   vs the ceiling plane
+
+Walls and the ceiling are planes we already know from the SHELL, so those two are exact arithmetic
+and cost nothing. Only the downward case needs rays, because only there is the identity of the
+supporting body in question.
+
+Everything is computed in the `Room.glb` frame, which is Y-up: height is y, the plan is (x, z), and
+a SHELL point maps in as SHELL(x, y) -> glb(x, -y).
+
+Consumes the same `bodies` dict as `collision_mesh.build_bodies`, so the two checks share one
+decomposition of the room and cannot disagree about what an object is.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .geometry import _expected
+
+UP = np.array([0.0, 1.0, 0.0])   # Room.glb is Y-up
+DOWN = -UP
+
+# metres
+GAP = 0.015        # a surface this close to the contact face counts as touching
+EMBED = 0.015      # deeper than this into the support is embedded, not resting on
+# Wall mounts get their own, much looser tolerance: a bracket, batten or backplate legitimately
+# holds a thing off the wall. Measured on Elliott-Studio, a wall-hung TV and a wall cabinet both
+# stand 6 cm proud, and at GAP they were both reported as floating in mid-air. Loosening this
+# cannot swallow floor-standing furniture, because the DOWNWARD test runs first and wins.
+WALL_GAP = 0.10
+# Vertices within this of the extreme are the contact face. Not razor-thin on purpose: a mesh whose
+# base is a millimetre out of level would otherwise offer a hairline strip of feet. Widening is
+# safe — a candidate that turns out not to reach its support is dropped by its ray gap anyway.
+FACE_BAND = 0.02
+BACK_OFF = 0.10    # rays start this far back along the face normal, so an embedded face still
+                   # sees the surface it is buried in (deeper than this is a placement error,
+                   # not an embedding, and gets reported as such)
+MAX_ORIGINS = 32   # rays per object — the feet of a chair are 4 points; 32 is generous
+SPAN_TOL = 0.05    # fraction-free slack for "does this object lie along that wall's span"
+
+
+# ---------------------------------------------------------------------------------------------
+# contact faces and rays
+# ---------------------------------------------------------------------------------------------
+
+def _contact_face(mesh, direction, band: float = FACE_BAND, cap: int = MAX_ORIGINS):
+    """The vertices on the mesh's extreme face along `direction` — its contact patch that way.
+
+    `direction` is where the support is expected to be: DOWN gives the feet, UP the top, a wall's
+    outward normal the back face. Downsampled evenly (and deterministically — same glb in, same
+    rays out) so a 50k-triangle sofa costs the same as a stool.
+    """
+    V = np.asarray(mesh.vertices, dtype=float)
+    if len(V) == 0:
+        return V
+    d = np.asarray(direction, dtype=float)
+    proj = V @ d
+    keep = V[proj >= proj.max() - band]
+    if len(keep) > cap:
+        order = np.lexsort((keep[:, 2], keep[:, 1], keep[:, 0]))
+        keep = keep[order][np.linspace(0, len(keep) - 1, cap).astype(int)]
+    return keep
+
+
+def _first_hits(origins, direction, targets: dict):
+    """Cast one ray per origin and keep, PER RAY, the nearest surface across all targets.
+
+    Nearest per ray is the point: a laptop on a table in a room hits both the tabletop (0 m) and the
+    floor (0.75 m), and only the first one is holding it up. Rays start BACK_OFF behind the face so
+    a face already buried in its support still sees that surface ahead of it — which is what makes
+    the gap signed: positive = a gap (floating), ~0 = touching, negative = embedded.
+
+    Returns (gap per ray, parent name per ray, hit point per ray); gap is +inf where nothing was hit.
+    """
+    n = len(origins)
+    gaps = np.full(n, np.inf)
+    parent: list[str | None] = [None] * n
+    points = np.zeros((n, 3))
+    if n == 0:
+        return gaps, parent, points
+
+    d = np.asarray(direction, dtype=float)
+    start = origins - d * BACK_OFF
+    dirs = np.tile(d, (n, 1))
+    for name, mesh in targets.items():
+        if mesh is None or len(mesh.faces) == 0:
+            continue
+        loc, idx_ray, _ = mesh.ray.intersects_location(start, dirs, multiple_hits=False)
+        if len(loc) == 0:
+            continue
+        t = (loc - start[idx_ray]) @ d - BACK_OFF   # distance from the ORIGINAL face, signed
+        for k, r in enumerate(idx_ray):
+            if t[k] < gaps[r]:
+                gaps[r], parent[r], points[r] = t[k], name, loc[k]
+    return gaps, parent, points
+
+
+def _plan_overlaps(a, b, slack: float = GAP) -> bool:
+    """Do two meshes' footprints overlap in plan (glb x/z)? Cheap prefilter before any ray work."""
+    amin, amax = a.bounds
+    bmin, bmax = b.bounds
+    return (amin[0] - slack <= bmax[0] and bmin[0] - slack <= amax[0]
+            and amin[2] - slack <= bmax[2] and bmin[2] - slack <= amax[2])
+
+
+# ---------------------------------------------------------------------------------------------
+# wall / ceiling planes (no rays — we know these surfaces exactly from the SHELL)
+# ---------------------------------------------------------------------------------------------
+
+def _wall_planes(shell: dict):
+    """SHELL walls as glb-plan planes: (wall_id, origin, inward normal, along unit, length)."""
+    walls = shell.get("walls") or {}
+    pts = [(p[0], -p[1]) for w in walls.values() for p in (w.get("start"), w.get("end")) if p]
+    if not pts:
+        return []
+    fcx = sum(p[0] for p in pts) / len(pts)
+    fcz = sum(p[1] for p in pts) / len(pts)
+    out = []
+    for wid, w in walls.items():
+        s, e = w.get("start"), w.get("end")
+        if not s or not e:
+            continue
+        sx, sz, ex, ez = s[0], -s[1], e[0], -e[1]
+        dx, dz = ex - sx, ez - sz
+        L = float(np.hypot(dx, dz))
+        if L < 1e-6:
+            continue
+        ux, uz = dx / L, dz / L
+        nx, nz = -uz, ux
+        if (fcx - sx) * nx + (fcz - sz) * nz < 0:     # orient toward the room interior
+            nx, nz = -nx, -nz
+        out.append((wid, (sx, sz), (nx, nz), (ux, uz), L))
+    return out
+
+
+def _wall_support(mesh, planes):
+    """The wall this object is mounted on, or None.
+
+    Mounted means its BACK face sits on the wall plane: project every vertex onto the inward normal
+    and take the minimum — that IS the back face, whatever the object's shape — then require it to
+    be within touching distance of the plane, and the object to lie along the wall's span.
+    """
+    V = np.asarray(mesh.vertices, dtype=float)
+    best = None
+    for wid, (sx, sz), (nx, nz), (ux, uz), L in planes:
+        rx, rz = V[:, 0] - sx, V[:, 2] - sz
+        d = rx * nx + rz * nz                      # >0 interior, so the back face is the minimum
+        t = (rx * ux + rz * uz) / L
+        if not ((t >= -SPAN_TOL) & (t <= 1 + SPAN_TOL)).any():
+            continue                               # object does not lie along this wall
+        gap = float(d.min())
+        if -EMBED <= gap <= WALL_GAP and (best is None or abs(gap) < abs(best[1])):
+            best = (wid, gap)
+    return best
+
+
+# ---------------------------------------------------------------------------------------------
+# stability
+# ---------------------------------------------------------------------------------------------
+
+def _hull2d(pts):
+    """Convex hull of plan points (monotone chain). Hand-rolled to keep scipy out of the deps."""
+    P = sorted({(round(float(x), 6), round(float(z), 6)) for x, z in pts})
+    if len(P) < 3:
+        return P
+
+    def cross(o, a, b):
+        return (a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0])
+
+    def half(seq):
+        h = []
+        for p in seq:
+            while len(h) >= 2 and cross(h[-2], h[-1], p) <= 0:
+                h.pop()
+            h.append(p)
+        return h
+
+    return half(P)[:-1] + half(P[::-1])[:-1]
+
+
+def _inside(hull, p, tol: float = 1e-9) -> bool:
+    """Is a plan point inside the convex support polygon? Degenerate hulls (a line, a single
+    contact point) are never 'inside' — an object balanced on one point is exactly the unstable
+    case this is here to catch."""
+    if len(hull) < 3:
+        return False
+    sign = 0
+    for i in range(len(hull)):
+        a, b = hull[i], hull[(i + 1) % len(hull)]
+        c = (b[0] - a[0]) * (p[1] - a[1]) - (b[1] - a[1]) * (p[0] - a[0])
+        if abs(c) <= tol:
+            continue
+        s = 1 if c > 0 else -1
+        if sign and s != sign:
+            return False
+        sign = s
+    return True
+
+
+# ---------------------------------------------------------------------------------------------
+# the check
+# ---------------------------------------------------------------------------------------------
+
+def find_supports(bodies: dict, shell: dict) -> dict:
+    """What holds every object up → (scene graph, findings).
+
+    Hypotheses are tried in the order they win ties in the real world: something standing ON the
+    floor is floor-supported even though its back also touches a wall, so DOWN is tested first, then
+    the wall, then the ceiling. An object that matches none of them is floating.
+
+    Returns {'supports': {id: {...}}, 'graph': {child: parent}, 'findings': [...]}.
+    """
+    furniture = bodies.get("furniture") or {}
+    floor = bodies.get("floor")
+    planes = _wall_planes(shell)
+    ceil_y = shell.get("ceiling_z")
+
+    supports: dict[str, dict] = {}
+    graph: dict[str, str] = {}
+    findings: list[dict] = []
+    embedded: list[tuple] = []   # (object, what it is buried in, depth) — resolved after the loop
+
+    for oid, mesh in furniture.items():
+        # --- 1. downward: the floor, or the top of another object -----------------------------
+        feet = _contact_face(mesh, DOWN)
+        face_y = float(feet[:, 1].min()) if len(feet) else float(mesh.bounds[0][1])
+        targets = {}
+        if floor is not None and _plan_overlaps(mesh, floor):
+            targets["Floor"] = floor
+        for other, om in furniture.items():
+            # only bodies with geometry in the band the rays actually travel through
+            if (other != oid and _plan_overlaps(mesh, om)
+                    and om.bounds[1][1] >= face_y - GAP and om.bounds[0][1] <= face_y + BACK_OFF):
+                targets[other] = om
+        gaps, parent, points = _first_hits(feet, DOWN, targets)
+
+        touching = [i for i, g in enumerate(gaps) if -EMBED <= g <= GAP]
+        buried = [i for i, g in enumerate(gaps) if g < -EMBED]
+        contact = touching + buried
+        if contact:
+            # An object may rest on SEVERAL bodies at once — a plank across two boxes, a tray
+            # bridging two shelf levels. Taking only the body most rays hit and discarding the rest
+            # would both name the wrong parent on a near-tie and, worse, judge stability against
+            # half the contact patch: a plank supported at both ends has its centre in the gap
+            # BETWEEN the two patches, and would read as balanced on nothing.
+            names = [parent[i] for i in contact]
+            per = {n: [i for i in contact if parent[i] == n] for n in set(names)}
+            who = max(per, key=lambda n: (len(per[n]), -min(abs(gaps[i]) for i in per[n])))
+            also = sorted(n for n in per if n != who)
+            gap = float(min(gaps[i] for i in per[who]))
+            supports[oid] = {"kind": "floor" if who == "Floor" else "on_object",
+                             "parent": who, "gap_m": round(gap, 4), "also_on": also}
+            graph[oid] = who
+
+            for n, idx in per.items():
+                deep = float(min(gaps[i] for i in idx))
+                if deep < -EMBED:
+                    embedded.append((oid, n, -deep))
+            # Stability: the centre must fall inside everything it touches, taken together. Buried
+            # rays count as contact here — a face sunk into its support is still HELD UP by it, and
+            # its burial is already a finding of its own. Judging stability on the unburied rays
+            # alone turns one defect into two: a built-in fridge whose base is partly over its
+            # cabinet plinth would be called both embedded AND balanced on the strip beside it.
+            if contact:
+                hull = _hull2d([(points[i][0], points[i][2]) for i in contact])
+                c = mesh.centroid
+                if not _inside(hull, (c[0], c[2])):
+                    on = " + ".join([who, *also])
+                    findings.append({"id": oid, "kind": "unstable", "parent": who,
+                                     "detail": f"centre falls outside the patch it rests on ({on})"})
+            continue
+
+        # --- 2. wall hanging: the BACK face against a wall plane ------------------------------
+        # Deliberately not the bottom face — a picture on a wall has nothing at all beneath it.
+        hit = _wall_support(mesh, planes)
+        if hit:
+            wid, gap = hit
+            supports[oid] = {"kind": "wall", "parent": wid, "gap_m": round(gap, 4)}
+            graph[oid] = wid
+            if gap < -EMBED:
+                embedded.append((oid, wid, -gap))
+            continue
+
+        # --- 3. ceiling hanging: the TOP face against the ceiling plane -----------------------
+        if ceil_y is not None:
+            gap = float(ceil_y) - float(mesh.bounds[1][1])
+            if -EMBED <= gap <= GAP:
+                supports[oid] = {"kind": "ceiling", "parent": "Ceiling", "gap_m": round(gap, 4)}
+                graph[oid] = "Ceiling"
+                continue
+
+        # --- 4. nothing holds it up -----------------------------------------------------------
+        floor_y = shell.get("floor_z")
+        how_high = f"{face_y - float(floor_y):.2f} m above the floor" if floor_y is not None else "no support found"
+        supports[oid] = {"kind": "floating", "parent": None, "gap_m": None}
+        findings.append({"id": oid, "kind": "floating",
+                         "detail": f"nothing under, behind or over it — {how_high}"})
+
+    findings.extend(_embedded_findings(embedded, shell))
+    findings.extend(_graph_issues(graph, set(furniture)))
+    return {"supports": supports, "graph": graph, "findings": findings}
+
+
+def _embedded_findings(embedded: list, shell: dict) -> list[dict]:
+    """Turn raw burial measurements into findings — once per pair, and only where it is a defect.
+
+    Two things have to be filtered out, both seen on the first real room this ran against:
+
+    * A pair buried in each other is reported from BOTH sides (each one's contact face finds the
+      other's geometry above it). It is one defect, so keep the deeper measurement and drop the
+      mirror image.
+    * Some burial is CORRECT. A built-in fridge sits inside its cabinet run, an undermount sink
+      inside its counter — the same containment the clash check already allows by category, so it
+      is allowed here from the same table rather than a second opinion that contradicts it.
+    """
+    cats = {i: (o.get("category") or "") for i, o in (shell.get("objects") or {}).items()}
+    deepest: dict[frozenset, tuple] = {}
+    for oid, host, depth in embedded:
+        if _expected(cats.get(oid, ""), cats.get(host, "")):
+            continue
+        key = frozenset((oid, host))
+        if key not in deepest or depth > deepest[key][2]:
+            deepest[key] = (oid, host, depth)
+    return [{"id": oid, "kind": "embedded", "parent": host,
+             "detail": f"{depth:.3f} m into {host} — it should sit on it, not inside it"}
+            for oid, host, depth in sorted(deepest.values(), key=lambda e: -e[2])]
+
+
+def support_pairs(graph: dict, objects: set) -> set:
+    """Support edges as unordered object pairs — the contacts the CLASH check should expect.
+
+    Resting on something IS touching it, and FCL counts touching as contact, so a book on a shelf
+    and a lamp on a table are reported as `object_clash` by `collision_mesh` today. The support
+    graph answers that generically: if B holds A up, their contact is not a clash. That is the same
+    job the hand-written `EXPECTED_CONTAINMENT` category table does for a chair under a table or a
+    sink in its counter, except derived from the geometry instead of enumerated by category — so it
+    covers pairs nobody thought to list.
+    """
+    return {frozenset((c, p)) for c, p in graph.items() if p in objects}
+
+
+ROOTS = ("Floor", "Ceiling")
+
+
+def _graph_issues(graph: dict, objects: set) -> list[dict]:
+    """The last rule as a graph check: every chain ends at the floor, a wall or the ceiling.
+
+    A parent outside `objects` is structure (Floor / Ceiling / a wall id) and terminates the chain.
+    Anything else must climb to one, so the only two failures are a cycle (two objects resting on
+    each other) and a chain that runs off into something with no support of its own.
+    """
+    out = []
+    for oid in graph:
+        seen, cur = [], oid
+        while cur in graph:
+            if cur in seen:
+                out.append({"id": oid, "kind": "support_cycle",
+                            "detail": "support chain loops: " + " → ".join(seen + [cur])})
+                break
+            seen.append(cur)
+            cur = graph[cur]
+        else:
+            if cur in objects or not (cur.startswith(ROOTS) or cur.startswith("Wall")):
+                out.append({"id": oid, "kind": "unsupported_chain",
+                            "detail": f"chain ends at {cur}, which nothing holds up"})
+    return out

--- a/src/litereality_agent/pipeline/room_qc/__init__.py
+++ b/src/litereality_agent/pipeline/room_qc/__init__.py
@@ -10,6 +10,8 @@ DETECT — read only, never edits a room:
 
     collision.py  the gate: one glb in, findings + an exit code out
     checks.py     the box report over room_layout.json + SHELL (no compile needed)
+    support.py    what holds every object up — nothing floats. Report only: a floating object is a
+                  MISSING SUPPORT, not a misplaced one, so there is nothing safe to auto-fix.
 
 REPAIR — the only things here that write `Room.py`:
 

--- a/src/litereality_agent/pipeline/room_qc/support.py
+++ b/src/litereality_agent/pipeline/room_qc/support.py
@@ -1,0 +1,85 @@
+"""support.py — DETERMINISTIC support check for a built room. No model.
+
+Nothing floats. Every object rests on the floor, hangs on a wall, sits on top of another object, or
+hangs from the ceiling — and this reports the ones that do none of those, plus the ones that sink
+into their support instead of resting on it, and the ones balanced off the edge of it.
+
+Report only: unlike `fix.py` / `correct.py` there is no auto-repair here. A floating object is
+almost never a placement that needs nudging down — it is a MISSING SUPPORT (the shelf it belongs on
+was never built), and silently dropping it to the floor would hide the real defect. So this prints
+what is wrong and leaves the repair to the authoring pass.
+
+Needs a compiled `Room.glb`, and it must be NEWER than `Room.py`: `correct.py` moves objects after
+the build, so a stale glb describes a room that no longer exists. Run this after the final compile.
+
+    python -m litereality_agent.pipeline.room_qc.support --room <room dir>
+    python -m litereality_agent.pipeline.room_qc.support --room <room dir> --graph
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+from pathlib import Path
+
+from litereality_agent.agent.tools.check_collisions.source import collision_mesh as sc
+from litereality_agent.agent.tools.check_collisions.source import support as sp
+from litereality_agent.agent.tools.check_collisions.source.geometry import _extract_shell
+
+
+def _find_glb(room_dir: Path) -> Path | None:
+    """Newest Room.glb at or beside the room dir — same discovery the other QC modules use."""
+    cands = sorted(glob.glob(str(room_dir.parent) + "/**/Room.glb", recursive=True),
+                   key=lambda p: Path(p).stat().st_mtime, reverse=True)
+    return Path(cands[0]) if cands else None
+
+
+def check(room_dir=None, shell_path=None) -> dict:
+    room_dir = Path(room_dir) if room_dir else None
+    shell_path = Path(shell_path or (room_dir / "Room.py"))
+    SHELL = _extract_shell(shell_path.read_text())
+
+    glb = _find_glb(room_dir) if room_dir else None
+    if glb is None:
+        return {"error": "no compiled Room.glb found — build the room first",
+                "supports": {}, "graph": {}, "findings": []}
+
+    bodies = sc.build_bodies(glb, SHELL)
+    out = sp.find_supports(bodies, SHELL)
+    out["source"] = glb.name
+    out["stale"] = shell_path.stat().st_mtime > glb.stat().st_mtime
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--room", help="room dir containing Room.py (and a compiled Room.glb nearby)")
+    ap.add_argument("--shell", help="Room.py path (overrides --room's Room.py)")
+    ap.add_argument("--graph", action="store_true", help="also print the support scene graph")
+    a = ap.parse_args()
+    if not (a.room or a.shell):
+        ap.error("need --room or --shell")
+    r = check(a.room, a.shell)
+
+    if r.get("error"):
+        print(f"SUPPORT CHECK: {r['error']}")
+        return 0
+
+    findings, supports = r["findings"], r["supports"]
+    print(f"SUPPORT CHECK {r['source']}")
+    print(f"  objects: {len(supports)}   issues: {len(findings)}")
+    if r.get("stale"):
+        print("  ! Room.glb is older than Room.py — recompile for accurate results")
+    if a.graph:
+        for oid, s in sorted(supports.items()):
+            arrow = f"→ {s['parent']}" if s["parent"] else "→ (nothing)"
+            print(f"  {oid:16} {s['kind']:10} {arrow}")
+    for f in findings:
+        print(f"  ✗ {f['id']:16} {f['kind']:18} {f['detail']}")
+    if not findings:
+        print("  ✓ clean — everything rests on something")
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -1,0 +1,146 @@
+"""support — nothing floats: every object traces back to the floor, a wall or the ceiling.
+
+Offline and synthetic: boxes assembled by hand into the cases that actually matter, so the test
+needs no capture, no Blender and no compiled Room.glb.
+
+  Table0 on the floor, Book0 on the table            the ordinary chain
+  Shelf0 on a wall, Mug0 on the shelf                the case the bottom face CANNOT answer —
+                                                     a wall-hung shelf has nothing beneath it, and
+                                                     the chain still has to reach the wall
+  Plank0 across two boxes                            multi-support: its centre is in the GAP between
+                                                     the two contact patches and must read stable
+  Cup0 half off the table edge                       resting, but unstable
+  Bowl0 sunk into the tabletop                       embedded, not resting on
+  Lamp0 in mid-air                                   floating
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+# trimesh (and the r-tree its ray caster needs) are core dependencies — the support check IS ray
+# casts, so a missing one must FAIL these tests rather than skip them. A skipped support gate is an
+# invisible one, exactly as in test_check_collisions.
+import trimesh
+
+from litereality_agent.agent.tools.check_collisions.source import support as sp
+
+# A 4 m x 3 m room. SHELL plan (x, y) maps into the glb as (x, -y), so the room's glb footprint is
+# x in [0, 4], z in [-3, 0]; height is glb y.
+SHELL = {
+    "floor_z": 0.0,
+    "ceiling_z": 2.6,
+    "walls": {
+        "Wall0": {"start": [0, 0], "end": [4, 0], "thickness": 0.1},
+        "Wall1": {"start": [4, 0], "end": [4, 3], "thickness": 0.1},
+        "Wall2": {"start": [4, 3], "end": [0, 3], "thickness": 0.1},
+        "Wall3": {"start": [0, 3], "end": [0, 0], "thickness": 0.1},
+    },
+}
+
+
+def _box(x0, x1, y0, y1, z0, z1):
+    """Axis-aligned box from its glb bounds (y is height)."""
+    return trimesh.creation.box(
+        extents=(x1 - x0, y1 - y0, z1 - z0),
+        transform=trimesh.transformations.translation_matrix(
+            ((x0 + x1) / 2, (y0 + y1) / 2, (z0 + z1) / 2)),
+    )
+
+
+@pytest.fixture(scope="module")
+def result():
+    bodies = {
+        "floor": _box(0, 4, -0.05, 0.0, -3, 0),
+        "structure": None,
+        "leaves": {},
+        "furniture": {
+            "Table0": _box(0.5, 1.5, 0.0, 0.75, -1.5, -0.5),      # on the floor
+            "Book0": _box(0.9, 1.1, 0.75, 0.80, -1.1, -0.9),      # on the table
+            "Bowl0": _box(0.6, 0.8, 0.70, 0.85, -1.4, -1.2),      # sunk 0.05 m into the tabletop
+            "Cup0": _box(1.45, 1.65, 0.75, 0.85, -1.1, -0.9),     # half off the table edge
+            "Shelf0": _box(0.5, 1.5, 1.20, 1.25, -0.3, 0.0),      # hung on Wall0 (glb z = 0)
+            "Mug0": _box(0.9, 1.1, 1.25, 1.35, -0.2, -0.1),       # on the wall-hung shelf
+            "BoxA": _box(2.0, 2.3, 0.0, 0.5, -0.5, -0.2),
+            "BoxB": _box(3.2, 3.5, 0.0, 0.5, -0.5, -0.2),
+            "Plank0": _box(2.05, 3.45, 0.50, 0.55, -0.45, -0.25),  # spans BoxA and BoxB
+            "Lamp0": _box(2.9, 3.1, 0.90, 1.10, -2.1, -1.9),      # mid-air
+        },
+    }
+    return sp.find_supports(bodies, SHELL)
+
+
+def _kinds(result, oid):
+    return {f["kind"] for f in result["findings"] if f["id"] == oid}
+
+
+def test_floor_and_stacking_chain(result):
+    """The ordinary case: a table on the floor, a book on the table."""
+    assert result["supports"]["Table0"]["kind"] == "floor"
+    assert result["supports"]["Book0"] == {"kind": "on_object", "parent": "Table0",
+                                           "gap_m": 0.0, "also_on": []}
+    assert result["graph"]["Table0"] == "Floor"
+    assert result["graph"]["Book0"] == "Table0"
+    assert not _kinds(result, "Book0")
+
+
+def test_wall_hung_shelf_is_found_from_its_back_face(result):
+    """The case the bottom face cannot answer — nothing is underneath a wall-hung shelf, so the
+    probe has to come off its BACK face instead, and the chain still has to reach the wall."""
+    assert result["supports"]["Shelf0"]["kind"] == "wall"
+    assert result["supports"]["Shelf0"]["parent"] == "Wall0"
+    assert result["graph"]["Mug0"] == "Shelf0"
+    assert not _kinds(result, "Shelf0")
+    assert not _kinds(result, "Mug0")
+
+
+def test_multi_support_plank_is_stable(result):
+    """A plank across two boxes rests on BOTH. Judging it against one patch would put its centre in
+    mid-air and call it unstable."""
+    s = result["supports"]["Plank0"]
+    assert {s["parent"], *s["also_on"]} == {"BoxA", "BoxB"}
+    assert "unstable" not in _kinds(result, "Plank0")
+
+
+def test_off_the_edge_is_unstable(result):
+    """Touching is not enough — the centre has to be over what it touches."""
+    assert result["supports"]["Cup0"]["parent"] == "Table0"
+    assert "unstable" in _kinds(result, "Cup0")
+
+
+def test_sunk_into_its_support_is_embedded(result):
+    assert "embedded" in _kinds(result, "Bowl0")
+
+
+def test_mid_air_is_floating(result):
+    assert result["supports"]["Lamp0"]["kind"] == "floating"
+    assert "floating" in _kinds(result, "Lamp0")
+
+
+def test_every_chain_reaches_the_structure(result):
+    """No cycles and no dangling chains among the well-formed objects."""
+    bad = {f["id"] for f in result["findings"]
+           if f["kind"] in ("support_cycle", "unsupported_chain")}
+    assert bad == set()
+
+
+def test_support_pairs_are_expected_contact():
+    """Resting IS touching, so the clash check needs these pairs on its allow-list."""
+    graph = {"Book0": "Table0", "Table0": "Floor", "Shelf0": "Wall0"}
+    pairs = sp.support_pairs(graph, {"Book0", "Table0", "Shelf0"})
+    assert pairs == {frozenset(("Book0", "Table0"))}
+
+
+def test_support_cycle_is_reported():
+    """Two objects resting on each other reach nothing — the graph check is what catches it."""
+    issues = sp._graph_issues({"A": "B", "B": "A"}, {"A", "B"})
+    assert {i["kind"] for i in issues} == {"support_cycle"}
+
+
+def test_contact_face_follows_the_probe_direction():
+    """The point of the whole design: which vertices are the contact patch depends on where the
+    support is expected to be, not on the object's lowest z."""
+    m = _box(0, 1, 0, 2, 0, 1)
+    assert np.allclose(sp._contact_face(m, sp.DOWN)[:, 1].max(), 0.0)
+    assert np.allclose(sp._contact_face(m, sp.UP)[:, 1].min(), 2.0)

--- a/uv.lock
+++ b/uv.lock
@@ -380,6 +380,22 @@ wheels = [
 ]
 
 [[package]]
+name = "coacd"
+version = "1.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/7b/f931ae04532bb581ae51732b270f3d31aaebf453941b4850e8aa2d104af6/coacd-1.0.12-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:cf208fe22338e6b44f52e70f4d159a4a101f7c9907438a3786f4814f16e80eeb", size = 3424127, upload-time = "2026-08-13T23:54:01.24Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/8d/473be0e7f95bc0c4d7b8ba341aa567feb9f09a965079bd1d74023bfc5607/coacd-1.0.12-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7d56a1f02cc79ee0406f79aa791afa630daeb86cfb3c0c83ec562fe736016bfd", size = 2584737, upload-time = "2026-08-13T23:54:02.673Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/76/686d2fe66129fb1d634867832ce2a07051edaa1f8856fa2fa85fc8ab70a7/coacd-1.0.12-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1ee175e108351250be8839922e8acb410957583d19d5660b4c4952ed1de947fa", size = 2651576, upload-time = "2026-08-13T23:54:03.909Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/1b/78ad57b0ccef627ac1f8509ee828c5c3d12f752346655d5fd9571cea5904/coacd-1.0.12-cp39-abi3-win_amd64.whl", hash = "sha256:b5140e0e45f50ba95a53ba08dd2e76b50cfc5c225fd890b10a53530ecbe37a3f", size = 1485530, upload-time = "2026-08-13T23:54:05.833Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1276,6 +1292,7 @@ source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
     { name = "claude-agent-sdk" },
+    { name = "coacd" },
     { name = "fastapi" },
     { name = "google-genai" },
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -1291,6 +1308,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "python-fcl" },
     { name = "rich" },
+    { name = "rtree" },
     { name = "tqdm" },
     { name = "trimesh" },
     { name = "uvicorn" },
@@ -1322,6 +1340,7 @@ dev = [
 requires-dist = [
     { name = "anthropic", specifier = ">=0.40.0" },
     { name = "claude-agent-sdk" },
+    { name = "coacd" },
     { name = "fastapi", specifier = ">=0.111.0" },
     { name = "google-genai", specifier = ">=1.0.0" },
     { name = "modal", marker = "extra == 'modal'", specifier = ">=1.3,<2" },
@@ -1335,6 +1354,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.10.0" },
     { name = "python-fcl" },
     { name = "rich", specifier = ">=13.7.0" },
+    { name = "rtree", specifier = ">=1.4.1" },
     { name = "torch", marker = "extra == 'detect'" },
     { name = "torch", marker = "extra == 'gen3d'" },
     { name = "torchvision", marker = "extra == 'detect'" },
@@ -2872,6 +2892,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/97/0043896fdd7828ce09a1d9a8b06433714d0960fc4ff3fc4aa72b666b764e/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:2bfd04c19ddbd6640de0b51894d764bd2758854d5b75bd102d2ef10cb9c293a9", size = 558118, upload-time = "2026-06-30T07:17:47.759Z" },
     { url = "https://files.pythonhosted.org/packages/f6/40/02355f0e134f783a8f9814c4680a1bd311d37671577a5964ea838573ff37/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:ca6546b66be9dc4738b1b043d5ebd5488c66c578c5ff0fd0e8065313fe3afb76", size = 623138, upload-time = "2026-06-30T07:17:49.355Z" },
     { url = "https://files.pythonhosted.org/packages/10/85/48f0abdcef5cce4e034c7a5b0ceeceba0b01bf0d942824f4bb720afe2dec/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:8e65860d238379ed982fd9ba690579b5e95af2f4840f99c772816dbe573cb826", size = 586486, upload-time = "2026-06-30T07:17:51.141Z" },
+]
+
+[[package]]
+name = "rtree"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/09/7302695875a019514de9a5dd17b8320e7a19d6e7bc8f85dcfb79a4ce2da3/rtree-1.4.1.tar.gz", hash = "sha256:c6b1b3550881e57ebe530cc6cffefc87cd9bf49c30b37b894065a9f810875e46", size = 52425, upload-time = "2025-08-13T19:32:01.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/d9/108cd989a4c0954e60b3cdc86fd2826407702b5375f6dfdab2802e5fed98/rtree-1.4.1-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:d672184298527522d4914d8ae53bf76982b86ca420b0acde9298a7a87d81d4a4", size = 468484, upload-time = "2025-08-13T19:31:50.593Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/cf/2710b6fd6b07ea0aef317b29f335790ba6adf06a28ac236078ed9bd8a91d/rtree-1.4.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a7e48d805e12011c2cf739a29d6a60ae852fb1de9fc84220bbcef67e6e595d7d", size = 436325, upload-time = "2025-08-13T19:31:52.367Z" },
+    { url = "https://files.pythonhosted.org/packages/55/e1/4d075268a46e68db3cac51846eb6a3ab96ed481c585c5a1ad411b3c23aad/rtree-1.4.1-py3-none-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:efa8c4496e31e9ad58ff6c7df89abceac7022d906cb64a3e18e4fceae6b77f65", size = 459789, upload-time = "2025-08-13T19:31:53.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/75/e5d44be90525cd28503e7f836d077ae6663ec0687a13ba7810b4114b3668/rtree-1.4.1-py3-none-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:12de4578f1b3381a93a655846900be4e3d5f4cd5e306b8b00aa77c1121dc7e8c", size = 507644, upload-time = "2025-08-13T19:31:55.164Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/85/b8684f769a142163b52859a38a486493b05bafb4f2fb71d4f945de28ebf9/rtree-1.4.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:b558edda52eca3e6d1ee629042192c65e6b7f2c150d6d6cd207ce82f85be3967", size = 1454478, upload-time = "2025-08-13T19:31:56.808Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a4/c2292b95246b9165cc43a0c3757e80995d58bc9b43da5cb47ad6e3535213/rtree-1.4.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f155bc8d6bac9dcd383481dee8c130947a4866db1d16cb6dff442329a038a0dc", size = 1555140, upload-time = "2025-08-13T19:31:58.031Z" },
+    { url = "https://files.pythonhosted.org/packages/74/25/5282c8270bfcd620d3e73beb35b40ac4ab00f0a898d98ebeb41ef0989ec8/rtree-1.4.1-py3-none-win_amd64.whl", hash = "sha256:efe125f416fd27150197ab8521158662943a40f87acab8028a1aac4ad667a489", size = 389358, upload-time = "2025-08-13T19:31:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/50/0a9e7e7afe7339bd5e36911f0ceb15fed51945836ed803ae5afd661057fd/rtree-1.4.1-py3-none-win_arm64.whl", hash = "sha256:3d46f55729b28138e897ffef32f7ce93ac335cb67f9120125ad3742a220800f0", size = 355253, upload-time = "2025-08-13T19:32:00.296Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Stacked on #36.

The clash check asks whether two things occupy the same volume. This asks the opposite question: does every object **touch** the thing that holds it up. Indoors there are only four answers — the floor, a wall, the top of another object, or the ceiling — and an object matching none of them is floating.

The support relation is **derived, never declared**, so the scene graph falls out of the same pass: the surface an object rests on IS its parent. That turns "everything traces back to structure" into a graph check rather than more geometry.

```
Floor
├── Table0
│   ├── Book0
│   └── Cup0
└── Sofa0
Wall0
└── Shelf0
    └── Mug0
```

`Mug0 → Shelf0 → Wall0` never touches the floor and is still correct — which is why the rule is "the chain ends at structure", not "the object is above the floor".

## How

**Rays, not boxes.** An object's box top is not its support surface: a table's box top is the tabletop, but a chair's is the *backrest*, and nothing rests on a backrest. Rays start from the object's own extreme vertices rather than a grid over its footprint — a grid sends most of its rays through the empty air between a chair's legs, while the extreme vertices *are* the feet.

**Which face probes which support.** The bottom face only answers the downward question; a picture on a wall has nothing at all beneath it. So each hypothesis probes the face pointing at its own candidate:

| hypothesis | probe |
|---|---|
| floor / on another object | bottom face, rays cast down — which body is hit decides the parent |
| wall hanging | back face vs the wall plane (exact arithmetic, no rays) |
| ceiling hanging | top face vs the ceiling plane |

Walls and the ceiling are planes we already know from the SHELL, so only the downward case needs rays — the only case where the identity of the supporting body is in question.

**Report only.** A floating object is a *missing support*, not a misplaced one — the shelf it belongs on was never built — so dropping it to the floor would hide the real defect. Nothing here writes `Room.py`.

Consumes the same `bodies` dict as `collision_mesh.build_bodies`, so the two checks share one decomposition of the room and cannot disagree about what an object is.

## Thresholds set against a real room, not guessed

- **Wall mounts get their own, much looser tolerance.** A bracket or batten legitimately holds a thing off the wall: on Elliott-Studio a wall-hung TV and a wall cabinet both stand 6 cm proud, and at the resting tolerance both read as floating in mid-air. Safe to loosen because the downward test runs first and wins, so nothing standing on the floor can be captured by it.
- **The contact-face band is 2 cm, not razor-thin.** A base a millimetre out of level would otherwise offer a hairline strip of feet. Widening is free — a candidate that does not reach its support is dropped by its ray gap anyway.
- **Buried rays count toward the stability hull.** A face sunk into its support is still held up by it, and its burial is already its own finding; judging stability on the unburied rays alone turned one defect into two.

## Two cases the first real room forced

- **Objects can rest on several bodies** — a plank across two boxes, a tray bridging two shelf levels. Keeping only the modal one puts a steady plank's centre in the gap *between* the contact patches and calls it unstable.
- **A pair buried in each other is reported from both sides**, and some burial is correct (a sink in its counter). Now one finding per pair, filtered through the same `EXPECTED_CONTAINMENT` table the clash check uses, so the two gates cannot contradict each other.

`support_pairs()` exposes the graph as an allow-list: resting on something is touching it, so a book on a shelf is contact the clash check should *expect*. That is the job `EXPECTED_CONTAINMENT` does by category, except derived from geometry — so it covers pairs nobody thought to enumerate.

## It finds a bug in the current gate

On Elliott-Studio (20 objects) the collision gate reports four objects floating — `Storage1/2/8/9`. All four are wall-mounted cabinets: `check_all` exempts only `_FLOOR_STANDING` categories and `storage` is in that set. The support check resolves all four to their walls.

I have **not** wired `collision.py`'s grounding section to defer to this, since #36 is still in flight there. Happy to as a follow-up.

Two findings survive on that room, both real: `Sofa0` rests on the floor along a single 5 cm strip (the mesh is tilted ~2.7°), and `Refrigerator0` is 0.092 m into `StorageRun0` — which the collision gate independently reports as a 0.771 m overlap, so it is a genuine clash and `EXPECTED_CONTAINMENT` was left alone.

## Notes

- New dep `rtree` — trimesh's ray caster needs it for its broad phase, and this check is all ray casts. Small pure wheel, no compiler.
- Relocking for it also picks up **`coacd`, which #36 added to `pyproject.toml` but never locked** — `uv sync --locked` would fail on #36 as it stands.

```
python -m litereality_agent.pipeline.room_qc.support --room <room dir> [--graph]
```

## Test plan

- `tests/test_support.py` — 10 tests, synthetic boxes, no capture/Blender/glb needed: the ordinary floor→table→book chain; a wall-hung shelf with a mug on it (the case the bottom face cannot answer); a plank across two boxes (must read stable); a cup half off the table edge (must read unstable); a bowl sunk into the tabletop; a lamp in mid-air; a support cycle.
- Full suite green against #36's tree: `578 passed, 2 skipped`.
- `ruff check` clean on the new files.