### PR TITLE
Settle the layout before anything is built from it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ __MACOSX
 
 # macOS finder junk
 .DS_Store
+
+# the standalone layout prototype: its arena, viewers and benchmark artifacts
+physical_engine/out/

--- a/src/litereality_agent/pipeline/scene_init/flow.py
+++ b/src/litereality_agent/pipeline/scene_init/flow.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from litereality_agent import console, telemetry
 from litereality_agent.pipeline.scene_init import paths as config
 from litereality_agent.pipeline.scene_init.ingest import merge_boxes
+from litereality_agent.pipeline.scene_init import layout
 from litereality_agent.pipeline.scene_init.ingest.crop import crop_objects
 from litereality_agent.pipeline.scene_init.ingest.detect import bbox_polish
 from litereality_agent.pipeline.scene_init.ingest.extract import extract_scene
@@ -129,6 +130,22 @@ def _process_scan(scan: str, raw: Path, args: argparse.Namespace) -> dict:
     telemetry.stage("box_merge", scan, "start")
     merge_res = merge_boxes.merge_for_scan(scan)
     telemetry.stage("box_merge", scan, "done", merged=len(merge_res.get("merged", {})))
+
+    # 1c. layout repair — settle the LAYOUT while it is still only boxes. Same window as the merge
+    # above and for the same reason: after this point every mistake in a box gets paid for
+    # repeatedly. A duplicate detection becomes two generated assets; a counter run recorded half a
+    # metre too deep becomes an asset generated at the wrong extent and then squashed to fit; a box
+    # that moves after its crop was cut leaves the reference image describing geometry that no
+    # longer exists. Repairing here costs nothing and the correction propagates to the crop, the
+    # references, the chair clustering and the reconstruction for free.
+    # $LR_LAYOUT=0 opts out; $LR_LAYOUT_AGENT=1 lets it consult the reference photographs.
+    telemetry.stage("layout", scan, "start")
+    layout_res = layout.run_layout(scan)
+    telemetry.stage("layout", scan, "done",
+                    before=layout_res.get("before", 0), after=layout_res.get("after", 0),
+                    moved=len(layout_res.get("moved", [])),
+                    resized=len(layout_res.get("resized", [])),
+                    dropped=len(layout_res.get("dropped", [])))
 
     # 2. per-object crops
     # Reuse mirrors extract_scene above: the stage inspects the disk and decides for itself, rather

--- a/src/litereality_agent/pipeline/scene_init/flow.py
+++ b/src/litereality_agent/pipeline/scene_init/flow.py
@@ -28,9 +28,9 @@ import time
 from pathlib import Path
 
 from litereality_agent import console, telemetry
+from litereality_agent.pipeline.scene_init import layout
 from litereality_agent.pipeline.scene_init import paths as config
 from litereality_agent.pipeline.scene_init.ingest import merge_boxes
-from litereality_agent.pipeline.scene_init import layout
 from litereality_agent.pipeline.scene_init.ingest.crop import crop_objects
 from litereality_agent.pipeline.scene_init.ingest.detect import bbox_polish
 from litereality_agent.pipeline.scene_init.ingest.extract import extract_scene

--- a/src/litereality_agent/pipeline/scene_init/ingest/merge_boxes.py
+++ b/src/litereality_agent/pipeline/scene_init/ingest/merge_boxes.py
@@ -25,6 +25,9 @@ The merge writes two things besides the rewritten pkl:
     down to the sub-part its detector recognises (the sink).
 
 Set ``LR_BOX_MERGE=0`` to disable, or ``LR_BOX_MERGE_THRESH`` to change the overlap ratio.
+``LR_BOX_MERGE_WALL_GUARD=0`` turns off the wall gate (see `_separated_by_wall`), which is on by
+default and can only ever REMOVE a merge — with it off, and with no walls on disk, this module
+behaves exactly as it did before that gate existed.
 """
 
 from __future__ import annotations
@@ -49,6 +52,13 @@ YAW_TOLERANCE_DEG = 3.0  # boxes must share a yaw to be part of one run
 # to overlap — allowing a small gap so a sink resting on the counter still fuses with its cabinet,
 # while an upper cabinet a real gap above the base does NOT. Override with $LR_BOX_MERGE_VGAP.
 DEFAULT_VGAP = 0.12  # m: max vertical gap between extents still treated as overlapping (touching)
+# Wall gate: two boxes with a WALL BETWEEN THEM are not one counter run, whatever their footprints
+# do. RoomPlan sometimes detects a unit twice and records the second copy far too deep — deep
+# enough to punch through the wall behind it — and that smeared copy then overlaps a genuine unit
+# in the NEXT room. Union-find welds the two runs into a single box spanning the wall, and every
+# later stage reads the result as one counter recorded too deep. Set $LR_BOX_MERGE_WALL_GUARD=0
+# to disable. See `_separated_by_wall`.
+WALL_GUARD_EPS = 1e-6  # keeps a shared endpoint from reading as a crossing
 
 
 def _union_obb(members: list[dict]) -> dict:
@@ -137,8 +147,67 @@ def _vertical_gap(a: dict, b: dict) -> float:
     return max(abot, bbot) - min(atop, btop)  # >0 only when there is a gap between the extents
 
 
+def wall_segments(scene_data_dir: str | Path) -> list[tuple[tuple[float, float], tuple[float, float]]]:
+    """This scan's wall centrelines as 2-D segments in the ARKit ground plane (x, z).
+
+    The centrelines come from :mod:`..layout.adapter`, which recovers each wall from its transform
+    MATRIX rather than its Euler angle — ``R = Ry(theta) . Rz(180)`` does not decompose the obvious
+    way, and doing it by hand tilts every wall a few degrees. That module works in the SHELL frame
+    (Z up, floor on XY) where ``(x, y, z)_ARKit -> (x, -z, y)_SHELL``, so coming back to the ground
+    plane this file works in is ``(x, z)_ARKit = (X, -Y)_SHELL``.
+
+    Returns an empty list rather than raising. No walls simply means no wall guard: the merge then
+    behaves exactly as it did before this function existed, which is the right way to fail for a
+    check that only ever REMOVES merges.
+    """
+    try:
+        from ..layout import adapter
+
+        shell = adapter.shell_from_scene_data(Path(scene_data_dir))
+        return [((float(w["start"][0]), -float(w["start"][1])),
+                 (float(w["end"][0]), -float(w["end"][1])))
+                for w in (shell.get("walls") or {}).values()]
+    except Exception as exc:  # noqa: BLE001 — a missing or unreadable room is not a merge failure
+        print(f"  [box-merge] no walls available for the wall guard ({type(exc).__name__}: {exc})",
+              flush=True)
+        return []
+
+
+def _separated_by_wall(a: dict, b: dict, walls: list) -> bool:
+    """Is there a wall standing between these two boxes?
+
+    Deliberately the crude, physical test: draw the straight line between the two centres and ask
+    whether it crosses a wall SEGMENT. Not "which side of the wall's infinite line" — a room is
+    full of walls whose infinite lines cut everything in half, and the question here is only ever
+    about the wall actually standing in the way.
+
+    This is what Kitchen-Xiaoyang_Lyu needed. One oven was detected twice and the second copy came
+    back 1.46 m deep, straight through the wall behind it. That copy genuinely overlaps the counter
+    run on one side AND a storage unit on the other, so it bridges them, and the merged box —
+    2.53 x 1.62 m in the shipped run — spans a wall. No later stage can undo that: the layout pass
+    reads it as a counter recorded too deep and every repair it can make is the wrong one.
+    """
+    if not walls:
+        return False
+    ax, az = float(a["position"][0]), float(a["position"][2])
+    bx, bz = float(b["position"][0]), float(b["position"][2])
+    dx, dz = bx - ax, bz - az
+    for (sx, sz), (ex, ez) in walls:
+        wx, wz = ex - sx, ez - sz
+        denominator = dx * wz - dz * wx
+        if abs(denominator) < 1e-12:  # parallel: the wall lies beside them, not between them
+            continue
+        ox, oz = sx - ax, sz - az
+        t = (ox * wz - oz * wx) / denominator
+        u = (ox * dz - oz * dx) / denominator
+        if WALL_GUARD_EPS < t < 1.0 - WALL_GUARD_EPS and WALL_GUARD_EPS < u < 1.0 - WALL_GUARD_EPS:
+            return True
+    return False
+
+
 def auto_groups(
-    objs: list[dict], thresh: float = DEFAULT_THRESH, vgap: float = DEFAULT_VGAP
+    objs: list[dict], thresh: float = DEFAULT_THRESH, vgap: float = DEFAULT_VGAP,
+    walls: list | None = None
 ) -> list[list[str]]:
     """Cluster counter-run boxes that genuinely overlap in 3D (same yaw, footprints, heights).
 
@@ -147,6 +216,11 @@ def auto_groups(
     so a real chain — sink over the base cabinet, base cabinet abutting the next base cabinet —
     still merges; the vertical gate is what stops a wall/upper cabinet, whose footprint overlaps but
     which floats a real gap above, from being dragged in through a box between them.
+
+    `walls`, when given, adds the horizontal twin of that gate: a pair with a wall BETWEEN them
+    never fuses, however well their boxes overlap. The vertical gate cannot express this — the
+    bridging box overlaps its neighbour on each side perfectly plausibly, and the resulting group
+    is no taller than a single cabinet. Omit `walls` and the behaviour is exactly as before.
     """
     ids = [
         o["object_type"]
@@ -166,6 +240,8 @@ def auto_groups(
         for j in range(i + 1, len(ids)):
             a, b = by[ids[i]], by[ids[j]]
             if _footprint_overlap(a, b) > thresh and _vertical_gap(a, b) <= vgap:
+                if _separated_by_wall(a, b, walls or []):
+                    continue
                 parent[find(ids[i])] = find(ids[j])
     groups: dict = {}
     for i in ids:
@@ -265,6 +341,7 @@ def merge_for_scan(scan: str, *, thresh: float | None = None, enabled: bool | No
         vgap = float(os.environ.get("LR_BOX_MERGE_VGAP", DEFAULT_VGAP))
     except ValueError:
         vgap = DEFAULT_VGAP
+    guard = os.environ.get("LR_BOX_MERGE_WALL_GUARD", "1") not in ("0", "false", "no")
 
     try:
         pkl = config.scene_data_dir(scan) / "objects.pkl"
@@ -272,7 +349,13 @@ def merge_for_scan(scan: str, *, thresh: float | None = None, enabled: bool | No
             print(f"  [box-merge] no objects.pkl at {pkl} — skipping", flush=True)
             return {"merged": {}, "skipped": {}}
         objs = pickle.load(open(pkl, "rb"))
-        detected = auto_groups(objs, thresh, vgap)
+        # Walls are read from the same scene_data folder the objects came from, so this needs no
+        # new plumbing and no ordering change: `walls.pkl` is written by extraction, before the
+        # window this function runs in.
+        walls = wall_segments(pkl.parent) if guard else []
+        if guard and not walls:
+            print("  [box-merge] wall guard inactive — no wall centrelines for this scan", flush=True)
+        detected = auto_groups(objs, thresh, vgap, walls)
         if not detected:
             print(f"  [box-merge] no overlapping counter runs (thresh={thresh})", flush=True)
             return {"merged": {}, "skipped": {}}

--- a/src/litereality_agent/pipeline/scene_init/ingest/merge_boxes.py
+++ b/src/litereality_agent/pipeline/scene_init/ingest/merge_boxes.py
@@ -221,6 +221,11 @@ def apply_merges(
         entry = _union_obb([by[m] for m in present])
         entry["object_type"] = name
         entry["mesh_id"] = name
+        # Provenance travels WITH the box. `members.json` beside the references records the same
+        # thing, but a later stage holding only objects.pkl cannot reach it, and the layout pass
+        # that runs next needs to know this unit was assembled rather than detected — otherwise it
+        # reads a run swallowing its own cabinet as a duplicate and deletes the run.
+        entry["merged_from"] = list(present)
         new_entries.append(entry)
         consumed.update(present)
         merged[name] = present

--- a/src/litereality_agent/pipeline/scene_init/layout/__init__.py
+++ b/src/litereality_agent/pipeline/scene_init/layout/__init__.py
@@ -1,0 +1,32 @@
+"""layout — make the room's LAYOUT sound before anything expensive is built from it.
+
+Runs inside ingest, immediately after ``merge_boxes`` and before crops, references and
+reconstruction. That window is deliberate and it is the same one the merge itself occupies: by the
+time an object has been cropped, clustered and reconstructed, every mistake in its box has been
+paid for several times over. A duplicate detection becomes two generated assets. A counter run
+recorded half a metre too deep becomes an asset generated at the wrong extent and then squashed to
+fit. A box that moves after its crop was cut leaves the reference image describing geometry that no
+longer exists.
+
+So the layout is settled first, on boxes, where a correction is free:
+
+``check``     the success condition — nothing overlapping that should not, nothing inside a wall,
+              nothing off the floor plate. Also what the repair optimises against.
+``repair``    a search over legal ACTIONS (drop a duplicate, seat a unit against its wall, fit one
+              into its corner, separate two along the wall they share, trim a little off each of
+              two that no longer fit) where every action is applied to a copy and kept only if the
+              room provably improves. A repair can therefore never return a worse room.
+``agent``     where geometry runs out. Reads the reference photograph and answers the question a
+              person would find easy and a solver cannot: is this box the wrong SIZE, does it
+              belong in that corner, or are these two the same object detected twice.
+
+This is not collision QC. Small box-on-box overlap is a physics concern; what is settled here —
+duplicates, units buried in walls, furniture outside the room, boxes recorded at the wrong size —
+is visible in any render and expensive to discover later.
+"""
+
+from .adjust import check
+from .repair import repair, score
+from .stage import run_layout
+
+__all__ = ["check", "repair", "score", "run_layout"]

--- a/src/litereality_agent/pipeline/scene_init/layout/__init__.py
+++ b/src/litereality_agent/pipeline/scene_init/layout/__init__.py
@@ -12,10 +12,16 @@ So the layout is settled first, on boxes, where a correction is free:
 
 ``check``     the success condition — nothing overlapping that should not, nothing inside a wall,
               nothing off the floor plate. Also what the repair optimises against.
-``repair``    a search over legal ACTIONS (drop a duplicate, seat a unit against its wall, fit one
-              into its corner, separate two along the wall they share, trim a little off each of
-              two that no longer fit) where every action is applied to a copy and kept only if the
-              room provably improves. A repair can therefore never return a worse room.
+``repair``    a search over legal ACTIONS (seat a unit against its wall, fit one into its corner,
+              separate two along the wall they share, trim a little off each of two that no longer
+              fit) where every action is applied to a copy and kept only if the room provably
+              improves. A repair can therefore never return a worse room. It also never DELETES:
+              deleting a duplicate detection is available behind ``$LR_LAYOUT_DROP=1`` and off,
+              because a wrong deletion is the only outcome here that leaves no trace to notice.
+``report``    every run draws what it did: the scanned room and the repaired one side by side,
+              the scanned positions ghosted under the repair and each correction drawn as an
+              arrow. A violation count cannot tell a counter put back against its wall from a
+              table shoved half a metre across the room; both read as zero. The picture can.
 ``agent``     where geometry runs out. Reads the reference photograph and answers the question a
               person would find easy and a solver cannot: is this box the wrong SIZE, does it
               belong in that corner, or are these two the same object detected twice.
@@ -27,6 +33,7 @@ is visible in any render and expensive to discover later.
 
 from .adjust import check
 from .repair import repair, score
+from .report import render
 from .stage import run_layout
 
-__all__ = ["check", "repair", "score", "run_layout"]
+__all__ = ["check", "render", "repair", "score", "run_layout"]

--- a/src/litereality_agent/pipeline/scene_init/layout/adapter.py
+++ b/src/litereality_agent/pipeline/scene_init/layout/adapter.py
@@ -158,6 +158,11 @@ def shell_from_scene_data(scene_data_dir: str | Path, *, thickness: float = 0.16
             "size": [_r(width), _r(depth), _r(height)],
             "yaw": _r(math.degrees(math.atan2(along[1], along[0])), 2),
         }
+        # Carried, not derived: the repair may not delete a unit the box merge assembled, and the
+        # compound NAME is not proof of one — an object called `Sink_Storage0` in a capture that
+        # never ran the merge is just a detection with an underscore in it.
+        if entry.get("merged_from"):
+            objects[object_id]["merged_from"] = list(entry["merged_from"])
 
     return {"walls": walls, "openings": {}, "objects": objects,
             "floor": {"verts": verts, "faces": faces},

--- a/src/litereality_agent/pipeline/scene_init/layout/adapter.py
+++ b/src/litereality_agent/pipeline/scene_init/layout/adapter.py
@@ -1,0 +1,135 @@
+"""adapter.py — the RoomPlan pkl set on disk, as the SHELL the repair works on, and back again.
+
+Two coordinate conventions meet here and the whole module exists to keep them apart.
+
+``scene_data`` is ARKit's: **Y is up**, the floor is the XZ plane, and a wall carries a centre, a
+rotation about Y and a bbox. The SHELL is the repair's: **Z is up**, the floor is XY, walls are
+2-D centrelines with a thickness, objects are oriented footprints with a yaw. Every conversion is
+in this file and nowhere else, so a sign error has one place to hide rather than a dozen.
+
+Reading is delegated to :mod:`.scene_data`, which recovers a wall's centreline from its transform
+matrix rather than its Euler angle — ``R = Ry(theta) . Rz(180)`` does not decompose the obvious
+way, and getting it wrong tilts every wall in the room by a few degrees.
+
+Writing back is deliberately narrow. The repair may move an object, resize it, or drop it; it may
+not invent one, and it never touches walls, floor or openings — those are the room's structure and
+a layout pass has no business rewriting them. So ``apply_to_objects`` edits ``position`` and
+``bbox`` in place on the entries it recognises and removes the dropped ones, leaving every other
+field (``file``, ``mesh_id``, ``rotation``, ``top_down_rect``) exactly as extraction wrote it.
+"""
+
+from __future__ import annotations
+
+import math
+import pickle
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+__all__ = ["shell_from_scene_data", "apply_to_objects", "load_objects"]
+
+
+def _as_list(value) -> list[float]:
+    return [float(v) for v in np.asarray(value).reshape(-1)]
+
+
+def load_objects(scene_data_dir: str | Path) -> list[dict]:
+    path = Path(scene_data_dir) / "objects.pkl"
+    return pickle.load(open(path, "rb")) if path.is_file() else []
+
+
+def shell_from_scene_data(scene_data_dir: str | Path, *, thickness: float = 0.16) -> dict[str, Any]:
+    """Build a SHELL from one scan's ``scene_data`` folder."""
+    from . import scene_data as loader
+
+    scene_data_dir = Path(scene_data_dir)
+    geometry = loader._build_from_scene_data(str(scene_data_dir), thickness=thickness)
+    walls_org = geometry.get("walls_org") or {}
+    floor_pkl = geometry.get("floor_pkl") or {}
+
+    walls: dict[str, Any] = {}
+    floor_y: list[float] = []
+    for index in sorted(walls_org):
+        wall = walls_org[index]
+        (x1, z1), (x2, z2) = wall["pose"]["2d_line"]
+        bbox = _as_list(wall["pose"]["bbox"])
+        # ARKit XZ is the SHELL's XY; the wall's own thickness is its third bbox term, which
+        # RoomPlan reports as ~0.0001 m because it models walls as planes.
+        walls[f"Wall{index}"] = {"start": [x1, z1], "end": [x2, z2],
+                                 "thickness": float(bbox[2]) if len(bbox) > 2 else 0.0001,
+                                 "height": float(bbox[1]) if len(bbox) > 1 else 2.5}
+        centre = _as_list(wall["pose"]["position"])
+        if len(centre) > 1 and len(bbox) > 1:
+            floor_y.append(centre[1] - bbox[1] / 2.0)
+
+    verts: list[list[float]] = []
+    faces: list[list[int]] = []
+    for patch in floor_pkl.values():
+        points = np.asarray(patch, dtype=float).reshape(-1, 3)
+        if len(points) < 3:
+            continue
+        base = len(verts)
+        # ARKit (x, y, z) -> SHELL (x, z, y): the horizontal plane becomes XY, height becomes Z
+        verts += [[float(p[0]), float(p[2]), float(p[1])] for p in points]
+        faces += [[base, base + i, base + i + 1] for i in range(1, len(points) - 1)]
+
+    floor_z = min((v[2] for v in verts), default=min(floor_y, default=0.0))
+    ceiling_z = floor_z + max((w["height"] for w in walls.values()), default=2.5)
+
+    objects: dict[str, Any] = {}
+    for entry in load_objects(scene_data_dir):
+        object_id = entry.get("object_type") or entry.get("mesh_id")
+        if not object_id:
+            continue
+        position, bbox = _as_list(entry["position"]), _as_list(entry["bbox"])
+        if len(position) < 3 or len(bbox) < 3:
+            continue
+        rotation = entry.get("rotation", 0.0)
+        yaw = float(np.asarray(rotation).reshape(-1)[0]) if np.size(rotation) else 0.0
+        objects[object_id] = {
+            "category": _category(object_id),
+            # position is the box CENTRE in ARKit; swap Z and Y to reach the SHELL frame
+            "center": [position[0], position[2], position[1]],
+            # bbox is (width, height, depth) in ARKit; the SHELL wants (width, depth, height)
+            "size": [bbox[0], bbox[2], bbox[1]],
+            "yaw": yaw,
+        }
+
+    return {"walls": walls, "openings": {}, "objects": objects,
+            "floor": {"verts": verts, "faces": faces},
+            "floor_z": floor_z, "ceiling_z": ceiling_z}
+
+
+def _category(object_id: str) -> str:
+    """RoomPlan names an object `<Category><index>`; the rules key on the category."""
+    return "".join(c for c in object_id if not c.isdigit()).strip("_").lower()
+
+
+def apply_to_objects(entries: list[dict], shell: dict[str, Any]) -> dict[str, Any]:
+    """Fold a repaired SHELL back into the ``objects.pkl`` list, in place.
+
+    Returns a summary of what changed. Only centre and size are written, and only for entries the
+    SHELL still contains — an object the repair dropped is removed, and nothing is ever added.
+    """
+    objects = shell.get("objects") or {}
+    moved, resized, dropped = [], [], []
+    kept: list[dict] = []
+    for entry in entries:
+        object_id = entry.get("object_type") or entry.get("mesh_id")
+        repaired = objects.get(object_id)
+        if repaired is None:
+            dropped.append(object_id)
+            continue
+        position, bbox = _as_list(entry["position"]), _as_list(entry["bbox"])
+        want_position = [repaired["center"][0], repaired["center"][2], repaired["center"][1]]
+        want_bbox = [repaired["size"][0], repaired["size"][2], repaired["size"][1]]
+        if math.dist(position[:3], want_position) > 1e-4:
+            entry["position"] = np.asarray(want_position, dtype=float)
+            moved.append(object_id)
+        if any(abs(a - b) > 1e-4 for a, b in zip(bbox[:3], want_bbox)):
+            entry["bbox"] = np.asarray(want_bbox, dtype=float)
+            resized.append(object_id)
+        kept.append(entry)
+    entries[:] = kept
+    return {"moved": moved, "resized": resized, "dropped": dropped}

--- a/src/litereality_agent/pipeline/scene_init/layout/adapter.py
+++ b/src/litereality_agent/pipeline/scene_init/layout/adapter.py
@@ -7,6 +7,14 @@ rotation about Y and a bbox. The SHELL is the repair's: **Z is up**, the floor i
 2-D centrelines with a thickness, objects are oriented footprints with a yaw. Every conversion is
 in this file and nowhere else, so a sign error has one place to hide rather than a dozen.
 
+The mapping is ``(x, y, z)_ARKit -> (x, -z, y)_SHELL``. The negation is the whole reason this
+paragraph exists. ARKit is right-handed with +Z toward the viewer; the SHELL's XY is a plan view,
+so preserving orientation requires flipping that axis. Getting it wrong does not mirror the room
+into something obviously broken — it produces walls of exactly the right LENGTHS that no longer
+meet at their corners, which reads as a plausible-looking room that is subtly, uselessly wrong.
+The check: a room's wall endpoints coincide to within centimetres. If they are half a metre apart,
+this sign is why.
+
 Reading is delegated to :mod:`.scene_data`, which recovers a wall's centreline from its transform
 matrix rather than its Euler angle — ``R = Ry(theta) . Rz(180)`` does not decompose the obvious
 way, and getting it wrong tilts every wall in the room by a few degrees.
@@ -53,8 +61,13 @@ def load_objects(scene_data_dir: str | Path) -> list[dict]:
 def shell_from_scene_data(scene_data_dir: str | Path, *, thickness: float = 0.16) -> dict[str, Any]:
     """Build a SHELL from one scan's ``scene_data`` folder."""
     from . import scene_data as loader
+    from .shell import ARKIT_TO_Z_UP, _box_frame, _r
 
     scene_data_dir = Path(scene_data_dir)
+    raw_walls = []
+    walls_pkl = scene_data_dir / "walls.pkl"
+    if walls_pkl.is_file():
+        raw_walls = pickle.load(open(walls_pkl, "rb"))
     geometry = loader._build_from_scene_data(str(scene_data_dir), thickness=thickness)
     walls_org = geometry.get("walls_org") or {}
     floor_pkl = geometry.get("floor_pkl") or {}
@@ -63,27 +76,47 @@ def shell_from_scene_data(scene_data_dir: str | Path, *, thickness: float = 0.16
     floor_y: list[float] = []
     for index in sorted(walls_org):
         wall = walls_org[index]
-        (x1, z1), (x2, z2) = wall["pose"]["2d_line"]
-        bbox = _as_list(wall["pose"]["bbox"])
-        # ARKit XZ is the SHELL's XY; the wall's own thickness is its third bbox term, which
-        # RoomPlan reports as ~0.0001 m because it models walls as planes.
-        walls[f"Wall{index}"] = {"start": [x1, z1], "end": [x2, z2],
-                                 "thickness": float(bbox[2]) if len(bbox) > 2 else 0.0001,
-                                 "height": float(bbox[1]) if len(bbox) > 1 else 2.5}
-        centre = _as_list(wall["pose"]["position"])
-        if len(centre) > 1 and len(bbox) > 1:
-            floor_y.append(centre[1] - bbox[1] / 2.0)
+        # the loader drops `transform` from its pose, so the raw pkl entry is what carries it
+        pose = dict(wall["pose"])
+        if index < len(raw_walls):
+            pose.setdefault("transform", (raw_walls[index].get("pose") or {}).get("transform"))
+        matrix = _world_matrix(pose)
+        centre, along, width, depth, height = _box_frame(matrix, prefer_long=True)
+        half = along * (width / 2.0)
+        walls[f"Wall{index}"] = {
+            "start": [_r(centre[0] - half[0]), _r(centre[1] - half[1])],
+            "end": [_r(centre[0] + half[0]), _r(centre[1] + half[1])],
+            "thickness": _r(depth), "height": _r(height)}
+        floor_y.append(float(centre[2]) - height / 2.0)
 
+    # The floor comes from its OWN mesh, put through the same change of basis as everything else.
+    # The loader's clipped patches are a convex quad; a real room is rarely one, and on Tea_room's
+    # L-shape that quad is a small rotated diamond covering neither half of the room, which reads
+    # as most of the furniture standing off the plate.
     verts: list[list[float]] = []
     faces: list[list[int]] = []
-    for patch in floor_pkl.values():
-        points = np.asarray(patch, dtype=float).reshape(-1, 3)
-        if len(points) < 3:
-            continue
-        base = len(verts)
-        # ARKit (x, y, z) -> SHELL (x, z, y): the horizontal plane becomes XY, height becomes Z
-        verts += [[float(p[0]), float(p[2]), float(p[1])] for p in points]
-        faces += [[base, base + i, base + i + 1] for i in range(1, len(points) - 1)]
+    floor_file = scene_data_dir / "floor.pkl"
+    if floor_file.is_file():
+        raw_floor = pickle.load(open(floor_file, "rb"))
+        points = np.asarray(raw_floor.get("points", []), dtype=float).reshape(-1, 3)
+        indices = np.asarray(raw_floor.get("faces", []), dtype=int).reshape(-1, 3)
+        transform = raw_floor.get("transform")
+        if len(points) >= 3 and len(indices):
+            if transform is not None:
+                matrix = np.asarray(transform, dtype=float).reshape(4, 4).T
+                points = (matrix @ np.c_[points, np.ones(len(points))].T).T[:, :3]
+            world = (ARKIT_TO_Z_UP @ np.c_[points, np.ones(len(points))].T).T[:, :3]
+            verts = [[_r(p[0]), _r(p[1]), _r(p[2])] for p in world]
+            faces = [[int(a), int(b), int(c)] for a, b, c in indices
+                     if max(a, b, c) < len(verts)]
+    if not faces:                                  # fall back to whatever the loader could clip
+        for patch in floor_pkl.values():
+            points = np.asarray(patch, dtype=float).reshape(-1, 3)
+            if len(points) < 3:
+                continue
+            base = len(verts)
+            verts += [[_r(p[0]), _r(-p[2]), _r(p[1])] for p in points]
+            faces += [[base, base + i, base + i + 1] for i in range(1, len(points) - 1)]
 
     # A floor plate has to be plausible before it is trusted. Some captures hand back a floor
     # entity whose transform collapses it: Airbnb-Cam's is 0.27 m2 and 4 cm wide against a room
@@ -113,20 +146,59 @@ def shell_from_scene_data(scene_data_dir: str | Path, *, thickness: float = 0.16
         position, bbox = _as_list(entry["position"]), _as_list(entry["bbox"])
         if len(position) < 3 or len(bbox) < 3:
             continue
-        rotation = entry.get("rotation", 0.0)
-        yaw = float(np.asarray(rotation).reshape(-1)[0]) if np.size(rotation) else 0.0
+        matrix = _world_matrix({"position": position, "bbox": bbox,
+                                "rotation": entry.get("rotation"),
+                                "transform": entry.get("transform")})
+        # prefer_long=False: an object keeps its OWN local axes. Taking the longer one instead
+        # rotates any object whose local Y is longer by 90 degrees — the chair-orientation bug.
+        centre, along, width, depth, height = _box_frame(matrix, prefer_long=False)
         objects[object_id] = {
             "category": _category(object_id),
-            # position is the box CENTRE in ARKit; swap Z and Y to reach the SHELL frame
-            "center": [position[0], position[2], position[1]],
-            # bbox is (width, height, depth) in ARKit; the SHELL wants (width, depth, height)
-            "size": [bbox[0], bbox[2], bbox[1]],
-            "yaw": yaw,
+            "center": [_r(centre[0]), _r(centre[1]), _r(centre[2])],
+            "size": [_r(width), _r(depth), _r(height)],
+            "yaw": _r(math.degrees(math.atan2(along[1], along[0])), 2),
         }
 
     return {"walls": walls, "openings": {}, "objects": objects,
             "floor": {"verts": verts, "faces": faces},
             "floor_z": floor_z, "ceiling_z": ceiling_z}
+
+
+def _world_matrix(pose: dict) -> np.ndarray:
+    """A scene_data pose -> its 4x4 box matrix in the SHELL's Z-up world, scale baked in.
+
+    Going through the matrix is the point. The obvious shortcut — read the pose's centre and
+    extents, swap the axes by hand — gets the CENTRES right and the DIRECTIONS wrong, because the
+    handedness flip in ``(x, y, z) -> (x, -z, y)`` also reverses the sense of rotation about the
+    vertical. The symptom is walls of exactly the correct lengths whose endpoints no longer meet,
+    which looks like a plausible room until you try to stand in it. Applying the change of basis to
+    the whole transform and reading the columns back out cannot make that mistake.
+    """
+    from .shell import ARKIT_TO_Z_UP
+
+    bbox = _as_list(pose.get("bbox") or [1.0, 1.0, 1.0])
+    transform = pose.get("transform")
+    if transform is not None:
+        # ROW-major, translation in the LAST ROW — USD's convention, preserved verbatim in the pkl.
+        # The whole 4x4 transposes; taking only the rotation block and reading the translation from
+        # the last column silently inverts the rotation, which leaves every centre correct and every
+        # DIRECTION reversed about the vertical. Walls then have exactly the right lengths and no
+        # longer meet at their corners.
+        matrix = np.asarray(transform, dtype=float).reshape(4, 4).T.copy()
+    else:                                   # only a Y-rotation was recorded
+        rotation = pose.get("rotation", 0.0)
+        yaw = float(np.asarray(rotation).reshape(-1)[1 if np.size(rotation) >= 3 else 0])
+        c, s = math.cos(math.radians(yaw)), math.sin(math.radians(yaw))
+        matrix = np.eye(4)
+        matrix[:3, :3] = np.array([[c, 0.0, s], [0.0, 1.0, 0.0], [-s, 0.0, c]])
+        matrix[:3, 3] = _as_list(pose["position"])[:3]
+    # the rotation part is orthonormal, so bake the extents into the columns: their LENGTHS then
+    # are the box's extents, which is what _box_frame reads
+    for axis in range(3):
+        column = matrix[:3, axis]
+        norm = float(np.linalg.norm(column)) or 1.0
+        matrix[:3, axis] = column / norm * (bbox[axis] if axis < len(bbox) else 1.0)
+    return ARKIT_TO_Z_UP @ matrix
 
 
 def _category(object_id: str) -> str:
@@ -150,7 +222,7 @@ def apply_to_objects(entries: list[dict], shell: dict[str, Any]) -> dict[str, An
             dropped.append(object_id)
             continue
         position, bbox = _as_list(entry["position"]), _as_list(entry["bbox"])
-        want_position = [repaired["center"][0], repaired["center"][2], repaired["center"][1]]
+        want_position = [repaired["center"][0], repaired["center"][2], -repaired["center"][1]]
         want_bbox = [repaired["size"][0], repaired["size"][2], repaired["size"][1]]
         if math.dist(position[:3], want_position) > 1e-4:
             entry["position"] = np.asarray(want_position, dtype=float)

--- a/src/litereality_agent/pipeline/scene_init/layout/adapter.py
+++ b/src/litereality_agent/pipeline/scene_init/layout/adapter.py
@@ -29,6 +29,17 @@ import numpy as np
 
 __all__ = ["shell_from_scene_data", "apply_to_objects", "load_objects"]
 
+MIN_PLATE_FRACTION = 0.30   # a floor covering less of its own walls than this is not believable
+
+
+def _polygon_area(verts: list[list[float]], faces: list[list[int]]) -> float:
+    """Total XY area of the floor triangles, for sanity-checking the plate."""
+    total = 0.0
+    for a, b, c in faces:
+        (ax, ay), (bx, by), (cx, cy) = verts[a][:2], verts[b][:2], verts[c][:2]
+        total += abs((bx - ax) * (cy - ay) - (cx - ax) * (by - ay)) / 2.0
+    return total
+
 
 def _as_list(value) -> list[float]:
     return [float(v) for v in np.asarray(value).reshape(-1)]
@@ -73,6 +84,23 @@ def shell_from_scene_data(scene_data_dir: str | Path, *, thickness: float = 0.16
         # ARKit (x, y, z) -> SHELL (x, z, y): the horizontal plane becomes XY, height becomes Z
         verts += [[float(p[0]), float(p[2]), float(p[1])] for p in points]
         faces += [[base, base + i, base + i + 1] for i in range(1, len(points) - 1)]
+
+    # A floor plate has to be plausible before it is trusted. Some captures hand back a floor
+    # entity whose transform collapses it: Airbnb-Cam's is 0.27 m2 and 4 cm wide against a room
+    # nearly 3 m across, and taking it at face value put EVERY object "off the floor plate" —
+    # seven violations that were all artefacts of one bad mesh. A plate that covers almost none of
+    # the area its own walls enclose is not a plate, and the honest response is to decline the test
+    # rather than to report what it says. `check` then falls back to the wall bounds, which is
+    # weaker but true.
+    if verts:
+        plate = _polygon_area(verts, faces)
+        wall_points = [p for w in walls.values() for p in (w["start"], w["end"])]
+        if wall_points:
+            xs = [p[0] for p in wall_points]
+            ys = [p[1] for p in wall_points]
+            enclosed = (max(xs) - min(xs)) * (max(ys) - min(ys))
+            if enclosed > 0 and plate < MIN_PLATE_FRACTION * enclosed:
+                verts, faces = [], []
 
     floor_z = min((v[2] for v in verts), default=min(floor_y, default=0.0))
     ceiling_z = floor_z + max((w["height"] for w in walls.values()), default=2.5)

--- a/src/litereality_agent/pipeline/scene_init/layout/adjust.py
+++ b/src/litereality_agent/pipeline/scene_init/layout/adjust.py
@@ -55,7 +55,6 @@ import numpy as np
 
 from .graph import (
     CLASH_TOL,
-    is_wall_hung,
     FLOOR_STANDING,
     FURNITURE,
     OPEN_FRAME,
@@ -63,6 +62,7 @@ from .graph import (
     WALL_MOUNTED,
     Z_BAND_TOL,
     expected_pair,
+    is_wall_hung,
     obb_mtv,
     wall_distance,
 )

--- a/src/litereality_agent/pipeline/scene_init/layout/adjust.py
+++ b/src/litereality_agent/pipeline/scene_init/layout/adjust.py
@@ -1,0 +1,757 @@
+"""adjust.py — STAGE 3: make the layout physically consistent, deterministically.
+
+A RoomPlan capture is a *measurement*, so its boxes overlap. Chairs interpenetrate, a table runs
+into a wall, a shelf floats 4 cm off the floor. None of that can be simulated: a physics engine
+handed two boxes that already overlap either explodes them apart on the first step or wedges them.
+This stage produces a layout in which nothing overlaps that should not, so the room is
+**simulation-ready** before any agent or solver is involved.
+
+Two halves, in the same shape as ``pipeline/room_qc`` upstream:
+
+``check(shell)``
+    read-only. Every violation the geometry admits — ``below_floor``, ``above_ceiling``,
+    ``floating``, ``sunk``, ``outside_room``, ``wall_clash``, ``object_clash``,
+    ``fixture_over_opening`` — measured, never guessed.
+
+``resolve(shell)``
+    repair. Three faults are CONTAINMENT rather than collision — a box buried in a wall, a box off
+    the floor plate, a box through the ceiling — and the pair relaxation below cannot see any of
+    them: a wall is not in ``objects``, the floor plate is not a box, and a lifted object clashes
+    with nothing. They are put back first, each firing only on what ``check`` actually reports, so
+    a correctly placed unit is never "corrected". A buried object goes back to touching the face of
+    its own wall, which is both the shortest move that clears the slab and the one that keeps it
+    installed against that wall — shoving it into the room would trade a collision for a counter
+    that is no longer a counter.
+
+    Then the iterative relaxation. Each clashing pair is separated along its **minimum translation
+    vector** — by construction the shortest move that fixes it — and the move is split between the
+    two by MOBILITY:
+
+    * an object standing against a wall is ANCHORED and does not move. A counter run belongs
+      against its wall; the thing in front of it is what should give way. Anchored-vs-anchored is
+      reported, never forced.
+    * ``FREE_STANDING`` categories (chairs, tables, desks…) stay mobile even against a wall —
+      that is where they happen to be, not where they belong.
+    * motion is XY only. Vertical placement is grounding's job, and a ``floating`` violation means
+      a missing support object, not a misplaced one — so it is reported and grounded separately.
+
+Every candidate move is then validated (displacement cap, still inside the floor polygon, not
+driven into a wall) and reverted if it fails, so an object is never left somewhere worse than it
+started. What survives is reported as ``unresolved``: honest output beats a silent bad fix.
+
+The allow-list is shared with :mod:`physical_engine.graph`, so the resolver can never "fix"
+something the graph considers correct — pushing an undermount sink out of its counter would be a
+regression, not a repair.
+"""
+
+from __future__ import annotations
+
+import copy
+import math
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+from .graph import (
+    CLASH_TOL,
+    is_wall_hung,
+    FLOOR_STANDING,
+    FURNITURE,
+    OPEN_FRAME,
+    PASSTHROUGH,
+    WALL_MOUNTED,
+    Z_BAND_TOL,
+    expected_pair,
+    obb_mtv,
+    wall_distance,
+)
+from .shell import object_footprint, opening_span, wall_frame
+
+__all__ = ["Violation", "Move", "AdjustResult", "check", "resolve", "ground", "reseat_openings"]
+
+# tolerances (metres)
+Z_TOL = 0.05           # poke through the floor or ceiling
+FLOAT_TOL = 0.08       # gap under a floor-standing object
+SUNK_TOL = 0.05
+FIXTURE_PEN = 0.08     # wall-fixture overlap, measured in the wall's own plane
+MAX_NUDGE = 0.30       # a bigger correction than this is a reconstruction error, not a nudge
+ANCHOR_TOL = 0.12      # gap to a wall under which an object counts as installed against it
+OUTSIDE_TOL = 0.10     # slack on the floor plate before a centre counts as off it
+OPENING_OVERHANG_TOL = 0.10   # how far an opening may run past its wall before it is misplaced
+WALL_SLAB_TOL = 0.02   # how far past a wall's own half-thickness a centre still counts as inside it
+WALL_CROSS_TOL = 0.05  # how far a FOOTPRINT may cross a wall line before it is inside the wall
+FLOOR_OUT_TOL = 0.05   # how far a footprint corner may sit off the floor plate
+SEPARATION = 0.005     # extra clearance, so a resolved pair is separated and not merely touching
+MAX_ITERS = 60
+
+# Things people slide around: standing against a wall is where they happen to be, not where they
+# belong. Everything else (counters, cabinets, baths, appliances) is INSTALLED — once against its
+# wall, that position is load-bearing information from the scan.
+FREE_STANDING = {"chair", "stool", "table", "desk", "sofa", "television"}
+
+
+@dataclass
+class Violation:
+    """One finding. ``severity`` separates a DEFECT from an observation worth recording.
+
+    ``info`` findings are things the geometry cannot distinguish from a fault but which are almost
+    always correct — a wall cabinet is not touching the floor because it is bolted to a wall. They
+    are reported, never "fixed", and never counted as failures. Dropping them silently would hide
+    the one case that IS a fault (a cabinet floating nowhere near a wall); calling them errors
+    buries the real findings, which is what upstream does: 21 of its 39 findings across these
+    scans are wall-hung kitchen units.
+    """
+
+    object: str
+    kind: str
+    detail: str
+    magnitude: float = 0.0
+    other: str | None = None
+    severity: str = "error"          # error | info
+
+    def __str__(self) -> str:
+        return f"{self.object:16} {self.kind:22} {self.detail}"
+
+
+@dataclass
+class Move:
+    object: str
+    before: list[float]
+    after: list[float]
+    distance: float
+    reason: str
+
+    def __str__(self) -> str:
+        return (f"{self.object:16} {self.distance * 100:5.1f} cm  "
+                f"({self.before[0]:.3f},{self.before[1]:.3f}) -> "
+                f"({self.after[0]:.3f},{self.after[1]:.3f})   {self.reason}")
+
+
+@dataclass
+class AdjustResult:
+    shell: dict[str, Any]
+    moves: list[Move] = field(default_factory=list)
+    before: list[Violation] = field(default_factory=list)
+    after: list[Violation] = field(default_factory=list)
+    unresolved: list[Violation] = field(default_factory=list)
+    iterations: int = 0
+
+    @staticmethod
+    def _errors(items: list[Violation]) -> list[Violation]:
+        return [v for v in items if v.severity == "error"]
+
+    @property
+    def errors_before(self) -> list[Violation]:
+        return self._errors(self.before)
+
+    @property
+    def errors_after(self) -> list[Violation]:
+        return self._errors(self.after)
+
+    @property
+    def notes(self) -> list[Violation]:
+        return [v for v in self.after if v.severity == "info"]
+
+    @property
+    def resolved(self) -> int:
+        return len(self.errors_before) - len(self.errors_after)
+
+    def report(self) -> str:
+        lines = [f"layout adjustment: {len(self.errors_before)} violations in, "
+                 f"{len(self.errors_after)} out ({self.iterations} iterations, "
+                 f"{len(self.moves)} objects moved)"]
+        if self.errors_before:
+            lines.append("  before:")
+            lines += [f"    ✗ {v}" for v in self.errors_before]
+        if self.moves:
+            lines.append("  moves:")
+            lines += [f"    → {m}" for m in self.moves]
+        lines.append("  after:")
+        lines += ([f"    ✗ {v}" for v in self.errors_after] if self.errors_after
+                  else ["    ✓ clean — no geometric violations"])
+        if self.notes:
+            lines.append("  noted (correct, not defects):")
+            lines += [f"    · {v}" for v in self.notes]
+        return "\n".join(lines)
+
+
+# ── shared geometry ──────────────────────────────────────────────────────────
+def _obb(obj: dict[str, Any], position: tuple[float, float] | None = None):
+    cx, cy = position if position else (obj["center"][0], obj["center"][1])
+    return (cx, cy, obj["size"][0] / 2.0, obj["size"][1] / 2.0, math.radians(obj.get("yaw", 0.0)))
+
+
+def _support(obj: dict[str, Any], direction) -> float:
+    hw, hd = obj["size"][0] / 2.0, obj["size"][1] / 2.0
+    yaw = math.radians(obj.get("yaw", 0.0))
+    c, s = math.cos(yaw), math.sin(yaw)
+    return (abs(hw * (c * direction[0] + s * direction[1]))
+            + abs(hd * (-s * direction[0] + c * direction[1])))
+
+
+def _floor_bounds(shell: dict[str, Any]) -> tuple[np.ndarray, np.ndarray] | None:
+    verts = np.asarray((shell.get("floor") or {}).get("verts") or [], dtype=float)
+    if len(verts) == 0:
+        walls = shell.get("walls") or {}
+        pts = [p for w in walls.values() for p in (w["start"], w["end"])]
+        if not pts:
+            return None
+        verts = np.asarray(pts, dtype=float)
+    return verts[:, 0:2].min(axis=0), verts[:, 0:2].max(axis=0)
+
+
+def _wall_slab(wall: dict[str, Any]) -> float:
+    """Half-width of the band a centre must be outside of to be clear of this wall.
+
+    RoomPlan reports walls as planes — thicknesses of 0.1 mm are common — so the wall's own
+    geometry is too thin to test against, and :data:`WALL_SLAB_TOL` is what actually decides.
+    ``_in_wall`` and ``_wall_escape`` both measure against this, so the band a repair aims to clear
+    is by construction the band the check complains about.
+    """
+    return wall.get("thickness", 0.1) / 2.0 + WALL_SLAB_TOL
+
+
+def _in_wall(obj: dict[str, Any], walls: dict[str, Any], position=None) -> str | None:
+    """Is this object's CENTRE inside a wall slab? Furniture merely resting against a wall has its
+    centre about half its depth away, well outside a 1 mm RoomPlan slab, so this does not fire on it."""
+    cx, cy = position if position else (obj["center"][0], obj["center"][1])
+    centre = np.array([cx, cy])
+    for wall_id, wall in (walls or {}).items():
+        start, along, normal, length = wall_frame(wall)
+        rel = centre - start
+        t = float(np.dot(rel, along))
+        if 0.0 <= t <= length and abs(float(np.dot(rel, normal))) < _wall_slab(wall):
+            return wall_id
+    return None
+
+
+def _floor_triangles(shell: dict[str, Any]) -> list[tuple] | None:
+    """The floor plate as XY triangles, or None when the scan gave no usable mesh.
+
+    ``floor`` is a TRIANGLE MESH, not a boundary ring: MIL-Meeting's is 30 vertices and 16 faces,
+    with every vertex duplicated, and consecutive entries a median of 2.8 m apart. Ray-casting that
+    vertex list as if it were an ordered polygon returns an arbitrary answer — it only looks right
+    on the synthetic rooms, whose plate happens to be a 4-vertex quad. Going through ``faces`` is
+    the only reading that works on both, and it handles an L-shaped or multi-room plate for free,
+    since "inside" is just "inside any triangle".
+    """
+    floor = shell.get("floor") or {}
+    verts = np.asarray(floor.get("verts") or [], dtype=float)
+    faces = floor.get("faces")
+    if len(verts) < 3 or not faces:
+        return None
+    return [(verts[a][:2], verts[b][:2], verts[c][:2]) for a, b, c in faces
+            if max(a, b, c) < len(verts)]
+
+
+def _inside_floor(point, triangles: list[tuple]) -> bool:
+    """Is this XY point on the floor plate? Inside any one of its triangles."""
+    def side(p, q, r):
+        return (p[0] - r[0]) * (q[1] - r[1]) - (q[0] - r[0]) * (p[1] - r[1])
+
+    for a, b, c in triangles:
+        d1, d2, d3 = side(point, a, b), side(point, b, c), side(point, c, a)
+        if not (((d1 < 0) or (d2 < 0) or (d3 < 0)) and ((d1 > 0) or (d2 > 0) or (d3 > 0))):
+            return True
+    return False
+
+
+def _outside(position, bounds) -> bool:
+    """Is this centre off the floor plate? The single definition — ``check`` and the move
+    validator both call it, so the tolerance cannot drift between detecting and repairing."""
+    low, high = bounds
+    return not (low[0] - OUTSIDE_TOL <= position[0] <= high[0] + OUTSIDE_TOL
+                and low[1] - OUTSIDE_TOL <= position[1] <= high[1] + OUTSIDE_TOL)
+
+
+def _interior_normal(wall: dict[str, Any], polygon, centroid) -> np.ndarray:
+    """Which way out of this wall is INTO the room.
+
+    A wall's normal has no inherent sign, and pushing a buried object out of the wrong face puts it
+    in the corridor next door. The floor plate settles it: probe just off each face and keep the
+    side that is inside it. An interior partition has room on both sides and no probe can decide —
+    there the room centroid is the tie-break, which is the best available guess and is why this
+    returns a direction rather than a certainty.
+    """
+    start, along, normal, length = wall_frame(wall)
+    mid = start + along * (length / 2.0)
+    if polygon is not None:
+        probe = wall.get("thickness", 0.1) / 2.0 + 0.10
+        plus, minus = (_inside_floor(mid + normal * probe, polygon),
+                       _inside_floor(mid - normal * probe, polygon))
+        if plus != minus:
+            return normal if plus else -normal
+    if centroid is not None:
+        return normal if float(np.dot(np.asarray(centroid, float) - mid, normal)) >= 0 else -normal
+    return normal
+
+
+def _wall_escape(obj: dict[str, Any], wall: dict[str, Any], inward: np.ndarray,
+                 position) -> tuple[float, float]:
+    """Where a box buried in a wall belongs: its back face on that wall's own line.
+
+    Not "just far enough that ``check`` stops complaining" — clearing the centre out of a 4 cm slab
+    takes 4 cm and leaves the object 90% inside the wall, which passes the check and fails the
+    room. The target is where a unit standing at a wall actually sits, which is measured rather
+    than assumed: across 324 synthetic and 139 captured wall-standing objects the median distance
+    from centre to wall line is exactly the box's own support in that direction — back face on the
+    line, not on the face of the slab. RoomPlan reports walls as planes and reconstructs the unit
+    up to that plane, so adding half a thickness on top of it overshoots every repair by ~2 cm and
+    pushes borderline ones past the nudge cap for no gain.
+    """
+    start, along, normal, length = wall_frame(wall)
+    centre = np.asarray(position, dtype=float)
+    # Far enough that the box is out of the wall, AND far enough that the check agrees it is. The
+    # second is not implied by the first: a 3 cm wardrobe panel on a 0.1 mm wall is clear of the
+    # slab 1.6 cm out and still inside the tolerance band, so aiming at the geometry alone produces
+    # a move that is immediately reverted for landing back in the wall it just left.
+    clear = max(_support(obj, inward), _wall_slab(wall) + SEPARATION)
+    perp = float(np.dot(centre - start, inward))
+    if perp >= clear:
+        return float(centre[0]), float(centre[1])
+    target = centre + inward * (clear - perp)
+    return float(target[0]), float(target[1])
+
+
+def _wall_crossing(obj: dict[str, Any], wall: dict[str, Any], position=None) -> float:
+    """How far this object's FOOTPRINT crosses the wall's line, within that wall's own segment.
+
+    The test that matters, and the one the centre cannot express. RoomPlan reports walls as planes
+    — thicknesses of 0.1 mm are normal — so "is the centre inside the slab" asks whether the centre
+    is within about 4 cm of the line, and a 1.4 m table can cross a wall by half a metre with its
+    centre comfortably in the room. Across the 21 captures that is 18 objects through walls, of
+    which the centre test finds none.
+
+    Two conditions, both necessary. The footprint must have corners on BOTH sides of the line, so
+    an object standing in the next room is not reported as being a wall's depth "inside" it; and
+    those corners must project within the wall's own extent, so a wall does not act as an infinite
+    half-space across the whole floor plan. The depth returned is the shallower side — by
+    construction the shortest move that would take the box off the line.
+    """
+    start, along, normal, length = wall_frame(wall)
+    corners = object_footprint(obj)
+    if position is not None:
+        corners = corners + (np.asarray(position, dtype=float)
+                             - np.asarray(obj["center"][:2], dtype=float))
+    along_t = [float(np.dot(c - start, along)) for c in corners]
+    if max(along_t) < -0.05 or min(along_t) > length + 0.05:
+        return 0.0
+    perp = [float(np.dot(c - start, normal)) for c in corners]
+    if min(perp) >= 0.0 or max(perp) <= 0.0:
+        return 0.0                       # entirely on one side: not a crossing
+    return min(-min(perp), max(perp))
+
+
+def _worst_wall_crossing(obj, walls, position=None) -> tuple[str, float] | None:
+    worst: tuple[str, float] | None = None
+    for wall_id, wall in (walls or {}).items():
+        depth = _wall_crossing(obj, wall, position)
+        if depth > WALL_CROSS_TOL and (worst is None or depth > worst[1]):
+            worst = (wall_id, depth)
+    return worst
+
+
+def _off_floor(obj: dict[str, Any], triangles, position=None) -> float:
+    """How far the footprint's worst corner lies off the floor plate. 0 when it is all on it."""
+    if not triangles:
+        return 0.0
+    corners = object_footprint(obj)
+    if position is not None:
+        corners = corners + (np.asarray(position, dtype=float)
+                             - np.asarray(obj["center"][:2], dtype=float))
+    outside = [c for c in corners if not _inside_floor(c, triangles)]
+    if not outside:
+        return 0.0
+
+    def edge_distance(point, a, b) -> float:
+        ab = b - a
+        length_sq = float(np.dot(ab, ab)) or 1e-12
+        t = max(0.0, min(1.0, float(np.dot(point - a, ab)) / length_sq))
+        return float(np.linalg.norm(point - (a + t * ab)))
+
+    return max(min(min(edge_distance(c, t[i], t[(i + 1) % 3]) for i in range(3))
+                   for t in triangles) for c in outside)
+
+
+def _fixture_escape(obj: dict[str, Any], wall: dict[str, Any], opening: dict[str, Any],
+                    position) -> tuple[float, float] | None:
+    """Slide a wall fixture along its wall until it is off an opening. None if it cannot be.
+
+    Along the wall, never off it: a television reads as mounted over a window because one of the
+    two is a few centimetres out, and the fix is to put the fixture beside the window on the wall
+    it is actually on. Moving it away from the wall would unmount it, and moving it up or down is
+    the one degree of freedom a scan cannot justify. Whichever side is nearer wins; if neither side
+    has room left on the wall, this returns None and the violation stands.
+    """
+    start, along, _normal, length = wall_frame(wall)
+    centre = np.asarray(position, dtype=float)
+    t = float(np.dot(centre - start, along))
+    half = _support(obj, along)
+    o0, o1 = opening_span(opening)
+    options = [target for target in (o0 - half - SEPARATION, o1 + half + SEPARATION)
+               if half <= target <= length - half]
+    if not options:
+        return None
+    moved = centre + along * (min(options, key=lambda target: abs(target - t)) - t)
+    return float(moved[0]), float(moved[1])
+
+
+def _return_inside(obj: dict[str, Any], bounds, position) -> tuple[float, float]:
+    """Slide a box that is off the floor plate back onto it — footprint and all, not just centre."""
+    low, high = bounds
+    out = [float(position[0]), float(position[1])]
+    for axis, direction in ((0, np.array([1.0, 0.0])), (1, np.array([0.0, 1.0]))):
+        support = _support(obj, direction)
+        lo, hi = low[axis] + support, high[axis] - support
+        if lo > hi:                       # the plate is narrower than the object — centre it
+            lo = hi = (low[axis] + high[axis]) / 2.0
+        out[axis] = min(max(out[axis], lo), hi)
+    return out[0], out[1]
+
+
+def _anchored(obj: dict[str, Any], walls: dict[str, Any]) -> bool:
+    """Installed against a wall → it stays put and the other side of the pair moves."""
+    if obj.get("category", "") in FREE_STANDING:
+        return False
+    for wall in (walls or {}).values():
+        measured = wall_distance(obj, wall)
+        if measured is not None and measured[0] < ANCHOR_TOL:
+            return True
+    return False
+
+
+# ── DETECT ───────────────────────────────────────────────────────────────────
+def check(shell: dict[str, Any]) -> list[Violation]:
+    """Every geometric violation in a SHELL. Pure arithmetic — no Blender, no compiled glb."""
+    walls = shell.get("walls") or {}
+    objects = shell.get("objects") or {}
+    openings = shell.get("openings") or {}
+    floor_z = float(shell.get("floor_z", 0.0))
+    ceiling_z = float(shell.get("ceiling_z", floor_z + 2.5))
+    bounds = _floor_bounds(shell)
+    triangles = _floor_triangles(shell)
+
+    out: list[Violation] = []
+    for object_id, obj in objects.items():
+        category = obj.get("category", "")
+        bottom = obj["center"][2] - obj["size"][2] / 2.0
+        top = obj["center"][2] + obj["size"][2] / 2.0
+        if bottom < floor_z - Z_TOL:
+            out.append(Violation(object_id, "below_floor",
+                                 f"bottom {bottom:.2f} < floor {floor_z:.2f}", floor_z - bottom))
+        if top > ceiling_z + Z_TOL:
+            out.append(Violation(object_id, "above_ceiling",
+                                 f"top {top:.2f} > ceiling {ceiling_z:.2f}", top - ceiling_z))
+        if category in FLOOR_STANDING:
+            gap = bottom - floor_z
+            hung = is_wall_hung(obj, walls, floor_z)
+            if gap > FLOAT_TOL and hung:
+                out.append(Violation(object_id, "wall_hung",
+                                     f"{gap:.2f} m above the floor, mounted on {hung}",
+                                     gap, hung, severity="info"))
+            elif gap > FLOAT_TOL:
+                out.append(Violation(object_id, "floating", f"{gap:.2f} m above the floor", gap))
+            elif gap < -SUNK_TOL:
+                out.append(Violation(object_id, "sunk", f"{-gap:.2f} m into the floor", -gap))
+        if triangles:
+            off = _off_floor(obj, triangles)
+            if off > FLOOR_OUT_TOL:
+                out.append(Violation(object_id, "outside_room",
+                                     f"footprint {off:.2f} m off the floor plate", off))
+        elif bounds is not None and _outside(obj["center"][:2], bounds):
+            cx, cy = obj["center"][0], obj["center"][1]
+            out.append(Violation(object_id, "outside_room",
+                                 f"centre ({cx:.2f},{cy:.2f}) outside the footprint"))
+        if category in FURNITURE:
+            crossed = _worst_wall_crossing(obj, walls)
+            if crossed:
+                out.append(Violation(object_id, "wall_clash",
+                                     f"footprint {crossed[1]:.2f} m into {crossed[0]}",
+                                     crossed[1], crossed[0]))
+            elif _in_wall(obj, walls):
+                hit = _in_wall(obj, walls)
+                out.append(Violation(object_id, "wall_clash", f"centre inside {hit}", other=hit))
+
+    ids = list(objects)
+    for i in range(len(ids)):
+        for j in range(i + 1, len(ids)):
+            a_id, b_id = ids[i], ids[j]
+            a, b = objects[a_id], objects[b_id]
+            cat_a, cat_b = a.get("category", ""), b.get("category", "")
+            if expected_pair(cat_a, cat_b):
+                continue
+            if {cat_a, cat_b} & (PASSTHROUGH | OPEN_FRAME):
+                continue
+            a_bottom, a_top = a["center"][2] - a["size"][2] / 2, a["center"][2] + a["size"][2] / 2
+            b_bottom, b_top = b["center"][2] - b["size"][2] / 2, b["center"][2] + b["size"][2] / 2
+            if min(a_top, b_top) - max(a_bottom, b_bottom) <= Z_BAND_TOL:
+                continue
+            mtv = obb_mtv(_obb(a), _obb(b))
+            if mtv and mtv[0] > CLASH_TOL:
+                out.append(Violation(a_id, "object_clash",
+                                     f"footprint into {b_id} ~{mtv[0]:.2f} m", mtv[0], b_id))
+
+    # an opening that runs off the end of the wall that hosts it. RoomPlan puts a door in a wall's
+    # folder even when the geometry straddles a corner, so `offset + width` can exceed the wall
+    # length — MIL-Meeting's Door1 overhangs Wall1 by 0.55 m. Nothing downstream notices, and the
+    # opening is then cut in the wrong place (or off the end, i.e. not at all).
+    for opening_id, opening in openings.items():
+        wall = walls.get(opening.get("wall") or "")
+        if not wall:
+            out.append(Violation(opening_id, "orphan_opening", "not hosted by any wall"))
+            continue
+        length = wall_frame(wall)[3]
+        t0, t1 = opening_span(opening)
+        overhang = max(-t0, t1 - length)
+        if overhang > OPENING_OVERHANG_TOL:
+            out.append(Violation(opening_id, "opening_off_wall",
+                                 f"runs {overhang:.2f} m past {opening['wall']} "
+                                 f"(len {length:.2f} m)", overhang, opening.get("wall")))
+
+    # a wall fixture sitting over a door or window, measured in the wall's own plane
+    for opening_id, opening in openings.items():
+        wall = walls.get(opening.get("wall") or "")
+        if not wall:
+            continue
+        start, along, normal, length = wall_frame(wall)
+        o0, o1 = opening_span(opening)
+        sill = floor_z + opening.get("sill", 0.0)
+        z0, z1 = sill, sill + opening["height"]
+        for object_id, obj in objects.items():
+            if obj.get("category", "") not in WALL_MOUNTED:
+                continue
+            measured = wall_distance(obj, wall)
+            if measured is None or measured[0] > 0.75:
+                continue
+            t = measured[1]
+            half = _support(obj, along)
+            bottom = obj["center"][2] - obj["size"][2] / 2.0
+            top = obj["center"][2] + obj["size"][2] / 2.0
+            overlap_t = min(t + half, o1) - max(t - half, o0)
+            overlap_z = min(top, z1) - max(bottom, z0)
+            if overlap_t > FIXTURE_PEN and overlap_z > FIXTURE_PEN:
+                out.append(Violation(object_id, "fixture_over_opening",
+                                     f"sits over {opening_id} on {opening['wall']} "
+                                     f"~{min(overlap_t, overlap_z):.2f} m",
+                                     min(overlap_t, overlap_z), opening_id))
+    return out
+
+
+# ── REPAIR ───────────────────────────────────────────────────────────────────
+def ground(shell: dict[str, Any]) -> tuple[dict[str, Any], list[Move]]:
+    """Vertical placement: drop what is floating onto the floor, pull what pokes through the
+    ceiling back under it. Z only, so it commutes with the XY solver.
+
+    The two passes are ordered, not alternatives. An object lifted through the ceiling is usually
+    *also* floating, and dropping it to the floor is the repair that puts it back where it belongs;
+    the ceiling clamp is what is left for the ones grounding cannot claim — a wall-hung cabinet has
+    no floor contact to restore, so the most that can be said about it is that its top is not
+    outside the room.
+    """
+    shell = copy.deepcopy(shell)
+    floor_z = float(shell.get("floor_z", 0.0))
+    ceiling_z = float(shell.get("ceiling_z", floor_z + 2.5))
+    moves: list[Move] = []
+    for object_id, obj in (shell.get("objects") or {}).items():
+        if obj.get("category", "") not in FLOOR_STANDING:
+            continue
+        if is_wall_hung(obj, shell.get("walls") or {}, floor_z):
+            continue                       # bolted to a wall — dropping it to the floor is wrong
+        bottom = obj["center"][2] - obj["size"][2] / 2.0
+        delta = floor_z - bottom
+        if abs(delta) <= max(FLOAT_TOL, SUNK_TOL):
+            continue
+        if abs(delta) > MAX_NUDGE * 2:
+            continue                       # a metre off the floor is a missing support, not a slip
+        before = list(obj["center"])
+        obj["center"][2] = round(obj["center"][2] + delta, 4)
+        moves.append(Move(object_id, before, list(obj["center"]), abs(delta), "grounded to floor_z"))
+
+    settled = {move.object for move in moves}
+    for object_id, obj in (shell.get("objects") or {}).items():
+        if object_id in settled:
+            continue
+        height = obj["size"][2]
+        overshoot = obj["center"][2] + height / 2.0 - ceiling_z
+        if overshoot <= Z_TOL:
+            continue
+        if height > ceiling_z - floor_z:
+            continue                       # taller than the room: a size error, not a placement one
+        # With the box no taller than the room, clearing the ceiling can never drive it through the
+        # floor: bottom - drop = floor_z + (ceiling_z - floor_z - height) - 0.001 >= floor_z.
+        drop = overshoot + 0.001
+        if drop > MAX_NUDGE * 2:
+            continue                       # a metre through the ceiling is not a slip either
+        before = list(obj["center"])
+        obj["center"][2] = round(obj["center"][2] - drop, 4)
+        moves.append(Move(object_id, before, list(obj["center"]), drop, "lowered under ceiling_z"))
+    return shell, moves
+
+
+def reseat_openings(shell: dict[str, Any]) -> tuple[dict[str, Any], list[Move]]:
+    """Slide an opening that runs off the end of its wall back onto it.
+
+    RoomPlan files a door under one wall while placing its geometry across the corner into the
+    next, so ``offset + width / 2`` can exceed the wall it is hosted by — MIL-Meeting's Door1
+    overhangs Wall1 by 0.55 m in the real capture. An opening that is not on its wall is not cut
+    where the door is, so the compiled room has a doorway in a solid wall and a hole in the wrong
+    one. Clamping the span into the wall is the minimal repair and the one that needs no guess.
+    The deeper fix — re-hosting the opening to the wall its geometry actually crosses — needs the
+    neighbouring wall's frame to agree, so it is left to whoever has that evidence.
+    """
+    shell = copy.deepcopy(shell)
+    walls = shell.get("walls") or {}
+    moves: list[Move] = []
+    for opening_id, opening in (shell.get("openings") or {}).items():
+        wall = walls.get(opening.get("wall") or "")
+        if not wall:
+            continue                       # orphaned: no wall to slide along. Reported, not guessed.
+        start, along, _normal, length = wall_frame(wall)
+        t0, t1 = opening_span(opening)
+        if max(-t0, t1 - length) <= OPENING_OVERHANG_TOL:
+            continue
+        half = opening["width"] / 2.0
+        if opening["width"] > length:
+            continue                       # wider than the wall it is on — not a placement fault
+        offset = min(max(opening["offset"], half), length - half)
+        before, after = start + along * opening["offset"], start + along * offset
+        distance = abs(offset - opening["offset"])
+        opening["offset"] = round(float(offset), 4)
+        moves.append(Move(opening_id, [float(before[0]), float(before[1])],
+                          [float(after[0]), float(after[1])], distance,
+                          f"slid back onto {opening['wall']}"))
+    return shell, moves
+
+
+def _clashing_pairs(objects: dict[str, Any], positions: dict[str, tuple[float, float]]):
+    """Every genuine interpenetration at the given positions → (a, b, depth, axis)."""
+    out = []
+    ids = list(objects)
+    for i in range(len(ids)):
+        for j in range(i + 1, len(ids)):
+            a_id, b_id = ids[i], ids[j]
+            a, b = objects[a_id], objects[b_id]
+            cat_a, cat_b = a.get("category", ""), b.get("category", "")
+            if expected_pair(cat_a, cat_b) or ({cat_a, cat_b} & (PASSTHROUGH | OPEN_FRAME)):
+                continue
+            a_bottom, a_top = a["center"][2] - a["size"][2] / 2, a["center"][2] + a["size"][2] / 2
+            b_bottom, b_top = b["center"][2] - b["size"][2] / 2, b["center"][2] + b["size"][2] / 2
+            if min(a_top, b_top) - max(a_bottom, b_bottom) <= Z_BAND_TOL:
+                continue
+            mtv = obb_mtv(_obb(a, positions[a_id]), _obb(b, positions[b_id]))
+            if mtv and mtv[0] > CLASH_TOL:
+                out.append((a_id, b_id, mtv[0], mtv[1]))
+    return out
+
+
+def resolve(shell: dict[str, Any], *, max_nudge: float = MAX_NUDGE,
+            max_iters: int = MAX_ITERS, do_ground: bool = True,
+            do_openings: bool = True) -> AdjustResult:
+    """Put the room back inside itself, then nudge what interpenetrates apart."""
+    original = copy.deepcopy(shell)
+    before = check(original)
+
+    working = copy.deepcopy(shell)
+    moves: list[Move] = []
+    if do_ground:
+        working, moves = ground(working)
+    if do_openings:
+        working, opening_moves = reseat_openings(working)
+        moves += opening_moves
+
+    objects = working.get("objects") or {}
+    walls = working.get("walls") or {}
+    start = {oid: (o["center"][0], o["center"][1]) for oid, o in objects.items()}
+    positions = dict(start)
+    anchored = {oid: _anchored(o, walls) for oid, o in objects.items()}
+    reasons: dict[str, str] = {}
+
+    # --- containment, before anything is relaxed ----------------------------
+    # A wall is not in `objects` and the floor plate is not a box, so neither of these faults is
+    # visible to the pair loop below; and an object buried in a wall has no clash worth separating
+    # until it is out of it. Both fire only where `check` reports, so nothing undamaged is touched,
+    # and both run first so that whatever the correction pushes them into is resolved as a clash.
+    polygon = _floor_triangles(working)
+    bounds = _floor_bounds(working)
+    centroid = (bounds[0] + bounds[1]) / 2.0 if bounds is not None else None
+    openings = working.get("openings") or {}
+    # Driven off `check` itself rather than re-derived, so a repair cannot fire anywhere the
+    # detector is silent — that is what keeps a correctly placed unit from being "corrected" — and
+    # so the two cannot drift apart later. Each takes the running position, so an object with two
+    # findings against it is repaired for both.
+    for violation in check(working):
+        obj = objects.get(violation.object)
+        if obj is None:
+            continue
+        if violation.kind == "wall_clash" and violation.other in walls:
+            wall = walls[violation.other]
+            positions[violation.object] = _wall_escape(
+                obj, wall, _interior_normal(wall, polygon, centroid), positions[violation.object])
+            reasons[violation.object] = f"pushed out of {violation.other}, back against its face"
+        elif violation.kind == "outside_room" and bounds is not None:
+            positions[violation.object] = _return_inside(obj, bounds, positions[violation.object])
+            reasons[violation.object] = "returned onto the floor plate"
+        elif violation.kind == "fixture_over_opening":
+            opening = openings.get(violation.other or "")
+            wall = walls.get((opening or {}).get("wall") or "") if opening else None
+            slid = _fixture_escape(obj, wall, opening, positions[violation.object]) if wall else None
+            if slid is not None:
+                positions[violation.object] = slid
+                reasons[violation.object] = f"slid clear of {violation.other}"
+
+    iterations = 0
+    for iterations in range(1, max_iters + 1):
+        pairs = _clashing_pairs(objects, positions)
+        if not pairs:
+            break
+        for a_id, b_id, depth, axis in pairs:
+            push = depth + SEPARATION
+            a_fixed, b_fixed = anchored[a_id], anchored[b_id]
+            if a_fixed and b_fixed:
+                continue                          # both installed — report it, never force it
+            share_a, share_b = (0.0, 1.0) if a_fixed else (1.0, 0.0) if b_fixed else (0.5, 0.5)
+            ax, ay = positions[a_id]
+            bx, by = positions[b_id]
+            positions[a_id] = (ax - axis[0] * push * share_a, ay - axis[1] * push * share_a)
+            positions[b_id] = (bx + axis[0] * push * share_b, by + axis[1] * push * share_b)
+    else:
+        pairs = _clashing_pairs(objects, positions)
+
+    # --- validate every move, revert the ones that made things worse ---------
+    for object_id, obj in objects.items():
+        new = positions[object_id]
+        old = start[object_id]
+        distance = math.dist(new, old)
+        if distance < 1e-4:
+            positions[object_id] = old
+            continue
+        reason = None
+        if distance > max_nudge:
+            reason = f"needs {distance * 100:.0f} cm, over the {max_nudge * 100:.0f} cm cap"
+        elif _in_wall(obj, walls, new):
+            reason = f"would push the centre into {_in_wall(obj, walls, new)}"
+        elif bounds is not None and _outside(new, bounds):
+            reason = "would leave the floor footprint"
+        if reason:
+            positions[object_id] = old
+            obj["_reverted"] = reason
+        else:
+            obj["center"][0], obj["center"][1] = round(new[0], 4), round(new[1], 4)
+            moves.append(Move(object_id, [old[0], old[1]], [new[0], new[1]], distance,
+                              reasons.get(object_id,
+                                          "separated along the minimum translation vector")))
+
+    unresolved: list[Violation] = []
+    for object_id, obj in objects.items():
+        note = obj.pop("_reverted", None)
+        if note:
+            unresolved.append(Violation(object_id, "unresolved", note))
+    for a_id, b_id, depth, _axis in _clashing_pairs(objects, positions):
+        if anchored[a_id] and anchored[b_id]:
+            unresolved.append(Violation(a_id, "unresolved",
+                                        f"both {a_id} and {b_id} are installed against a wall "
+                                        f"(~{depth:.2f} m overlap)", depth, b_id))
+
+    return AdjustResult(shell=working, moves=moves, before=before, after=check(working),
+                        unresolved=unresolved, iterations=iterations)

--- a/src/litereality_agent/pipeline/scene_init/layout/agent.py
+++ b/src/litereality_agent/pipeline/scene_init/layout/agent.py
@@ -160,8 +160,9 @@ def _reflush(shell: dict[str, Any], object_id: str, prefer: str | None = None) -
     the room says it is and its back face belongs on the wall, so the model is asked only for the
     size and the geometry decides the placement that follows from it.
     """
-    from .repair import _flush_to, attachments as _attachments
     from .adjust import _floor_bounds, _floor_triangles
+    from .repair import _flush_to
+    from .repair import attachments as _attachments
 
     obj = shell["objects"][object_id]
     walls = shell.get("walls") or {}

--- a/src/litereality_agent/pipeline/scene_init/layout/agent.py
+++ b/src/litereality_agent/pipeline/scene_init/layout/agent.py
@@ -1,0 +1,313 @@
+"""agent.py — the last resort: ask a model to look at the photograph.
+
+Everything up to v9 is geometry, and geometry has an answer for a box in the wrong PLACE. It has
+no answer for a box of the wrong SIZE, and that is what the residual failures turn out to be:
+Kitchen's ``Oven_Storage_Stove0`` is a merged run recorded as 2.53 x 1.47 m, and no kitchen counter
+is a metre and a half deep. It reads as half a metre inside the wall behind it because the box is
+too deep, not because the unit is misplaced, so every translation the solver can make is the wrong
+move — slide it out and it collides with the island, slide it along and it is still too deep.
+
+The scan does contain the answer, in the reference crops :mod:`physical_engine.views` already
+ranked and wrote out: a photograph of that counter with its box drawn on it. This module hands the
+model that image, the geometry, and the violation, and asks what is actually wrong.
+
+Nothing it proposes is trusted. Every edit is applied to a copy and kept ONLY if the violation
+count falls, no wall anchor is broken, and the change stays inside stated bounds. A proposal that
+fails any of those is dropped and recorded. That gate is the whole reason this is safe to include:
+the model chooses what to try, the geometry decides what is true.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import math
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from .adjust import ANCHOR_TOL, check
+from .graph import wall_distance
+from .shell import wall_frame
+
+__all__ = ["propose", "apply_proposals", "solve_v10"]
+
+MAX_SCALE = 0.60          # a proposal may not change a dimension by more than this fraction
+MAX_SHIFT = 0.60          # nor move a centre further than this, in metres
+TIMEOUT = 420
+
+
+def _anchors(shell: dict[str, Any]) -> dict[str, set[str]]:
+    walls = shell.get("walls") or {}
+    out: dict[str, set[str]] = {}
+    for oid, obj in (shell.get("objects") or {}).items():
+        held = {wid for wid, w in walls.items()
+                if (m := wall_distance(obj, w)) is not None and abs(m[0]) <= ANCHOR_TOL}
+        if held:
+            out[oid] = held
+    return out
+
+
+def _context(shell: dict[str, Any], violation, batch_dir: Path) -> dict[str, Any]:
+    objects = shell.get("objects") or {}
+    obj = objects.get(violation.object)
+    if obj is None:
+        return {}
+    walls = shell.get("walls") or {}
+    near_walls = {}
+    for wid, w in walls.items():
+        measured = wall_distance(obj, w)
+        # the wall named in the violation goes in whatever its distance: the model spotted this
+        # itself, replying "Wall6 isn't even in the provided wall list" for a Wall6 collision
+        if wid == violation.other or (measured is not None and abs(measured[0]) < 1.2):
+            if measured is None:
+                start, along, normal, length = wall_frame(w)
+                near_walls[wid] = {"start": [round(v, 3) for v in w["start"]],
+                                   "end": [round(v, 3) for v in w["end"]],
+                                   "length": round(length, 3), "gap_to_object": None}
+                continue
+            start, along, normal, length = wall_frame(w)
+            near_walls[wid] = {"start": [round(v, 3) for v in w["start"]],
+                               "end": [round(v, 3) for v in w["end"]],
+                               "length": round(length, 3),
+                               "gap_to_object": round(measured[0], 3)}
+    neighbours = {oid: {"category": o.get("category"), "size": [round(v, 3) for v in o["size"]],
+                        "center": [round(v, 3) for v in o["center"]]}
+                  for oid, o in objects.items()
+                  if oid != violation.object
+                  and math.dist(o["center"][:2], obj["center"][:2]) < 2.5}
+    refs = sorted((batch_dir / "references" / violation.object).glob("rank*.jpg"))[:2]
+    return {"object_id": violation.object,
+            "object": {"category": obj.get("category"), "size": [round(v, 3) for v in obj["size"]],
+                       "center": [round(v, 3) for v in obj["center"]], "yaw": obj.get("yaw")},
+            "violation": {"kind": violation.kind, "detail": violation.detail,
+                          "other": violation.other},
+            "walls": near_walls, "neighbours": neighbours,
+            "reference_images": [str(p) for p in refs]}
+
+
+PROMPT = """You are correcting a 3-D room reconstructed from an iPhone RoomPlan scan.
+
+The object below is back at ITS ORIGINAL SCANNED POSE. A deterministic solver did produce a legal
+arrangement for it, but only by {suspicion} — which a person looking at the room would not accept.
+Its attempt has been undone so you are judging the real measurement, not its guess.
+
+{context}
+
+The reference images listed above are photographs from the scan with this object's reconstructed
+box drawn on them. READ THEM with the Read tool before answering — they are the evidence for
+whether the box actually bounds the thing it claims to.
+
+A solver has already tried translation and failed, so consider that the BOX may be wrong rather
+than its position: RoomPlan merges adjacent units and routinely records a counter run deeper than
+it is, which makes it read as buried in the wall behind it.
+
+Think about what is actually wrong, the way a person would. Usually it is one of:
+  * the box is recorded DEEPER than the thing it bounds, because RoomPlan merged it with the wall
+    or the unit beside it  -> "resize"
+  * it belongs flush in a corner, touching two walls, and is a few cm out -> "attach" with both
+    wall ids; the geometry will trim and seat it for you
+  * it belongs against one wall -> "attach" with that single wall id
+  * the measurement is simply right and the violation is the wall's fault -> "none"
+
+Reply with ONLY a JSON object, no prose and no code fence:
+{{"action": "resize" | "translate" | "attach" | "none",
+  "size":   [x, y, z],       // resize only; metres
+  "center": [x, y, z],       // translate only; metres
+  "walls":  ["Wall3", "Wall7"],  // attach only; one or two wall ids from the list above
+  "confidence": 0.0-1.0,
+  "why": "one sentence citing what the photograph shows"}}
+
+Prefer "attach" over "translate" for anything that is furniture against a wall — it preserves the
+alignment a translation destroys. Use "none" if the images do not justify a change. Do not change a
+dimension by more than {scale:.0%} or move a centre more than {shift} m."""
+
+
+def propose(shell: dict[str, Any], violation, batch_dir: Path,
+            model: str = "sonnet", suspicion: str | None = None) -> dict[str, Any] | None:
+    """Ask the model what is wrong with one object. Returns its raw proposal, unvalidated."""
+    context = _context(shell, violation, batch_dir)
+    if not context:
+        return None
+    prompt = PROMPT.format(context=json.dumps(context, indent=2), scale=MAX_SCALE,
+                           shift=MAX_SHIFT, suspicion=suspicion or "moving it a long way")
+    try:
+        done = subprocess.run(
+            ["claude", "-p", prompt, "--output-format", "text", "--model", model,
+             "--allowed-tools", "Read"],
+            capture_output=True, text=True, timeout=TIMEOUT)
+    except subprocess.TimeoutExpired:
+        return {"action": "none", "why": "agent timed out"}
+    text = (done.stdout or "").strip()
+    start, end = text.find("{"), text.rfind("}")
+    if start < 0 or end <= start:
+        return {"action": "none", "why": f"unparseable reply: {text[:120]}"}
+    try:
+        out = json.loads(text[start:end + 1])
+    except json.JSONDecodeError:
+        return {"action": "none", "why": "invalid json"}
+    out["object_id"] = context["object_id"]
+    out["wall"] = violation.other
+    return out
+
+
+def _reflush(shell: dict[str, Any], object_id: str, prefer: str | None = None) -> None:
+    """After a resize, put the unit back against the wall it is installed on.
+
+    Shrinking a box about its centre pulls BOTH faces in, so a counter whose depth was over-measured
+    by half a metre comes out of the wall by only a quarter of it and stays in violation — which is
+    how the first accepted-looking proposal was correctly rejected. A counter's front face is where
+    the room says it is and its back face belongs on the wall, so the model is asked only for the
+    size and the geometry decides the placement that follows from it.
+    """
+    from .repair import _flush_to, attachments as _attachments
+    from .adjust import _floor_bounds, _floor_triangles
+
+    obj = shell["objects"][object_id]
+    walls = shell.get("walls") or {}
+    triangles = _floor_triangles(shell)
+    bounds = _floor_bounds(shell)
+    centroid = (bounds[0] + bounds[1]) / 2.0 if bounds is not None else None
+    import numpy as np
+    found = _attachments(obj, walls, triangles, centroid, tol=0.75)
+    # The wall named in the violation goes first. Flushing against whichever attachment happened to
+    # be found first put this counter against the wall it was already fine with and left it a
+    # quarter of a metre inside the one it was not.
+    found.sort(key=lambda a: a[0] != prefer)
+    for _wid, _heading, wall, _along, inward, _gap in found:
+        start = wall_frame(wall)[0]
+        centre = np.array(obj["center"][:2], float)
+        perp = float(np.dot(centre - start, inward))
+        want = math.copysign(_flush_to(obj, wall, inward), perp if perp else 1.0)
+        moved = centre + inward * (want - perp)
+        obj["center"][0], obj["center"][1] = round(float(moved[0]), 4), round(float(moved[1]), 4)
+
+
+def _bounded(obj, proposal) -> bool:
+    if proposal.get("action") == "attach":
+        walls = proposal.get("walls")
+        return isinstance(walls, list) and 1 <= len(walls) <= 2
+    if proposal.get("action") == "resize":
+        want = proposal.get("size")
+        if not (isinstance(want, list) and len(want) == 3):
+            return False
+        return all(v > 0.05 and abs(v - o) <= MAX_SCALE * o
+                   for v, o in zip(want, obj["size"]))
+    if proposal.get("action") == "translate":
+        want = proposal.get("center")
+        if not (isinstance(want, list) and len(want) == 3):
+            return False
+        return math.dist(want[:2], obj["center"][:2]) <= MAX_SHIFT
+    return False
+
+
+def apply_proposals(shell: dict[str, Any], proposals: list[dict[str, Any]]) -> tuple[dict, list]:
+    """Apply each proposal only if it is bounded, reduces violations, and breaks no anchor."""
+    current = copy.deepcopy(shell)
+    log = []
+    for proposal in proposals:
+        oid = proposal.get("object_id")
+        obj = (current.get("objects") or {}).get(oid or "")
+        if obj is None or proposal.get("action") not in ("resize", "translate", "attach"):
+            log.append({**proposal, "accepted": False, "reason": "no actionable change"})
+            continue
+        if not _bounded(obj, proposal):
+            log.append({**proposal, "accepted": False, "reason": "outside the stated bounds"})
+            continue
+        trial = copy.deepcopy(current)
+        target = trial["objects"][oid]
+        if proposal["action"] == "resize":
+            target["size"] = [round(float(v), 4) for v in proposal["size"]]
+            _reflush(trial, oid, proposal.get("wall"))
+        elif proposal["action"] == "attach":
+            # The model names the walls; the geometry does the fitting. Keeping the arithmetic on
+            # this side is the whole point — the model is good at "that wardrobe belongs in the
+            # corner" and has no business computing the centimetres.
+            from .repair import _corner_fit, _snap_delta
+            names = [w for w in proposal["walls"] if w in (trial.get("walls") or {})]
+            if not names:
+                log.append({**proposal, "accepted": False, "reason": "named no known wall"})
+                continue
+            if len(names) == 2:
+                fitted = _corner_fit(target, trial["walls"][names[0]], trial["walls"][names[1]])
+                if fitted:
+                    target["size"] = fitted
+            for wall_id in names:
+                delta = _snap_delta(target, trial["walls"][wall_id])
+                target["center"][0] = round(target["center"][0] + float(delta[0]), 4)
+                target["center"][1] = round(target["center"][1] + float(delta[1]), 4)
+        else:
+            target["center"] = [round(float(v), 4) for v in proposal["center"]]
+        before = len([v for v in check(current) if v.severity == "error"])
+        after = len([v for v in check(trial) if v.severity == "error"])
+        held_before, held_after = _anchors(current), _anchors(trial)
+        # Anchors of OTHER objects. A unit that is legitimately smaller than it was recorded can no
+        # longer reach both walls of the corner it was merged across, and that is the correction
+        # working, not damage. What must not happen is an edit to one object quietly moving another
+        # off its wall — so the gate is scoped to everything except the object being edited.
+        broke = sum(len(v - held_after.get(k, set()))
+                    for k, v in held_before.items() if k != oid)
+        if after < before and broke == 0:
+            current = trial
+            log.append({**proposal, "accepted": True,
+                        "reason": f"violations {before} -> {after}, no anchor broken"})
+        else:
+            log.append({**proposal, "accepted": False,
+                        "reason": f"violations {before} -> {after}, {broke} anchors broken"})
+    return current, log
+
+
+def _cache_path(root: Path) -> Path:
+    return root / "agent_proposals.json"
+
+
+def solve_v10(shell: dict[str, Any], *, batch_dir: str | Path | None = None,
+              model: str = "sonnet", refresh: bool = False, detail: bool = False):
+    """v9, then one bounded agent pass over whatever geometry could not settle.
+
+    Accepted proposals are CACHED beside the scene. A model asked the same question twice does not
+    give the same answer, and an arena whose score moves between runs cannot tell a real
+    improvement from a reroll — fallside-kitchen passed on one run of this and failed the next with
+    no code change in between. Caching makes the solver reproducible, makes a rebuild free, and
+    means the model is consulted once per finding rather than once per build. Delete the cache, or
+    pass ``refresh``, to ask again.
+    """
+    from .repair import repair as _repair
+
+    out = _repair(shell)[0]
+    errors = [v for v in check(out) if v.severity == "error"]
+    root = Path(batch_dir) if batch_dir else Path(
+        (shell.get("meta") or {}).get("batch_dir") or ".")
+    if not errors or not root.is_dir():
+        return (out, []) if detail else out
+
+    cache_file = _cache_path(root)
+    cached: dict[str, Any] = {}
+    if cache_file.is_file() and not refresh:
+        try:
+            cached = json.loads(cache_file.read_text())
+        except json.JSONDecodeError:
+            cached = {}
+
+    proposals, keys = [], []
+    for violation in errors:
+        key = f"{violation.object}:{violation.kind}:{violation.other or ''}"
+        if key in cached:
+            proposals.append(cached[key])
+            keys.append(key)
+            continue
+        proposal = propose(out, violation, root, model)
+        if proposal:
+            proposals.append(proposal)
+            keys.append(key)
+
+    fixed, log = apply_proposals(out, proposals)
+
+    # ONLY accepted proposals are cached. Storing every reply froze the first thing the model
+    # happened to say, so a scene the agent had repaired on one run stayed broken on every run
+    # afterwards — the cache was preserving its worst answer as eagerly as its best. A rejected
+    # proposal is simply not knowledge, and asking again next time costs one call.
+    keep = {k: p for k, p, entry in zip(keys, proposals, log) if entry.get("accepted")}
+    if keep != cached:
+        cache_file.write_text(json.dumps(keep, indent=1), encoding="utf-8")
+    return (fixed, log) if detail else fixed

--- a/src/litereality_agent/pipeline/scene_init/layout/agent_loop.py
+++ b/src/litereality_agent/pipeline/scene_init/layout/agent_loop.py
@@ -1,0 +1,130 @@
+"""agent_loop.py — hand the room to a reasoning agent and let it work.
+
+The difference from :mod:`physical_engine.agent` is the shape of the interaction. That module asks
+one question per violation and takes one answer; this one gives the agent a scene, a set of verbs,
+and the photographs, and lets it look, act, re-check and change its mind until the room is right.
+That matters because the remaining failures are not single-object questions: on Airbnb-Cam a
+wardrobe, a table and a second table are wrong TOGETHER, and any repair that considers one at a
+time scores worse at every individual step.
+
+The safety property is unchanged and is enforced where it belongs — at the end. The agent works on
+a copy in its own session directory; whatever it produces is scored against the deterministic
+result and is kept ONLY if it is better. A confused agent costs time and nothing else.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from .adjust import check
+from .repair import attachments, repair, score
+from .shell import save_shell
+
+__all__ = ["run_agent", "solve_v14"]
+
+TIMEOUT = 900
+
+BRIEF = """You are fixing the geometry of a room reconstructed from an iPhone RoomPlan scan, so a
+physics engine will accept it. Work in this directory: {session}
+
+Your tools — run them with Bash, exactly as written:
+
+  {py} -m physical_engine.toolcli {session} summary
+  {py} -m physical_engine.toolcli {session} object <ObjectId>
+  {py} -m physical_engine.toolcli {session} check
+  {py} -m physical_engine.toolcli {session} attach <ObjectId> <Wall> [<Wall2>]
+  {py} -m physical_engine.toolcli {session} move <ObjectId> <dx> <dy>
+  {py} -m physical_engine.toolcli {session} resize <ObjectId> <x> <y> <z>
+  {py} -m physical_engine.toolcli {session} drop <ObjectId> <reason>
+  {py} -m physical_engine.toolcli {session} undo
+
+`object` prints paths to reference photographs — the scan frames with that object's reconstructed
+box drawn on them. READ THEM with the Read tool. They are the only evidence for whether a box
+actually bounds the thing it claims to, and they are why you are being asked rather than the
+solver.
+
+What counts as done: zero violations, reported by `check`.
+
+What counts as a GOOD repair, and this part matters more than the count:
+
+* Furniture against a wall belongs against that wall. A unit in a corner belongs in that corner.
+  Prefer `attach` over `move` — it computes the distance for you and preserves the alignment that
+  a raw translation destroys. `attach X WallA WallB` fits X into the corner of those two walls,
+  trimming it slightly if it must.
+* RoomPlan merges adjacent installed units and records them too deep — a counter fused with the
+  wall behind it, an oven fused into its cabinet run. That reads as "inside the wall" and the
+  repair is `resize`, not `move`. A standalone table or chair is NOT merged that way, so do not
+  resize one to escape a wall.
+* Two boxes that were already stacked on each other in the scan are one object detected twice.
+  `drop` the redundant one and say so. Do not shuffle duplicates apart.
+* A chair overlapping the table it is tucked under is correct. Leave it.
+* Do not slide furniture across the room. Every verb prints the score; `defects` counts collisions
+  PLUS units knocked off their wall PLUS anything moved implausibly far, so a big move that clears
+  a clash can still make the number worse. If it does, `undo`.
+
+Start with `summary`. Look at the photographs for anything you are unsure about. Work until `check`
+reports nothing, or until you are confident the rest is a reconstruction fault rather than a
+placement one — if so, say which and stop. Finish by printing a one-paragraph summary of what you
+changed and why."""
+
+
+def run_agent(shell: dict[str, Any], session: Path, *, references: Path | None = None,
+              model: str = "sonnet", python: str | None = None) -> tuple[dict, str]:
+    """Give one scene to the agent in its own session directory. Returns (state, transcript)."""
+    session.mkdir(parents=True, exist_ok=True)
+    save_shell(shell, session / "state.json")
+    save_shell(shell, session / "baseline.json")
+    (session / "history.json").write_text(
+        json.dumps([{"note": "initial", "state": shell}]), encoding="utf-8")
+    if references and references.is_dir() and not (session / "references").exists():
+        shutil.copytree(references, session / "references")
+
+    interpreter = python or "python3"
+    brief = BRIEF.format(session=session, py=interpreter)
+    try:
+        done = subprocess.run(
+            ["claude", "-p", brief, "--output-format", "text", "--model", model,
+             "--allowed-tools", "Read", "Bash", "Glob"],
+            capture_output=True, text=True, timeout=TIMEOUT, cwd=str(session.parent))
+    except subprocess.TimeoutExpired:
+        return shell, "agent timed out"
+    from .shell import load_shell
+    final = load_shell(session / "state.json")
+    return final, (done.stdout or "")[-4000:]
+
+
+def solve_v14(shell: dict[str, Any], *, session_root: Path | None = None,
+              model: str = "sonnet", detail: bool = False):
+    """Deterministic repair, then a reasoning agent on whatever it could not finish.
+
+    The agent is given the DETERMINISTIC result rather than the raw scan: everything cheap and
+    checkable has already been done, so its attention goes to the part that actually needs
+    judgement. Its output is scored the same way and kept only if it wins.
+    """
+    import sys as _sys
+
+    baseline = copy.deepcopy(shell)
+    solved, moves, log = repair(shell)
+    errors = [v for v in check(solved) if v.severity == "error"]
+    root = Path((shell.get("meta") or {}).get("batch_dir") or ".")
+    if not errors:
+        return (solved, moves, log) if detail else solved
+
+    session = Path(session_root or (root / "agent_session"))
+    final, transcript = run_agent(solved, session, references=root / "references",
+                                  model=model, python=_sys.executable)
+
+    held = {oid: set(attachments(o, baseline.get("walls") or {}))
+            for oid, o in (baseline.get("objects") or {}).items()}
+    held = {k: v for k, v in held.items() if v}
+    # let the deterministic actions tidy whatever the agent left, then judge the pair
+    tidied, tidy_moves, tidy_log = repair(final)
+    if score(tidied, baseline, held) < score(solved, baseline, held):
+        return ((tidied, tidy_moves, log + [{"action": "agent", "detail": transcript[-400:]}]
+                 + tidy_log) if detail else tidied)
+    return (solved, moves, log) if detail else solved

--- a/src/litereality_agent/pipeline/scene_init/layout/graph.py
+++ b/src/litereality_agent/pipeline/scene_init/layout/graph.py
@@ -1,0 +1,642 @@
+"""graph.py — SHELL → a scene graph, by rule. No model, no learning, no randomness.
+
+STAGE 2. The SHELL is a flat bag of boxes. The graph states how they are *related*, and two kinds
+of relation are what a simulator actually needs:
+
+**1. Support — what holds what up.** A simulator has to know that a laptop rests on a desk that
+rests on the floor, and that a wall cabinet is bolted to a wall rather than floating. So support is
+a **tree, not a set of hints**: every object gets exactly ONE parent, resolved in priority order,
+and the parent is always something that can bear it — a wall, the floor, the ceiling, or a lower
+object::
+
+    Room0
+     ├── Floor0 ◀── Table0 ◀── Laptop0          rests on / stacked on
+     │          ◀── Chair0
+     ├── Wall2  ◀── Storage5                    hung on
+     └── Ceiling0 ◀── Vent0
+
+    Every object resolves to exactly one parent, or is reported `unsupported` — which is a defect,
+    not a silence. `graph.support_roots()` and `graph.unsupported()` expose both.
+
+**2. Grouping — what belongs to what.** The chairs around a table are not merely near it; they are
+part of that table's setting. That is not support (a chair rests on the floor, not on the table)
+and not collision (a tucked chair overlaps the table on purpose), so it needs its own relation:
+``belongs_to``. It is what lets a whole dining set be moved, reasoned about, or kept together.
+
+The remaining relations are structural or diagnostic:
+
+===============  =========================================================================
+``contains``     the room holds this element (structural, always true)
+``hosts``        an opening is cut into this wall (from the archive path — see roomplan.py)
+``corner``       two walls share an endpoint within :data:`CORNER_TOL`
+``supported_by`` THE SUPPORT TREE. ``kind`` says how: floor / object / wall / ceiling
+``belongs_to``   a chair is part of its table's setting
+``against``      a floor-standing object's box reaches a wall — contact, but NOT support
+``tucked_under`` an expected containment (chair under table, sink in counter) — NOT a collision
+``clashes``      a genuine interpenetration; this is the list stage 3 has to resolve
+===============  =========================================================================
+
+Support is decided by geometry, not by category: a laptop is supported by the desk because its
+underside meets the desk's top surface. Only the *exceptions* are category-driven — which
+categories can hang on a wall, which pairs may legitimately interpenetrate, which children belong
+to which parents — and those lists are carried over from ``pipeline/room_qc`` so a graph built here
+and a room checked upstream agree about what counts as wrong.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+import numpy as np
+
+from .shell import facing_yaw, object_footprint, opening_span, wall_frame
+
+__all__ = [
+    "Node", "Edge", "SceneGraph", "build_graph", "is_wall_hung",
+    "FURNITURE", "FLOOR_STANDING", "WALL_MOUNTED", "WALL_HUNG_CAPABLE", "WALL_HUNG_MIN_Z",
+    "PASSTHROUGH", "OPEN_FRAME", "EXPECTED_CONTAINMENT", "GROUP_PARENTS", "expected_pair",
+]
+
+# ── category knowledge (carried over from pipeline/room_qc so both agree) ────
+FURNITURE = {"table", "chair", "sofa", "storage", "television", "bed", "desk", "cabinet",
+             "refrigerator", "stove", "oven", "sink", "toilet", "bathtub", "washer", "dishwasher",
+             "fireplace", "stairs"}
+FLOOR_STANDING = {"table", "chair", "sofa", "storage", "desk", "cabinet", "bed",
+                  "refrigerator", "stove", "sink", "toilet", "bathtub", "washer", "dishwasher"}
+WALL_MOUNTED = {"television", "whiteboard", "noticeboard", "board", "socket", "switch", "radiator",
+                "shelf", "panel", "sign", "poster", "sensor", "dispenser", "access_panel", "ac",
+                "heater", "thermostat", "vent", "mirror", "clock", "hook"}
+# Categories that are routinely WALL-HUNG. A kitchen wall cabinet, a wall oven, a mounted TV and a
+# bracket shelf all sit a metre or more off the floor by design, so "not touching the floor" is
+# correct for them, not a defect. RoomPlan records no support information at all, which is why this
+# has to be stated as knowledge rather than measured.
+WALL_HUNG_CAPABLE = {"storage", "cabinet", "shelf", "shelving", "bookcase", "sink", "stove", "oven",
+                     "hob", "cooktop", "television", "microwave", "radiator", "heater", "mirror",
+                     "whiteboard", "noticeboard", "board", "panel", "dispenser", "ac"}
+WALL_HUNG_MIN_Z = 0.30   # m above the floor before "off the floor" is deliberate rather than noise
+
+# Long runs and trims that legitimately pass behind or through everything else.
+PASSTHROUGH = {"trunking", "conduit", "skirting", "ceiling_grid", "cornice", "rail"}
+# Open structures whose bounding box is mostly void — holding things inside it is the point.
+OPEN_FRAME = {"shelf", "shelving", "rack", "bookcase", "bookshelf"}
+# Interpenetration that is CORRECT: an undermount sink in its counter, a chair tucked under a table.
+EXPECTED_CONTAINMENT = {
+    ("chair", "table"), ("chair", "desk"), ("stool", "table"), ("stool", "desk"),
+    ("sink", "storage"), ("sink", "cabinet"), ("sink", "table"),
+    ("oven", "storage"), ("oven", "cabinet"), ("stove", "storage"), ("stove", "cabinet"),
+    ("dishwasher", "storage"), ("dishwasher", "cabinet"),
+    ("television", "storage"), ("television", "cabinet"),
+}
+
+# ── rule tolerances, in metres. Every edge below cites one of these. ─────────
+CORNER_TOL = 0.20      # two wall endpoints this close are the same corner
+SUPPORT_TOL = 0.08     # underside-to-surface gap that still counts as resting on it
+SUPPORT_OVERLAP = 0.25 # fraction of the smaller footprint that must overlap to call it support
+AGAINST_TOL = 0.15     # gap from an object's box to a wall plane that counts as "against" it
+FIXTURE_PERP = 0.75    # how far off a wall a fixture may sit and still be mounted to it
+CLASH_TOL = 0.001      # zero, to within float noise: two boxes that overlap at all, collide
+# 0.08 was too generous to be useful. On the 21 captures it hides 12 of the 13 genuine
+# object-object overlaps -- a storage unit 6.4 cm into the table beside it reads as clean. The
+# floor it has to clear is the drift on a box that is correctly placed, and on the synthetic
+# control (severe noise, no injected defect) that tops out at 6.8 cm only because the generator
+# leaves a 6 cm clearance and then jitters both boxes 4 cm; a pair whose footprints genuinely
+# overlap by 3 cm is touching, and a physics engine will treat it as contact either way.
+Z_BAND_TOL = 0.05      # boxes must share at least this much height to be able to collide
+CEILING_TOL = 0.15     # top this close to the ceiling counts as ceiling-mounted
+GROUP_GAP = 0.80       # m — how far a chair may sit from its table and still belong to it
+GROUP_FACING_BONUS = 60.0   # deg — a chair facing its table wins over a marginally closer one
+
+# Which child categories belong to which parents. Grouping is a FUNCTIONAL relation, so unlike
+# support it cannot be derived from geometry alone — proximity says a chair is near a table, not
+# that it is part of that table's setting.
+GROUP_PARENTS: dict[str, set[str]] = {
+    "chair": {"table", "desk"},
+    "stool": {"table", "desk", "counter"},
+}
+
+
+def is_wall_hung(obj: dict[str, Any], walls: dict[str, Any], floor_z: float) -> str | None:
+    """Is this object mounted on a wall rather than standing on the floor? → the wall id, or None.
+
+    Three conditions, all necessary: a category that CAN hang (:data:`WALL_HUNG_CAPABLE`), a
+    bottom clearly off the floor (:data:`WALL_HUNG_MIN_Z`), and a wall actually within reach. A
+    cabinet floating in the middle of a room satisfies the first two and is still a defect.
+    """
+    if obj.get("category", "") not in WALL_HUNG_CAPABLE:
+        return None
+    if obj["center"][2] - obj["size"][2] / 2 - floor_z < WALL_HUNG_MIN_Z:
+        return None
+    best: tuple[float, str] | None = None
+    for wall_id, wall in (walls or {}).items():
+        measured = wall_distance(obj, wall)
+        if measured is None:
+            continue
+        if measured[0] <= FIXTURE_PERP and (best is None or measured[0] < best[0]):
+            best = (measured[0], wall_id)
+    return best[1] if best else None
+
+
+def expected_pair(a: str, b: str, table: Iterable[tuple[str, str]] = EXPECTED_CONTAINMENT) -> bool:
+    """Is this category pair an overlap we EXPECT? Order-independent."""
+    table = set(table)
+    return (a, b) in table or (b, a) in table
+
+
+# ── graph types ──────────────────────────────────────────────────────────────
+@dataclass
+class Node:
+    id: str
+    kind: str                                  # room | wall | opening | floor | ceiling | object
+    category: str = ""
+    attrs: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Edge:
+    source: str
+    target: str
+    relation: str
+    attrs: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class SceneGraph:
+    nodes: list[Node] = field(default_factory=list)
+    edges: list[Edge] = field(default_factory=list)
+    meta: dict[str, Any] = field(default_factory=dict)
+
+    def node(self, node_id: str) -> Node | None:
+        return next((n for n in self.nodes if n.id == node_id), None)
+
+    def of_kind(self, kind: str) -> list[Node]:
+        return [n for n in self.nodes if n.kind == kind]
+
+    def relation(self, relation: str) -> list[Edge]:
+        return [e for e in self.edges if e.relation == relation]
+
+    def support_parent(self, node_id: str) -> str | None:
+        """What holds this object up — exactly one node, or None if nothing does."""
+        return next((e.target for e in self.edges
+                     if e.source == node_id and e.relation == "supported_by"), None)
+
+    def support_kind(self, node_id: str) -> str | None:
+        edge = next((e for e in self.edges
+                     if e.source == node_id and e.relation == "supported_by"), None)
+        return edge.attrs.get("kind") if edge else None
+
+    def support_children(self, node_id: str) -> list[str]:
+        return [e.source for e in self.edges
+                if e.target == node_id and e.relation == "supported_by"]
+
+    def support_roots(self) -> list[str]:
+        """The things everything ultimately rests on: the floor, the walls, the ceiling."""
+        targets = {e.target for e in self.edges if e.relation == "supported_by"}
+        return sorted(t for t in targets if self.support_parent(t) is None)
+
+    def support_chain(self, node_id: str) -> list[str]:
+        """This object's path down to its root — ``[Laptop0, Table0, Floor0]``."""
+        chain, seen = [node_id], {node_id}
+        while (parent := self.support_parent(chain[-1])) and parent not in seen:
+            chain.append(parent)
+            seen.add(parent)
+        return chain
+
+    def unsupported(self) -> list[str]:
+        """Objects nothing holds up — a defect, reported rather than silently grounded."""
+        return sorted(n.id for n in self.nodes
+                      if n.kind == "object" and n.attrs.get("unsupported"))
+
+    def group_members(self, parent_id: str) -> list[str]:
+        return sorted(e.source for e in self.edges
+                      if e.target == parent_id and e.relation == "belongs_to")
+
+    def groups(self) -> dict[str, list[str]]:
+        """Every functional group: parent id -> its members (a table and its chairs)."""
+        out: dict[str, list[str]] = {}
+        for edge in self.edges:
+            if edge.relation == "belongs_to":
+                out.setdefault(edge.target, []).append(edge.source)
+        return {k: sorted(v) for k, v in sorted(out.items())}
+
+    def neighbours(self, node_id: str, relation: str | None = None) -> list[str]:
+        return [e.target for e in self.edges
+                if e.source == node_id and (relation is None or e.relation == relation)]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"meta": self.meta,
+                "nodes": [asdict(n) for n in self.nodes],
+                "edges": [asdict(e) for e in self.edges]}
+
+    def save(self, path: str | Path) -> Path:
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(self.to_dict(), indent=2), encoding="utf-8")
+        return path
+
+    def to_networkx(self):
+        """A ``networkx.MultiDiGraph`` view, for layout and analysis."""
+        import networkx as nx
+
+        g = nx.MultiDiGraph()
+        for n in self.nodes:
+            g.add_node(n.id, kind=n.kind, category=n.category, **n.attrs)
+        for e in self.edges:
+            g.add_edge(e.source, e.target, key=e.relation, relation=e.relation, **e.attrs)
+        return g
+
+    def describe(self) -> str:
+        """A compact human-readable rendering of the whole graph."""
+        lines = [f"scene graph: {len(self.nodes)} nodes, {len(self.edges)} edges"]
+        by_relation: dict[str, list[Edge]] = {}
+        for e in self.edges:
+            by_relation.setdefault(e.relation, []).append(e)
+        for relation in ("contains", "hosts", "corner", "supported_by", "belongs_to",
+                         "against", "tucked_under", "clashes"):
+            group = by_relation.get(relation)
+            if not group:
+                continue
+            lines.append(f"  {relation} ({len(group)})")
+            for e in group[:40]:
+                note = " ".join(f"{k}={v}" for k, v in e.attrs.items())
+                lines.append(f"    {e.source} -> {e.target}" + (f"   [{note}]" if note else ""))
+            if len(group) > 40:
+                lines.append(f"    … {len(group) - 40} more")
+        return "\n".join(lines)
+
+
+# ── geometry the rules run on ────────────────────────────────────────────────
+def _obb(obj: dict[str, Any]) -> tuple[float, float, float, float, float]:
+    """(cx, cy, half_w, half_d, yaw_rad) — the 2-D oriented footprint box."""
+    return (obj["center"][0], obj["center"][1],
+            obj["size"][0] / 2.0, obj["size"][1] / 2.0, math.radians(obj.get("yaw", 0.0)))
+
+
+def obb_mtv(a, b) -> tuple[float, tuple[float, float]] | None:
+    """Separating-axis overlap of two oriented rectangles → (depth, axis), or None if apart.
+
+    The axis is the **minimum translation vector**, oriented a→b, so moving ``b`` by
+    ``axis * depth`` is by construction the shortest move that separates them. Stage 3's whole
+    resolver is built on that guarantee; an AABB test cannot provide it and false-clashes every
+    rotated chair besides.
+    """
+    def geometry(o):
+        cx, cy, hx, hy, r = o
+        c, s = math.cos(r), math.sin(r)
+        ux, uy = (c, s), (-s, c)
+        corners = [(cx + sx * hx * ux[0] + sy * hy * uy[0],
+                    cy + sx * hx * ux[1] + sy * hy * uy[1])
+                   for sx in (-1, 1) for sy in (-1, 1)]
+        return corners, (ux, uy)
+
+    ca, axes_a = geometry(a)
+    cb, axes_b = geometry(b)
+    best, best_axis = float("inf"), None
+    for axis in (*axes_a, *axes_b):
+        length = math.hypot(*axis) or 1.0
+        u = (axis[0] / length, axis[1] / length)
+        pa = [p[0] * u[0] + p[1] * u[1] for p in ca]
+        pb = [p[0] * u[0] + p[1] * u[1] for p in cb]
+        overlap = min(max(pa), max(pb)) - max(min(pa), min(pb))
+        if overlap <= 0:
+            return None                                    # a separating axis exists → no contact
+        if overlap < best:
+            centre_delta = (sum(p[0] * u[0] + p[1] * u[1] for p in cb) / 4
+                            - sum(p[0] * u[0] + p[1] * u[1] for p in ca) / 4)
+            best, best_axis = overlap, (u if centre_delta >= 0 else (-u[0], -u[1]))
+    return best, best_axis
+
+
+def _polygon_area(poly: np.ndarray) -> float:
+    x, y = poly[:, 0], poly[:, 1]
+    return 0.5 * abs(float(np.dot(x, np.roll(y, -1)) - np.dot(y, np.roll(x, -1))))
+
+
+def _clip_polygon(subject: np.ndarray, clip: np.ndarray) -> np.ndarray:
+    """Sutherland–Hodgman clip of one convex polygon by another → the intersection polygon."""
+    output = list(subject)
+    for i in range(len(clip)):
+        a, b = clip[i], clip[(i + 1) % len(clip)]
+        edge = b - a
+        inside = lambda p: edge[0] * (p[1] - a[1]) - edge[1] * (p[0] - a[0]) >= -1e-12  # noqa: E731
+        current, output = output, []
+        for j in range(len(current)):
+            p, q = current[j], current[(j + 1) % len(current)]
+            if inside(p):
+                output.append(p)
+                if not inside(q):
+                    output.append(_line_cross(p, q, a, b))
+            elif inside(q):
+                output.append(_line_cross(p, q, a, b))
+        if not output:
+            return np.zeros((0, 2))
+    return np.asarray(output)
+
+
+def _line_cross(p, q, a, b) -> np.ndarray:
+    d1, d2 = q - p, b - a
+    denom = d1[0] * d2[1] - d1[1] * d2[0]
+    if abs(denom) < 1e-12:
+        return p
+    t = ((a[0] - p[0]) * d2[1] - (a[1] - p[1]) * d2[0]) / denom
+    return p + t * d1
+
+
+def footprint_overlap(a: dict[str, Any], b: dict[str, Any]) -> float:
+    """Shared footprint area, as a fraction of the SMALLER of the two footprints."""
+    pa, pb = object_footprint(a), object_footprint(b)
+    area_a, area_b = _polygon_area(pa), _polygon_area(pb)
+    if min(area_a, area_b) < 1e-9:
+        return 0.0
+    shared = _clip_polygon(pa, pb)
+    if len(shared) < 3:
+        return 0.0
+    return _polygon_area(shared) / min(area_a, area_b)
+
+
+def _footprint_gap(a: dict[str, Any], b: dict[str, Any]) -> float:
+    """Shortest distance between two oriented footprints. 0 when they touch or overlap.
+
+    Centre-to-centre distance would make a chair beside a 3.5 m table look further away than one
+    at the far end of a small table, which is the wrong ordering for grouping.
+    """
+    pa, pb = object_footprint(a), object_footprint(b)
+    if len(_clip_polygon(pa, pb)) >= 3:
+        return 0.0
+    best = float("inf")
+    for poly, other in ((pa, pb), (pb, pa)):
+        for point in poly:
+            for k in range(len(other)):
+                p, q = other[k], other[(k + 1) % len(other)]
+                seg = q - p
+                length2 = float(seg @ seg)
+                t = 0.0 if length2 < 1e-12 else max(0.0, min(1.0, float((point - p) @ seg) / length2))
+                best = min(best, float(np.linalg.norm(point - (p + t * seg))))
+    return best
+
+
+def _support_along(obj: dict[str, Any], direction: np.ndarray) -> float:
+    """How far an object's footprint reaches along a unit direction from its centre."""
+    hw, hd = obj["size"][0] / 2.0, obj["size"][1] / 2.0
+    yaw = math.radians(obj.get("yaw", 0.0))
+    c, s = math.cos(yaw), math.sin(yaw)
+    return abs(hw * (c * direction[0] + s * direction[1])) + abs(hd * (-s * direction[0] + c * direction[1]))
+
+
+def wall_distance(obj: dict[str, Any], wall: dict[str, Any]) -> tuple[float, float] | None:
+    """(gap from the object's box to the wall plane, position along the wall) or None if off its ends.
+
+    The gap is measured from the box's *support* in the wall-normal direction, not from its centre,
+    so a deep counter standing flush against a wall reads 0 and not half its depth. Walls are
+    frequently diagonal, which is exactly why a world-AABB proxy is useless here.
+    """
+    start, along, normal, length = wall_frame(wall)
+    centre = np.asarray(obj["center"][:2], dtype=float)
+    rel = centre - start
+    t = float(np.dot(rel, along))
+    if not (-0.25 <= t <= length + 0.25):
+        return None
+    perp = abs(float(np.dot(rel, normal)))
+    return perp - _support_along(obj, normal) - wall.get("thickness", 0.0) / 2.0, t
+
+
+# ── the builder ──────────────────────────────────────────────────────────────
+def build_graph(shell: dict[str, Any], *, name: str = "room", meta: dict[str, Any] | None = None) -> SceneGraph:
+    """Apply every rule above to a SHELL and return the resulting :class:`SceneGraph`."""
+    walls = shell.get("walls") or {}
+    openings = shell.get("openings") or {}
+    objects = shell.get("objects") or {}
+    floor_z = float(shell.get("floor_z", 0.0))
+    ceiling_z = float(shell.get("ceiling_z", floor_z + 2.5))
+    verts = np.asarray((shell.get("floor") or {}).get("verts") or [], dtype=float)
+
+    graph = SceneGraph(meta={"name": name, "floor_z": floor_z, "ceiling_z": ceiling_z,
+                             **(meta or {})})
+    room_id = "Room0"
+
+    footprint_area = 0.0
+    if len(verts):
+        hull = verts[:, :2]
+        footprint_area = _polygon_area(hull[_convex_hull_indices(hull)]) if len(hull) >= 3 else 0.0
+    graph.nodes.append(Node(room_id, "room", name, {
+        "height": round(ceiling_z - floor_z, 4),
+        "floor_area": round(footprint_area, 3),
+        "n_walls": len(walls), "n_openings": len(openings), "n_objects": len(objects),
+    }))
+
+    # --- structural nodes ---------------------------------------------------
+    for wall_id, wall in walls.items():
+        start, along, normal, length = wall_frame(wall)
+        graph.nodes.append(Node(wall_id, "wall", "wall", {
+            "start": [round(v, 4) for v in start],
+            "end": [round(v, 4) for v in np.asarray(wall["end"], float)],
+            "length": round(length, 4),
+            "thickness": round(float(wall.get("thickness", 0.0)), 4),
+            "height": round(ceiling_z - floor_z, 4),
+            "normal": [round(v, 4) for v in normal],
+            "sliver": bool(length < 0.35),      # RoomPlan corner artifact, kept but flagged
+        }))
+        graph.edges.append(Edge(room_id, wall_id, "contains"))
+
+    for surface, z in (("Floor0", floor_z), ("Ceiling0", ceiling_z)):
+        graph.nodes.append(Node(surface, surface[:-1].lower(), surface[:-1].lower(),
+                                {"z": round(z, 4), "area": round(footprint_area, 3)}))
+        graph.edges.append(Edge(room_id, surface, "contains"))
+
+    for opening_id, opening in openings.items():
+        graph.nodes.append(Node(opening_id, "opening", opening.get("type", "opening"), {
+            "wall": opening.get("wall"),
+            "offset": opening.get("offset"),   # CENTRE along the wall — see shell.opening_span
+            "span": [round(v, 3) for v in opening_span(opening)],
+            "width": opening.get("width"),
+            "height": opening.get("height"), "sill": opening.get("sill"),
+        }))
+        graph.edges.append(Edge(room_id, opening_id, "contains"))
+        wall_id = opening.get("wall")
+        if wall_id in walls:
+            t0, t1 = opening_span(opening)
+            graph.edges.append(Edge(wall_id, opening_id, "hosts",
+                                    {"span": [round(t0, 3), round(t1, 3)],
+                                     "wall_length": round(wall_frame(wall)[3], 3)}))
+
+    for object_id, obj in objects.items():
+        bottom = obj["center"][2] - obj["size"][2] / 2.0
+        top = obj["center"][2] + obj["size"][2] / 2.0
+        graph.nodes.append(Node(object_id, "object", obj.get("category", ""), {
+            "center": [round(v, 4) for v in obj["center"]],
+            "size": [round(v, 4) for v in obj["size"]],
+            "yaw": obj.get("yaw", 0.0),        # heading of the box's WIDTH axis
+            "facing": round(facing_yaw(obj), 2),  # where the object points; see shell.facing_yaw
+            "bottom_z": round(bottom, 4), "top_z": round(top, 4),
+            "footprint_area": round(obj["size"][0] * obj["size"][1], 3),
+            **({"members": obj["members"]} if obj.get("members") else {}),
+        }))
+        graph.edges.append(Edge(room_id, object_id, "contains"))
+
+    # --- rule: walls that share a corner ------------------------------------
+    wall_ids = list(walls)
+    for i in range(len(wall_ids)):
+        for j in range(i + 1, len(wall_ids)):
+            a, b = walls[wall_ids[i]], walls[wall_ids[j]]
+            for ka in ("start", "end"):
+                for kb in ("start", "end"):
+                    gap = float(np.linalg.norm(np.asarray(a[ka], float) - np.asarray(b[kb], float)))
+                    if gap <= CORNER_TOL:
+                        graph.edges.append(Edge(wall_ids[i], wall_ids[j], "corner",
+                                                {"at": ka + "/" + kb, "gap": round(gap, 4)}))
+                        break
+                else:
+                    continue
+                break
+
+    # --- rule: THE SUPPORT TREE — exactly one parent per object -------------
+    # Resolved lowest-first so a supporter is already placed before anything can rest on it, and
+    # a supporter must sit strictly lower than its child, which makes cycles impossible.
+    ordered = sorted(objects.items(), key=lambda kv: kv[1]["center"][2] - kv[1]["size"][2] / 2.0)
+    for object_id, obj in ordered:
+        bottom = obj["center"][2] - obj["size"][2] / 2.0
+        top = obj["center"][2] + obj["size"][2] / 2.0
+
+        # 1. hung on a wall — a wall cabinet or a mounted TV is held by the wall, not the floor
+        hung = is_wall_hung(obj, walls, floor_z)
+        if hung is not None:
+            graph.edges.append(Edge(object_id, hung, "supported_by",
+                                    {"kind": "wall", "height": round(bottom - floor_z, 3)}))
+            continue
+
+        # 2. stacked on a lower object whose top surface it meets
+        best: tuple[float, str, float] | None = None
+        for other_id, other in objects.items():
+            if other_id == object_id:
+                continue
+            other_top = other["center"][2] + other["size"][2] / 2.0
+            other_bottom = other["center"][2] - other["size"][2] / 2.0
+            if other_bottom >= bottom - 1e-6:
+                continue                                   # not below us — cannot hold us up
+            if not (-SUPPORT_TOL <= bottom - other_top <= SUPPORT_TOL):
+                continue
+            if footprint_overlap(obj, other) < SUPPORT_OVERLAP:
+                continue
+            if best is None or other_top > best[2]:
+                best = (bottom - other_top, other_id, other_top)
+        if best is not None:
+            graph.edges.append(Edge(object_id, best[1], "supported_by",
+                                    {"kind": "object", "gap": round(best[0], 4)}))
+            continue
+
+        # 3. standing on the floor
+        if abs(bottom - floor_z) <= SUPPORT_TOL:
+            graph.edges.append(Edge(object_id, "Floor0", "supported_by",
+                                    {"kind": "floor", "gap": round(bottom - floor_z, 4)}))
+            continue
+
+        # 4. fixed to the ceiling — lights, vents, ceiling grids
+        if abs(ceiling_z - top) <= CEILING_TOL:
+            graph.edges.append(Edge(object_id, "Ceiling0", "supported_by",
+                                    {"kind": "ceiling", "gap": round(ceiling_z - top, 4)}))
+            continue
+
+        # 5. nothing holds it up. Reported, never invented: an unsupported object is a defect in
+        #    the scan, and silently attaching it to the floor would hide exactly that.
+        graph.nodes[[n.id for n in graph.nodes].index(object_id)].attrs["unsupported"] = True
+
+    # --- rule: which wall an object is merely AGAINST (contact, not support) --
+    for object_id, obj in objects.items():
+        if graph.support_parent(object_id) is not None and \
+                graph.support_kind(object_id) == "wall":
+            continue                                       # already held by a wall
+        best_against: tuple[float, str] | None = None
+        for wall_id, wall in walls.items():
+            measured = wall_distance(obj, wall)
+            if measured is None:
+                continue
+            if measured[0] <= AGAINST_TOL and (best_against is None or measured[0] < best_against[0]):
+                best_against = (measured[0], wall_id)
+        if best_against is not None:
+            graph.edges.append(Edge(object_id, best_against[1], "against",
+                                    {"gap": round(best_against[0], 4)}))
+
+    # --- rule: GROUPING — which parent object a child belongs to -------------
+    # Functional, not physical: a chair rests on the FLOOR but belongs to its TABLE. Proximity
+    # alone is not enough in a room of eight tables, so a chair that FACES a table is preferred
+    # over one that is marginally closer — that is what distinguishes "at this table" from
+    # "standing next to it on the way past".
+    for object_id, obj in objects.items():
+        parents = GROUP_PARENTS.get(obj.get("category", ""))
+        if not parents:
+            continue
+        centre = np.asarray(obj["center"][:2], dtype=float)
+        facing = math.radians(facing_yaw(obj))
+        best: tuple[float, str, float, float] | None = None
+        for other_id, other in objects.items():
+            if other_id == object_id or other.get("category", "") not in parents:
+                continue
+            gap = _footprint_gap(obj, other)
+            if gap > GROUP_GAP:
+                continue
+            to_parent = np.asarray(other["center"][:2], dtype=float) - centre
+            heading = math.degrees(math.atan2(to_parent[1], to_parent[0]))
+            off = abs((math.degrees(facing) - heading + 180.0) % 360.0 - 180.0)
+            # A chair facing its table is worth up to GROUP_FACING_BONUS of "closeness".
+            cost = gap + (off / 180.0) * (GROUP_FACING_BONUS / 180.0)
+            if best is None or cost < best[0]:
+                best = (cost, other_id, gap, off)
+        if best is not None:
+            graph.edges.append(Edge(object_id, best[1], "belongs_to",
+                                    {"gap": round(best[2], 3), "facing_off_deg": round(best[3], 1)}))
+
+    # --- rule: containment vs. genuine clash --------------------------------
+    ids = list(objects)
+    for i in range(len(ids)):
+        for j in range(i + 1, len(ids)):
+            a_id, b_id = ids[i], ids[j]
+            a, b = objects[a_id], objects[b_id]
+            a_bottom, a_top = a["center"][2] - a["size"][2] / 2, a["center"][2] + a["size"][2] / 2
+            b_bottom, b_top = b["center"][2] - b["size"][2] / 2, b["center"][2] + b["size"][2] / 2
+            if min(a_top, b_top) - max(a_bottom, b_bottom) <= Z_BAND_TOL:
+                continue                                    # no shared height band → cannot collide
+            mtv = obb_mtv(_obb(a), _obb(b))
+            if not mtv or mtv[0] <= CLASH_TOL:
+                continue
+            depth, axis = mtv
+            cat_a, cat_b = a.get("category", ""), b.get("category", "")
+            if expected_pair(cat_a, cat_b):
+                # EXPECTED_CONTAINMENT is written (contained, container), so the pair itself says
+                # which way the edge points: the chair goes under the table, never the reverse.
+                inner = a_id if (cat_a, cat_b) in EXPECTED_CONTAINMENT else b_id
+                outer = b_id if inner == a_id else a_id
+                graph.edges.append(Edge(inner, outer, "tucked_under", {"depth": round(depth, 4)}))
+            elif cat_a in PASSTHROUGH or cat_b in PASSTHROUGH \
+                    or cat_a in OPEN_FRAME or cat_b in OPEN_FRAME:
+                continue                                    # open frames and runs are meant to overlap
+            else:
+                graph.edges.append(Edge(a_id, b_id, "clashes", {
+                    "depth": round(depth, 4),
+                    "axis": [round(axis[0], 4), round(axis[1], 4)],
+                }))
+
+    graph.meta["n_clashes"] = len(graph.relation("clashes"))
+    graph.meta["support_roots"] = graph.support_roots()
+    graph.meta["unsupported"] = graph.unsupported()
+    graph.meta["groups"] = graph.groups()
+    return graph
+
+
+def _convex_hull_indices(points: np.ndarray) -> list[int]:
+    """Monotone-chain hull — used only to give the room a stable floor area."""
+    order = sorted(range(len(points)), key=lambda i: (points[i][0], points[i][1]))
+    def half(seq):
+        out: list[int] = []
+        for i in seq:
+            while len(out) >= 2:
+                o, a, p = points[out[-2]], points[out[-1]], points[i]
+                if (a[0] - o[0]) * (p[1] - o[1]) - (a[1] - o[1]) * (p[0] - o[0]) > 1e-12:
+                    break
+                out.pop()
+            out.append(i)
+        return out
+    lower, upper = half(order), half(reversed(order))
+    return lower[:-1] + upper[:-1]

--- a/src/litereality_agent/pipeline/scene_init/layout/graph.py
+++ b/src/litereality_agent/pipeline/scene_init/layout/graph.py
@@ -59,6 +59,7 @@ __all__ = [
     "Node", "Edge", "SceneGraph", "build_graph", "is_wall_hung",
     "FURNITURE", "FLOOR_STANDING", "WALL_MOUNTED", "WALL_HUNG_CAPABLE", "WALL_HUNG_MIN_Z",
     "PASSTHROUGH", "OPEN_FRAME", "EXPECTED_CONTAINMENT", "GROUP_PARENTS", "expected_pair",
+    "category_tokens", "in_category",
 ]
 
 # ── category knowledge (carried over from pipeline/room_qc so both agree) ────
@@ -140,10 +141,42 @@ def is_wall_hung(obj: dict[str, Any], walls: dict[str, Any], floor_z: float) -> 
     return best[1] if best else None
 
 
-def expected_pair(a: str, b: str, table: Iterable[tuple[str, str]] = EXPECTED_CONTAINMENT) -> bool:
-    """Is this category pair an overlap we EXPECT? Order-independent."""
+def category_tokens(category: str) -> set[str]:
+    """The categories a name stands for. ``oven_storage_stove`` is an oven AND a storage AND a stove.
+
+    The box merge fuses a counter run into one object and names it after its members, so a scan
+    that has been through it carries categories no table in this package was written against.
+    Nothing errors — the lookups simply stop matching, silently, and every category rule the merged
+    unit should have been subject to switches off for it.
+    """
+    return {token for token in (category or "").split("_") if token}
+
+
+def in_category(category: str, table: Iterable[str]) -> bool:
+    """Does this category — compound names included — belong to ``table``?"""
     table = set(table)
-    return (a, b) in table or (b, a) in table
+    return category in table or bool(category_tokens(category) & table)
+
+
+def expected_pair(a: str, b: str, table: Iterable[tuple[str, str]] = EXPECTED_CONTAINMENT) -> bool:
+    """Is this category pair an overlap we EXPECT? Order-independent.
+
+    A merged run is expanded to its members, which is the whole point: Kitchen's ``Sink1`` sits
+    inside ``Sink_Storage0``, and that is ``("sink", "storage")`` — already in the table, already
+    meant to be exempt, and missed only because the merge renamed one side. Read literally it was
+    reported as a collision, and the repair then tried to resolve it by deleting the counter run.
+
+    Only ONE side is expanded. Two compound names are matched exactly, because expanding both lets
+    any two merged counter runs find some member pair in the table and exempt a genuine
+    interpenetration between them.
+    """
+    table = set(table)
+    if (a, b) in table or (b, a) in table:
+        return True
+    ta, tb = category_tokens(a), category_tokens(b)
+    if len(ta) > 1 and len(tb) > 1:
+        return False
+    return any((x, y) in table or (y, x) in table for x in ta for y in tb)
 
 
 # ── graph types ──────────────────────────────────────────────────────────────
@@ -606,7 +639,15 @@ def build_graph(shell: dict[str, Any], *, name: str = "room", meta: dict[str, An
             if expected_pair(cat_a, cat_b):
                 # EXPECTED_CONTAINMENT is written (contained, container), so the pair itself says
                 # which way the edge points: the chair goes under the table, never the reverse.
-                inner = a_id if (cat_a, cat_b) in EXPECTED_CONTAINMENT else b_id
+                if len(category_tokens(cat_a)) > 1 or len(category_tokens(cat_b)) > 1:
+                    # A merged run names no direction: ``storage`` inside ``oven_storage_stove``
+                    # matches ``("oven", "storage")`` in BOTH orders, and reading the table would
+                    # put the counter run inside the cabinet it swallowed. Volume is not ambiguous.
+                    volumes = {i: o["size"][0] * o["size"][1] * o["size"][2]
+                               for i, o in ((a_id, a), (b_id, b))}
+                    inner = min(volumes, key=volumes.get)
+                else:
+                    inner = a_id if (cat_a, cat_b) in EXPECTED_CONTAINMENT else b_id
                 outer = b_id if inner == a_id else a_id
                 graph.edges.append(Edge(inner, outer, "tucked_under", {"depth": round(depth, 4)}))
             elif cat_a in PASSTHROUGH or cat_b in PASSTHROUGH \

--- a/src/litereality_agent/pipeline/scene_init/layout/repair.py
+++ b/src/litereality_agent/pipeline/scene_init/layout/repair.py
@@ -1,0 +1,734 @@
+"""repair.py — repair as a search over legal ACTIONS, where no action can make the room worse.
+
+Every solver up to v10 computed a displacement field and hoped the result was better. That is why
+the results were sometimes worse than the input: a push that separates one pair drives an object
+into a third, and nothing in the loop is obliged to notice. Here the shape is inverted. Each
+violation proposes a small number of concrete, human-recognisable actions; each action is applied
+to a COPY and scored; and one is kept only if the score strictly improves. A move that creates a
+new clash scores worse and is discarded, so a regression cannot be produced — not "is unlikely",
+cannot.
+
+The actions are ordered the way a person would try them, least invasive first:
+
+1. ``drop``        one of two boxes that were already sitting on top of each other in the INPUT is
+                   a duplicate detection, not a collision. Deleting the extra is free; moving it
+                   is nonsense.
+2. ``snap``        an installed unit reads as inside its wall because its depth was measured long.
+                   Putting it flush against that wall is a restoration, not a correction.
+3. ``dewrap``      two units on the SAME wall overlap along it. That is a one-dimensional problem
+                   — slide them apart along the wall — and solving it in 2D is what walks a
+                   dishwasher off its cabinet line.
+4. ``slide``       an installed unit slides along its own wall. It never leaves it.
+5. ``separate``    ordinary pair separation along the minimum translation vector, carrying the
+                   object's group with it so a table takes its chairs.
+6. ``shrink``      a merged box recorded deeper than the thing it bounds, trimmed and re-seated
+                   against its wall. Bounded, and only when it beats every cheaper action.
+
+Scoring is lexicographic: violations first, then wall anchors broken, then total displacement. So
+an action that removes no violation but moves something is rejected outright, and between two that
+both work, the one that disturbs the room less wins.
+"""
+
+from __future__ import annotations
+
+import copy
+import math
+from dataclasses import dataclass
+from typing import Any, Callable
+
+import numpy as np
+
+from . import adjust
+from .adjust import (ANCHOR_TOL, FLOOR_OUT_TOL, SEPARATION, Move, check,
+                     _floor_triangles, _inside_floor, _obb,
+                     _support, ground, reseat_openings)
+from .graph import build_graph, obb_mtv, wall_distance
+from .shell import object_footprint, wall_frame
+
+__all__ = ["duplicates", "score", "repair", "solve_v11"]
+
+REVIEW_SHIFT = 0.22  # past this, a move is a claim about the room rather than a correction
+DUP_SAME = 0.50      # overlap / smaller volume, for two boxes of the same category
+DUP_CROSS = 0.75     # more is demanded across categories: a tucked chair reaches ~0.5 honestly
+SHRINK_MAX = 0.35    # a box may not lose more than this fraction of a dimension
+# Only these get trimmed. RoomPlan merges ADJACENT INSTALLED units — a counter with the wall behind
+# it, an oven into its cabinet run — and records the result deeper than the thing it bounds. It
+# does not do that to a standalone table, so trimming a table 30% to clear a wall is inventing a
+# different table. Airbnb-Cam's Table0 lost a third of its width that way, which is why this list
+# exists rather than a blanket permission.
+SHRINKABLE = {"storage", "cabinet", "counter", "oven", "stove", "sink", "dishwasher",
+              "washer", "refrigerator", "shelf", "bathtub"}
+JOINT_SHRINK_MAX = 0.12   # a JOINT trim takes a little off each, never a lot off one
+ROOM_BUFFER = 0.10   # the floor plate traces the inner wall face; a flush unit overhangs it
+
+
+# ── the room, as facts ───────────────────────────────────────────────────────
+def attachments(obj, walls, tol: float = ANCHOR_TOL) -> dict[str, float]:
+    """Walls this object is installed against → {wall_id: signed gap}."""
+    out = {}
+    for wall_id, wall in (walls or {}).items():
+        measured = wall_distance(obj, wall)
+        if measured is None:
+            continue
+        gap, along_t = measured
+        length = wall_frame(wall)[3]
+        if abs(gap) <= tol and -0.10 <= along_t <= length + 0.10:
+            out[wall_id] = gap
+    return out
+
+
+def _volume(obj) -> float:
+    return max(1e-9, obj["size"][0] * obj["size"][1] * obj["size"][2])
+
+
+def _overlap_fraction(a, b) -> float:
+    """Intersection volume over the SMALLER box's volume.
+
+    Min-normalised rather than IoU on purpose: a small duplicate annotation sitting entirely inside
+    a larger one scores ~1.0 here, where IoU would stay low and miss it.
+    """
+    mtv = obb_mtv(_obb(a), _obb(b))
+    if not mtv:
+        return 0.0
+    az0, az1 = a["center"][2] - a["size"][2] / 2, a["center"][2] + a["size"][2] / 2
+    bz0, bz1 = b["center"][2] - b["size"][2] / 2, b["center"][2] + b["size"][2] / 2
+    z = min(az1, bz1) - max(az0, bz0)
+    if z <= 0:
+        return 0.0
+    # footprint intersection area, approximated from the separating-axis depth against the
+    # shorter shared edge — enough to rank duplicates, and it never over-reports
+    small = min(a["size"][0] * a["size"][1], b["size"][0] * b["size"][1])
+    inter = min(mtv[0] * min(max(a["size"][0], a["size"][1]),
+                             max(b["size"][0], b["size"][1])), small)
+    return (inter * z) / min(_volume(a), _volume(b))
+
+
+def duplicates(shell: dict[str, Any]) -> set[tuple[str, str]]:
+    """Pairs that were already heavily overlapping in the INPUT — duplicate detections.
+
+    Decided from the input alone, before any solver runs, so it cannot be gamed: a solver has no
+    way to manufacture the initial overlap that would license a deletion.
+    """
+    objects = shell.get("objects") or {}
+    ids = list(objects)
+    found = set()
+    for i in range(len(ids)):
+        for j in range(i + 1, len(ids)):
+            a, b = objects[ids[i]], objects[ids[j]]
+            same = a.get("category") == b.get("category")
+            if _overlap_fraction(a, b) >= (DUP_SAME if same else DUP_CROSS):
+                found.add((ids[i], ids[j]))
+    return found
+
+
+def groups(shell: dict[str, Any]) -> dict[str, set[str]]:
+    """parent -> the objects that move with it, so a table carries its chairs."""
+    graph = build_graph(shell, name="repair")
+    out: dict[str, set[str]] = {}
+    for edge in graph.relation("belongs_to"):
+        out.setdefault(edge.target, set()).add(edge.source)
+    return out
+
+
+# ── the score every action must beat ─────────────────────────────────────────
+def score(shell, baseline, held, exempt: str | None = None) -> tuple[int, int, float, float]:
+    """(violations, anchors broken, total penetration, displacement). Lexicographic, lower better.
+
+    Penetration sits third for a reason. Without it a repair that needs two steps can never take
+    the first: trimming an over-deep counter clears the wall behind it and reveals a 7 cm clip on
+    the wall beside it, so the violation COUNT is unchanged and a count-only gate discards the
+    trim — the room is measurably closer to correct and the solver cannot tell. Ranking depth
+    below violations and anchors keeps the guarantee (neither can rise) while letting genuine
+    progress through, and since every accepted action strictly reduces a quantity bounded at zero,
+    the loop still terminates.
+    """
+    errors = [v for v in check(shell) if v.severity == "error"]
+    now = {oid: set(attachments(o, shell.get("walls") or {}))
+           for oid, o in (shell.get("objects") or {}).items()}
+    # `exempt` is the object an action is resizing. A box that is legitimately smaller than it was
+    # recorded cannot still reach both walls of the corner it was merged across, and counting that
+    # as damage rejected the only correct repair for an over-deep counter run. Every OTHER object's
+    # anchors stay protected — the thing that must never happen is one edit quietly displacing
+    # something else.
+    broken = sum(len(walls - now.get(oid, set()))
+                 for oid, walls in held.items() if oid != exempt)
+    moved = 0.0
+    for oid, obj in (shell.get("objects") or {}).items():
+        was = (baseline.get("objects") or {}).get(oid)
+        if was:
+            moved += math.dist(obj["center"][:2], was["center"][:2])
+    # A furniture item that travelled half a metre from where it was scanned is a defect in its own
+    # right, not a tiebreak. Counting it only as "displacement", ranked below penetration, let the
+    # search buy one fewer overlap with a 54 cm slide across the room — legal, cheaper on paper,
+    # and obviously wrong to anyone looking at the result. Wall-mounted things are exempt: sliding
+    # a fixture along its own wall is how a fixture is repaired.
+    implausible = 0
+    for oid, obj in (shell.get("objects") or {}).items():
+        was = (baseline.get("objects") or {}).get(oid)
+        if not was or oid == exempt:
+            continue
+        if math.dist(obj["center"][:2], was["center"][:2]) > REVIEW_SHIFT and oid in held:
+            implausible += 1
+    penetration = sum(float(v.magnitude or 0.0) for v in errors)
+    # A collision and a unit knocked off its wall are counted as the SAME kind of defect, in one
+    # term. Ranking violations strictly above anchors let the search trade a dishwasher's wall for
+    # one fewer clash, which is a worse room by eye and a better score on paper — Airbnb-Cam's
+    # Table0 travelled 54 cm off its wall to remove a single overlap. Equal weight makes the trade
+    # explicit instead of automatic, and penetration then breaks the tie.
+    return (len(errors) + broken + implausible, round(penetration, 4), round(moved, 4))
+
+
+# ── the actions ──────────────────────────────────────────────────────────────
+def _shift(shell, object_id, delta, family):
+    """Move an object and everything that belongs to it, so a group stays a group."""
+    for oid in (object_id, *sorted(family.get(object_id, ()))):
+        obj = (shell.get("objects") or {}).get(oid)
+        if obj:
+            obj["center"][0] = round(obj["center"][0] + float(delta[0]), 4)
+            obj["center"][1] = round(obj["center"][1] + float(delta[1]), 4)
+
+
+def _flush_to(obj, wall, inward) -> float:
+    """The perpendicular offset an object installed against this wall should have: touching its
+    inner face, with nothing of it inside the wall."""
+    return _support(obj, inward) + wall.get("thickness", 0.0) / 2.0
+
+
+def _snap_delta(obj, wall):
+    """The move that puts this object's back face on its wall's line, on the side it is already on."""
+    start, along, normal, length = wall_frame(wall)
+    inward = normal
+    centre = np.array(obj["center"][:2], float)
+    perp = float(np.dot(centre - start, inward))
+    # Far enough that the box is out of the wall AND that `check` agrees. For a 3 cm wardrobe
+    # panel on a 0.1 mm wall those differ: its back face clears the wall 1.6 cm out while its
+    # centre is still inside the tolerance band, so aiming at the geometry alone leaves the
+    # violation exactly where it was.
+    clear = max(_support(obj, inward) + wall.get("thickness", 0.0) / 2.0,
+                adjust._wall_slab(wall) + SEPARATION)
+    want = math.copysign(clear, perp if perp else 1.0)
+    return inward * (want - perp)
+
+
+def _dewrap_delta(a, b, wall):
+    """Separate two units on the SAME wall by sliding ALONG it — a 1-D problem, solved in 1-D."""
+    start, along, _normal, _length = wall_frame(wall)
+    ta = float(np.dot(np.array(a["center"][:2], float) - start, along))
+    tb = float(np.dot(np.array(b["center"][:2], float) - start, along))
+    half_a, half_b = _support(a, along), _support(b, along)
+    gap = abs(tb - ta) - (half_a + half_b)
+    if gap >= 0:
+        return None
+    push = (-gap + SEPARATION) / 2.0
+    direction = 1.0 if tb >= ta else -1.0
+    return along * (-push * direction), along * (push * direction)
+
+
+def _floor_correction(obj, triangles, position) -> np.ndarray | None:
+    """Shortest vector that brings a footprint hanging off the plate back onto it.
+
+    Each outside corner is pulled to its nearest point on the plate's boundary; the corner that is
+    furthest out sets the move. Using the mesh rather than a bounding box matters here: an L-shaped
+    or multi-room plate has interior boundary that an AABB cannot see, and pulling an object toward
+    the middle of a bounding box can push it straight through the notch.
+    """
+    if not triangles:
+        return None
+    corners = object_footprint(obj) + (np.asarray(position, float)
+                                       - np.asarray(obj["center"][:2], float))
+    worst, best_vec = 0.0, None
+    for corner in corners:
+        if _inside_floor(corner, triangles):
+            continue
+        near, dist = None, float("inf")
+        for a, b, c in triangles:
+            for i, j in ((a, b), (b, c), (c, a)):
+                edge = j - i
+                length_sq = float(np.dot(edge, edge)) or 1e-12
+                t = max(0.0, min(1.0, float(np.dot(corner - i, edge)) / length_sq))
+                point = i + t * edge
+                d = float(np.linalg.norm(corner - point))
+                if d < dist:
+                    near, dist = point, d
+        if near is not None and dist > worst:
+            worst, best_vec = dist, near - corner
+    if best_vec is None or worst <= FLOOR_OUT_TOL:
+        return None
+    norm = float(np.linalg.norm(best_vec)) or 1.0
+    return best_vec / norm * (worst + SEPARATION)
+
+
+def _corner_fit(obj, wall_a, wall_b):
+    """Trim just enough, and translate, so a unit touches BOTH walls of its corner.
+
+    The case a human reads instantly and the generic solver cannot: a wardrobe stands in a corner,
+    is recorded slightly too deep, and reads as inside one wall while sitting 11 cm off the other.
+    Pushing it out of the first wall answers the violation and leaves it floating away from the
+    second — which is worse, not better, and is exactly what the plain shrink did here. The unit
+    belongs against both, so the repair is to make it fit the corner.
+    """
+    deltas, size = [], list(obj["size"])
+    for wall in (wall_a, wall_b):
+        start, along, normal, _length = wall_frame(wall)
+        centre = np.array(obj["center"][:2], float)
+        perp = float(np.dot(centre - start, normal))
+        want = math.copysign(_support(obj, normal) + wall.get("thickness", 0.0) / 2.0,
+                             perp if perp else 1.0)
+        gap = abs(perp) - abs(want)          # + means it stands off the wall, - means it is in it
+        deltas.append((normal, perp, want, gap))
+    # trim the axis facing whichever wall it is INSIDE, by that much, then re-seat against both
+    yaw = math.radians(obj.get("yaw", 0.0))
+    axes = (np.array([math.cos(yaw), math.sin(yaw)]), np.array([-math.sin(yaw), math.cos(yaw)]))
+    for normal, _perp, _want, gap in deltas:
+        if gap >= -1e-4:
+            continue
+        which = 0 if abs(float(np.dot(axes[0], normal))) > abs(float(np.dot(axes[1], normal))) else 1
+        trimmed = size[which] + gap - SEPARATION
+        if trimmed < size[which] * (1.0 - SHRINK_MAX) or trimmed < 0.12:
+            return None
+        size[which] = round(trimmed, 4)
+    return size
+
+
+def _axis_facing(obj, direction) -> int:
+    """Which of the box's own two horizontal axes points most along ``direction``."""
+    yaw = math.radians(obj.get("yaw", 0.0))
+    axis_x = np.array([math.cos(yaw), math.sin(yaw)])
+    axis_y = np.array([-math.sin(yaw), math.cos(yaw)])
+    return 0 if abs(float(np.dot(axis_x, direction))) > abs(float(np.dot(axis_y, direction))) else 1
+
+
+def _joint_shrink(a, b, axis, depth):
+    """Take HALF the overlap off each of two boxes, along the axis they overlap on.
+
+    The case this exists for is a room that is simply over-full once everything is where it belongs.
+    Both units are correctly against their walls, neither may move without leaving them, and the
+    only remaining freedom is size — so the right answer is a few centimetres off each rather than
+    a large trim on one or a large slide on either. Capped hard: a joint trim is a small correction
+    to two slightly generous boxes, and if it needs to be more than that the problem is not size.
+    """
+    out = []
+    for obj in (a, b):
+        which = _axis_facing(obj, np.asarray(axis, float))
+        size = list(obj["size"])
+        take = depth / 2.0 + SEPARATION
+        if take > size[which] * JOINT_SHRINK_MAX:
+            return None                      # too much to call it a trim
+        size[which] = round(size[which] - take, 4)
+        if size[which] < 0.12:
+            return None
+        out.append(size)
+    return out
+
+
+def _shrink_to_clear(obj, wall, depth):
+    """Trim the axis that faces this wall by what is buried, then re-seat against it."""
+    start, along, normal, _length = wall_frame(wall)
+    yaw = math.radians(obj.get("yaw", 0.0))
+    axis_x = np.array([math.cos(yaw), math.sin(yaw)])
+    axis_y = np.array([-math.sin(yaw), math.cos(yaw)])
+    which = 0 if abs(float(np.dot(axis_x, normal))) > abs(float(np.dot(axis_y, normal))) else 1
+    size = list(obj["size"])
+    # Trim by what is buried, ONCE. Doubling it would be right for a shrink about the centre, but
+    # the box is re-seated against the wall immediately afterwards, so the far face does not move.
+    # With the doubling, every real case exceeded SHRINK_MAX and no shrink was ever offered.
+    trimmed = size[which] - (depth + SEPARATION)
+    if trimmed < size[which] * (1.0 - SHRINK_MAX) or trimmed < 0.12:
+        return None
+    size[which] = round(trimmed, 4)
+    return size, which
+
+
+@dataclass
+class Candidate:
+    """One legal repair, ready to be tried and kept only if it earns its place."""
+
+    kind: str
+    detail: str
+    apply: Callable[[dict], None]
+    exempt: str | None = None        # an object whose own anchors this action may legitimately change
+
+
+def _candidates(shell, violation, held, family, dups) -> list[Candidate]:
+    """Everything worth trying for one violation, cheapest and least invasive first."""
+    objects = shell.get("objects") or {}
+    walls = shell.get("walls") or {}
+    obj = objects.get(violation.object)
+    if obj is None:
+        return []
+    out: list[Candidate] = []
+
+    # 1. a duplicate detection is deleted, never rearranged
+    for a_id, b_id in dups:
+        if violation.object not in (a_id, b_id):
+            continue
+        other = b_id if a_id == violation.object else a_id
+        for victim in (violation.object, other):
+            if victim in family:            # never delete something that hosts a group
+                continue
+            out.append(Candidate("drop", f"{victim} duplicates {a_id if victim == b_id else b_id}",
+                                 (lambda v: lambda s: s["objects"].pop(v, None))(victim)))
+
+    if violation.kind in ("wall_clash", "outside_room"):
+        wall_id = violation.other if violation.other in walls else None
+        # ONLY walls this object is genuinely installed against. The old 0.75 m sweep offered any
+        # wall within three quarters of a metre as somewhere the object "belongs", and Airbnb-Cam's
+        # Table0 was duly snapped onto a wall 50 cm away — abandoning the wall it was actually
+        # touching. Half a metre from a wall is not against it.
+        near = attachments(obj, walls, tol=ANCHOR_TOL)
+
+        # 2a. the minimal repair: push straight out of the wall it is inside, by exactly the depth
+        if wall_id:
+            wall = walls[wall_id]
+            depth = adjust._wall_crossing(obj, wall)
+            if depth > 0:
+                _start, _along, normal, _length = wall_frame(wall)
+                centre = np.array(obj["center"][:2], float)
+                side = math.copysign(1.0, float(np.dot(centre - _start, normal)) or 1.0)
+                push = normal * side * (depth + SEPARATION)
+                out.append(Candidate("push", f"{violation.object} out of {wall_id}",
+                                     (lambda d, o: lambda s: _shift(s, o, d, family))(
+                                         push, violation.object)))
+
+        # 2b. keep the wall it IS against and slide ALONG it until clear of the one it crosses.
+        # This is what a person does, and until now nothing in the action set could express it:
+        # the only wall repair was "seat it against wall X", so clearing wall B meant adopting
+        # some other wall as home.
+        if wall_id:
+            crossed = walls[wall_id]
+            for home_id in sorted(near):
+                if home_id == wall_id:
+                    continue
+                _s, along, _n, _l = wall_frame(walls[home_id])
+                for direction in (1.0, -1.0):
+                    probe = copy.deepcopy(obj)
+                    step = 0.0
+                    for _ in range(60):                 # 2 cm steps, up to 1.2 m
+                        step += 0.02
+                        probe["center"][0] = obj["center"][0] + along[0] * direction * step
+                        probe["center"][1] = obj["center"][1] + along[1] * direction * step
+                        if adjust._wall_crossing(probe, crossed) <= 0.0:
+                            break
+                    else:
+                        continue
+                    delta = along * direction * (step + SEPARATION)
+                    out.append(Candidate(
+                        "slide", f"{violation.object} along {home_id}, clear of {wall_id}",
+                        (lambda d, o: lambda s: _shift(s, o, d, family))(delta, violation.object)))
+
+        for candidate_wall in ([wall_id] if wall_id else []) + sorted(near):
+            wall = walls.get(candidate_wall or "")
+            if not wall:
+                continue
+            # 2. put it back flush against its wall
+            delta = _snap_delta(obj, wall)
+            if float(np.linalg.norm(delta)) > 1e-4:
+                out.append(Candidate("snap", f"{violation.object} flush to {candidate_wall}",
+                                     (lambda d, o: lambda s: _shift(s, o, d, family))(delta,
+                                                                                      violation.object)))
+            # 6. a box measured deeper than the thing it bounds, trimmed and re-seated
+            depth = adjust._wall_crossing(obj, wall)
+            may_shrink = obj.get("category", "") in SHRINKABLE and bool(near)
+            trimmed = _shrink_to_clear(obj, wall, depth) if (depth > 0 and may_shrink) else None
+            if trimmed:
+                size, _which = trimmed
+
+                def _do(o=violation.object, sz=size, w=candidate_wall):
+                    def run(s):
+                        s["objects"][o]["size"] = sz
+                        s["objects"][o]["center"][0] += float(_snap_delta(s["objects"][o],
+                                                                         s["walls"][w])[0])
+                        s["objects"][o]["center"][1] += float(_snap_delta(s["objects"][o],
+                                                                          s["walls"][w])[1])
+                    return run
+                out.append(Candidate("shrink",
+                                     f"{violation.object} trimmed to clear {candidate_wall}",
+                                     _do(), exempt=violation.object))
+
+    if violation.kind == "outside_room":
+        # Bring it back onto the plate. Measured from the nearest point INSIDE the room, so an
+        # object whose scan pose is outside can always be pulled back regardless of how far out it
+        # started — without this there was no action at all for a box off the floor.
+        triangles = _floor_triangles(shell)
+        back = _floor_correction(obj, triangles, tuple(obj["center"][:2]))
+        if back is not None:
+            out.append(Candidate("return", f"{violation.object} back onto the floor plate",
+                                 (lambda d, o: lambda s: _shift(s, o, d, family))(back,
+                                                                                  violation.object)))
+
+    if violation.kind in ("wall_clash", "outside_room") and obj.get("category", "") in SHRINKABLE:
+        near2 = sorted(attachments(obj, walls, tol=0.45))
+        for i in range(len(near2)):
+            for j in range(i + 1, len(near2)):
+                wall_a, wall_b = walls[near2[i]], walls[near2[j]]
+                head_a = math.degrees(math.atan2(*wall_frame(wall_a)[1][::-1])) % 180
+                head_b = math.degrees(math.atan2(*wall_frame(wall_b)[1][::-1])) % 180
+                if min(abs(head_a - head_b), 180 - abs(head_a - head_b)) < 25.0:
+                    continue                      # same direction: not a corner
+                fitted = _corner_fit(obj, wall_a, wall_b)
+                if not fitted:
+                    continue
+
+                def _fit(o=violation.object, sz=fitted, wa=near2[i], wb=near2[j]):
+                    def run(s):
+                        target = s["objects"][o]
+                        target["size"] = sz
+                        for wall_id in (wa, wb):
+                            d = _snap_delta(target, s["walls"][wall_id])
+                            target["center"][0] += float(d[0])
+                            target["center"][1] += float(d[1])
+                    return run
+                out.append(Candidate("corner_fit",
+                                     f"{violation.object} fitted into {near2[i]}/{near2[j]}",
+                                     _fit(), exempt=violation.object))
+
+    if violation.kind == "fixture_over_opening":
+        opening = (shell.get("openings") or {}).get(violation.other or "")
+        wall = walls.get((opening or {}).get("wall") or "") if opening else None
+        if wall:
+            slid = adjust._fixture_escape(obj, wall, opening, tuple(obj["center"][:2]))
+            if slid is not None:
+                delta = np.asarray(slid, float) - np.asarray(obj["center"][:2], float)
+                out.append(Candidate("slide", f"{violation.object} clear of {violation.other}",
+                                     (lambda d, o: lambda s: _shift(s, o, d, family))(
+                                         delta, violation.object)))
+
+    if violation.kind == "object_clash" and violation.other in objects:
+        other = objects[violation.other]
+        shared = set(attachments(obj, walls)) & set(attachments(other, walls))
+        # 3. two units on the same wall separate ALONG it
+        for wall_id in sorted(shared):
+            pair = _dewrap_delta(obj, other, walls[wall_id])
+            if pair:
+                da, db = pair
+                out.append(Candidate("dewrap", f"{violation.object}/{violation.other} along {wall_id}",
+                                     (lambda a, b, x, y: lambda s: (_shift(s, a, x, family),
+                                                                    _shift(s, b, y, family)))(
+                                         violation.object, violation.other, da, db)))
+        # 5b. both correctly placed and still overlapping: take a little off each
+        mtv_joint = obb_mtv(_obb(obj), _obb(other))
+        if mtv_joint:
+            pair = _joint_shrink(obj, other, mtv_joint[1], mtv_joint[0])
+            if pair:
+                def _joint(a_id=violation.object, b_id=violation.other, sizes=pair):
+                    def run(s):
+                        for oid, size in zip((a_id, b_id), sizes):
+                            s["objects"][oid]["size"] = size
+                            for wall_id in sorted(attachments(s["objects"][oid],
+                                                              s.get("walls") or {})):
+                                d = _snap_delta(s["objects"][oid], s["walls"][wall_id])
+                                s["objects"][oid]["center"][0] += float(d[0])
+                                s["objects"][oid]["center"][1] += float(d[1])
+                    return run
+                out.append(Candidate(
+                    "joint_shrink",
+                    f"{violation.object}+{violation.other} each trimmed {mtv_joint[0] / 2 * 100:.0f}cm",
+                    _joint(), exempt=violation.object))
+
+        # 4/5. otherwise separate along the MTV, moving whichever side is free
+        mtv = obb_mtv(_obb(obj), _obb(other))
+        if mtv:
+            push = np.array(mtv[1], float) * (mtv[0] + SEPARATION)
+            a_fixed = len(attachments(obj, walls)) > 1
+            b_fixed = len(attachments(other, walls)) > 1
+            options = []
+            if not b_fixed:
+                options.append((violation.other, push))
+            if not a_fixed:
+                options.append((violation.object, -push))
+            if not options:
+                options = [(violation.other, push * 0.5), (violation.object, -push * 0.5)]
+            for who, delta in options:
+                held_walls = attachments(objects[who], walls)
+                if len(held_walls) == 1:      # installed: project the push onto its wall
+                    wall = walls[next(iter(held_walls))]
+                    along = wall_frame(wall)[1]
+                    delta = along * float(np.dot(delta, along))
+                if float(np.linalg.norm(delta)) < 1e-4:
+                    continue
+                out.append(Candidate("separate", f"{who} away from its neighbour",
+                                     (lambda w, d: lambda s: _shift(s, w, d, family))(who, delta)))
+    return out
+
+
+def repair(shell: dict[str, Any], *, max_rounds: int = 14, beam: int = 3,
+           on_stuck: Callable[[dict, list], dict] | None = None) -> tuple[dict, list[dict]]:
+    """Search legal actions for the best room reachable, and return the best one SEEN.
+
+    Strictly greedy was not enough, and Airbnb-Cam is the proof: from its best greedy state every
+    single available action scores worse — 2 violations become 3, 4, or 5 — while the room is
+    plainly not finished. Two objects need to move together and no single move can start the pair.
+
+    So the search keeps a small beam and is allowed to step through a worse state to reach a better
+    one. The guarantee is unchanged, because it is enforced at the END rather than at every step:
+    the state returned is the best state ever visited, and the input is in that set. A room can
+    therefore never come back worse than it went in — the search simply has room to manoeuvre on
+    the way.
+    """
+    baseline = copy.deepcopy(shell)
+    work, moves = ground(copy.deepcopy(shell))
+    work, opening_moves = reseat_openings(work)
+    held = {oid: set(attachments(o, work.get("walls") or {}))
+            for oid, o in (work.get("objects") or {}).items()}
+    held = {k: v for k, v in held.items() if v}
+    dups = duplicates(baseline)
+    family = groups(work)
+    log: list[dict] = []
+
+    start_score = score(work, baseline, held)
+    frontier = [(start_score, work, [])]
+    best_score, best_state, best_log = start_score, work, []
+
+    for _round in range(max_rounds):
+        expanded = []
+        for state_score, state, trail in frontier:
+            errors = [v for v in check(state) if v.severity == "error"]
+            if not errors:
+                continue
+            for violation in errors:
+                for candidate in _candidates(state, violation, held, family, dups):
+                    trial = copy.deepcopy(state)
+                    try:
+                        candidate.apply(trial)
+                    except Exception:                   # noqa: BLE001 — a bad action is just skipped
+                        continue
+                    trial_score = score(trial, baseline, held, exempt=candidate.exempt)
+                    step = trail + [{"action": candidate.kind, "detail": candidate.detail,
+                                     "defects": trial_score[0]}]
+                    expanded.append((trial_score, trial, step))
+                    if trial_score < best_score:
+                        best_score, best_state, best_log = trial_score, trial, step
+        if not expanded or best_score[0] == 0:
+            break
+        expanded.sort(key=lambda item: item[0])
+        frontier = expanded[:beam]
+
+    work, log = best_state, best_log
+    current = best_score
+
+    if on_stuck is not None:
+        errors = [v for v in check(work) if v.severity == "error"]
+        if errors:
+            proposed = on_stuck(work, errors)
+            if proposed is not None:
+                trial_score = score(proposed, baseline, held)
+                if trial_score < current:
+                    work, current = proposed, trial_score
+                    log.append({"action": "photo", "detail": "reference image consulted",
+                        "defects": current[0]})
+
+    for oid, obj in (work.get("objects") or {}).items():
+        was = (baseline.get("objects") or {}).get(oid)
+        if not was:
+            continue
+        travelled = math.dist(obj["center"][:2], was["center"][:2])
+        resized = [round(v, 3) for v in obj["size"]] != [round(v, 3) for v in was["size"]]
+        if travelled >= 1e-4 or resized:
+            moves.append(Move(oid, [was["center"][0], was["center"][1]],
+                              [obj["center"][0], obj["center"][1]], travelled,
+                              "trimmed to its measured depth" if resized
+                              else "repaired within the room's own structure"))
+    return work, moves + opening_moves, log
+
+
+def solve_v11(shell: dict[str, Any], *, detail: bool = False):
+    """Action-based repair with a strict monotone gate. Cannot return a worse room than it got."""
+    out, moves, log = repair(shell)
+    return (out, moves, log) if detail else out
+
+
+def solve_v12(shell: dict[str, Any], *, detail: bool = False):
+    """v11, with the reference photograph as the last resort rather than the first.
+
+    The action set is deliberately exhausted before any model is asked. By the time ``on_stuck``
+    fires, every cheap, checkable, deterministic repair has already been tried and rejected, so the
+    question put to the model is narrow and the evidence for it — the crop with the box drawn on
+    the photo — is the only thing left that geometry does not have. Its answer goes through the
+    same gate as everything else: applied to a copy, kept only if the room improves.
+    """
+    from .agent import apply_proposals, propose
+    from pathlib import Path
+
+    root = Path((shell.get("meta") or {}).get("batch_dir") or ".")
+
+    def ask(state, errors):
+        if not root.is_dir() or not (root / "references").is_dir():
+            return None
+        proposals = [p for v in errors if (p := propose(state, v, root))]
+        if not proposals:
+            return None
+        fixed, _log = apply_proposals(state, proposals)
+        return fixed
+
+    out, moves, log = repair(shell, on_stuck=ask)
+    return (out, moves, log) if detail else out
+
+
+def solve_v13(shell: dict[str, Any], *, detail: bool = False):
+    """Deterministic first; where its answer is legal but implausible, UNDO it and ask.
+
+    v11 clears Airbnb-Cam — by sliding a table half a metre across the room. Nothing in the
+    violation count objects, and to a person the result is obviously wrong: that table did not move
+    50 cm, and the wardrobe beside it plainly belongs in its corner rather than 25 cm out from it.
+    Scoring cannot see this, because the room is genuinely collision-free either way.
+
+    So a move that is large enough to be a claim rather than a correction is treated as a question,
+    not an answer. Those objects are put BACK where the scan measured them — the model is asked
+    about the real measurement, not about a guess it would have to unpick — and it answers with
+    "attach it to these walls", "it is this size", or "leave it". Whatever it says goes through the
+    same gate, and if nothing it proposes beats the deterministic result, that result stands. The
+    ceiling is never lower than v11's; only the reasoning is better.
+    """
+    from pathlib import Path
+
+    from .agent import apply_proposals, propose
+
+    baseline = copy.deepcopy(shell)
+    solved, moves, log = repair(shell)
+    root = Path((shell.get("meta") or {}).get("batch_dir") or ".")
+
+    walls = solved.get("walls") or {}
+    suspects: dict[str, str] = {}
+    for oid, obj in (solved.get("objects") or {}).items():
+        was = (baseline.get("objects") or {}).get(oid)
+        if not was:
+            continue
+        travelled = math.dist(obj["center"][:2], was["center"][:2])
+        if travelled > REVIEW_SHIFT:
+            suspects[oid] = f"sliding it {travelled * 100:.0f} cm from where the scan put it"
+    for violation in (v for v in check(solved) if v.severity == "error"):
+        suspects.setdefault(violation.object, "failing to resolve it at all")
+
+    if not suspects or not root.is_dir() or not (root / "references").is_dir():
+        return (solved, moves, log) if detail else solved
+
+    # put the suspects back where the scan measured them, and ask about THAT
+    reverted = copy.deepcopy(solved)
+    for oid, _why in suspects.items():
+        was = (baseline.get("objects") or {}).get(oid)
+        if was:
+            reverted["objects"][oid]["center"] = list(was["center"])
+            reverted["objects"][oid]["size"] = list(was["size"])
+
+    held = {oid: set(attachments(o, walls)) for oid, o in (baseline.get("objects") or {}).items()}
+    held = {k: v for k, v in held.items() if v}
+    proposals = []
+    for violation in check(reverted):
+        if violation.severity != "error" or violation.object not in suspects:
+            continue
+        proposal = propose(reverted, violation, root, suspicion=suspects[violation.object])
+        if proposal:
+            proposals.append(proposal)
+    if not proposals:
+        return (solved, moves, log) if detail else solved
+
+    asked, gate = apply_proposals(reverted, proposals)
+    # let the deterministic actions clean up whatever the model's edit left behind
+    finished, more_moves, more_log = repair(asked)
+
+    if score(finished, baseline, held) < score(solved, baseline, held):
+        log = log + [{"action": "rollback+ask", "detail": ", ".join(
+            f"{g.get('object_id')}:{g.get('action')}:{'kept' if g.get('accepted') else 'dropped'}"
+            for g in gate)}] + more_log
+        return (finished, more_moves, log) if detail else finished
+    return (solved, moves, log) if detail else solved

--- a/src/litereality_agent/pipeline/scene_init/layout/repair.py
+++ b/src/litereality_agent/pipeline/scene_init/layout/repair.py
@@ -10,18 +10,24 @@ cannot.
 
 The actions are ordered the way a person would try them, least invasive first:
 
-1. ``drop``        one of two boxes that were already sitting on top of each other in the INPUT is
-                   a duplicate detection, not a collision. Deleting the extra is free; moving it
-                   is nonsense.
-2. ``snap``        an installed unit reads as inside its wall because its depth was measured long.
+0. ``drop``        OFF by default; ``$LR_LAYOUT_DROP=1`` arms it. Two boxes already sitting on top
+                   of each other in the input are one object detected twice, and deleting the extra
+                   was cheap and usually right — but "usually" is the problem. A deletion is the
+                   one action here with no visible failure mode: a move that goes wrong is a box in
+                   an odd place, while a wrong deletion is an oven that is simply not in the room,
+                   and nothing downstream reports the absence. Kitchen lost a counter run assembled
+                   from five detections that way. A duplicate left standing costs a redundant
+                   generated asset, which is visible, cheap and reversible; a wrong deletion is
+                   none of those. The trade is not close.
+1. ``snap``        an installed unit reads as inside its wall because its depth was measured long.
                    Putting it flush against that wall is a restoration, not a correction.
-3. ``dewrap``      two units on the SAME wall overlap along it. That is a one-dimensional problem
+2. ``dewrap``      two units on the SAME wall overlap along it. That is a one-dimensional problem
                    — slide them apart along the wall — and solving it in 2D is what walks a
                    dishwasher off its cabinet line.
-4. ``slide``       an installed unit slides along its own wall. It never leaves it.
-5. ``separate``    ordinary pair separation along the minimum translation vector, carrying the
+3. ``slide``       an installed unit slides along its own wall. It never leaves it.
+4. ``separate``    ordinary pair separation along the minimum translation vector, carrying the
                    object's group with it so a table takes its chairs.
-6. ``shrink``      a merged box recorded deeper than the thing it bounds, trimmed and re-seated
+5. ``shrink``      a merged box recorded deeper than the thing it bounds, trimmed and re-seated
                    against its wall. Bounded, and only when it beats every cheaper action.
 
 Scoring is lexicographic: violations first, then wall anchors broken, then total displacement. So
@@ -33,6 +39,7 @@ from __future__ import annotations
 
 import copy
 import math
+import os
 from dataclasses import dataclass
 from typing import Any, Callable
 
@@ -42,7 +49,7 @@ from . import adjust
 from .adjust import (ANCHOR_TOL, FLOOR_OUT_TOL, SEPARATION, Move, check,
                      _floor_triangles, _inside_floor, _obb,
                      _support, ground, reseat_openings)
-from .graph import build_graph, obb_mtv, wall_distance
+from .graph import build_graph, in_category, obb_mtv, wall_distance
 from .shell import object_footprint, wall_frame
 
 __all__ = ["duplicates", "score", "repair", "solve_v11"]
@@ -50,6 +57,16 @@ __all__ = ["duplicates", "score", "repair", "solve_v11"]
 REVIEW_SHIFT = 0.22  # past this, a move is a claim about the room rather than a correction
 DUP_SAME = 0.50      # overlap / smaller volume, for two boxes of the same category
 DUP_CROSS = 0.75     # more is demanded across categories: a tucked chair reaches ~0.5 honestly
+# Two detections of ONE object are about the same size. Past this ratio the big box is not a
+# duplicate of the small one, it CONTAINS it — a cabinet standing inside a counter run, a basin
+# undermounted in it. Kitchen's pair were 5.9x and 65x apart and both scored a perfect 1.00 on an
+# overlap measure normalised by the smaller box, which is exactly what containment looks like.
+DUP_VOLUME_RATIO = 3.0
+
+
+def _dropping_armed() -> bool:
+    """Deletion is opt-in. Read per call, so a test or a run can arm it without a reimport."""
+    return os.environ.get("LR_LAYOUT_DROP", "0") not in ("0", "false", "no", "")
 SHRINK_MAX = 0.35    # a box may not lose more than this fraction of a dimension
 # Only these get trimmed. RoomPlan merges ADJACENT INSTALLED units — a counter with the wall behind
 # it, an oven into its cabinet run — and records the result deeper than the thing it bounds. It
@@ -115,6 +132,9 @@ def duplicates(shell: dict[str, Any]) -> set[tuple[str, str]]:
     for i in range(len(ids)):
         for j in range(i + 1, len(ids)):
             a, b = objects[ids[i]], objects[ids[j]]
+            big, small = max(_volume(a), _volume(b)), min(_volume(a), _volume(b))
+            if big > DUP_VOLUME_RATIO * small:
+                continue                    # containment, not duplication — see DUP_VOLUME_RATIO
             same = a.get("category") == b.get("category")
             if _overlap_fraction(a, b) >= (DUP_SAME if same else DUP_CROSS):
                 found.add((ids[i], ids[j]))
@@ -358,13 +378,20 @@ def _candidates(shell, violation, held, family, dups) -> list[Candidate]:
         return []
     out: list[Candidate] = []
 
-    # 1. a duplicate detection is deleted, never rearranged
-    for a_id, b_id in dups:
+    # 0. a duplicate detection is deleted, never rearranged — only when armed. See the module
+    #    docstring: this is the one action whose failure is invisible downstream.
+    for a_id, b_id in (dups if _dropping_armed() else ()):
         if violation.object not in (a_id, b_id):
             continue
         other = b_id if a_id == violation.object else a_id
         for victim in (violation.object, other):
             if victim in family:            # never delete something that hosts a group
+                continue
+            if objects[victim].get("merged_from"):
+                # The box merge fused this unit out of several detections one step earlier, on
+                # evidence this pass does not have. Undoing that silently — and it is silent, the
+                # object simply stops existing — costs the scan every member of the run: Kitchen's
+                # Oven_Storage_Stove0 was five boxes, two ovens and two stoves among them.
                 continue
             out.append(Candidate("drop", f"{victim} duplicates {a_id if victim == b_id else b_id}",
                                  (lambda v: lambda s: s["objects"].pop(v, None))(victim)))
@@ -428,7 +455,7 @@ def _candidates(shell, violation, held, family, dups) -> list[Candidate]:
                                                                                       violation.object)))
             # 6. a box measured deeper than the thing it bounds, trimmed and re-seated
             depth = adjust._wall_crossing(obj, wall)
-            may_shrink = obj.get("category", "") in SHRINKABLE and bool(near)
+            may_shrink = in_category(obj.get("category", ""), SHRINKABLE) and bool(near)
             trimmed = _shrink_to_clear(obj, wall, depth) if (depth > 0 and may_shrink) else None
             if trimmed:
                 size, _which = trimmed
@@ -456,7 +483,8 @@ def _candidates(shell, violation, held, family, dups) -> list[Candidate]:
                                  (lambda d, o: lambda s: _shift(s, o, d, family))(back,
                                                                                   violation.object)))
 
-    if violation.kind in ("wall_clash", "outside_room") and obj.get("category", "") in SHRINKABLE:
+    if violation.kind in ("wall_clash", "outside_room") and in_category(obj.get("category", ""),
+                                                                        SHRINKABLE):
         near2 = sorted(attachments(obj, walls, tol=0.45))
         for i in range(len(near2)):
             for j in range(i + 1, len(near2)):
@@ -571,7 +599,7 @@ def repair(shell: dict[str, Any], *, max_rounds: int = 14, beam: int = 3,
     held = {oid: set(attachments(o, work.get("walls") or {}))
             for oid, o in (work.get("objects") or {}).items()}
     held = {k: v for k, v in held.items() if v}
-    dups = duplicates(baseline)
+    dups = duplicates(baseline) if _dropping_armed() else set()
     family = groups(work)
     log: list[dict] = []
 

--- a/src/litereality_agent/pipeline/scene_init/layout/repair.py
+++ b/src/litereality_agent/pipeline/scene_init/layout/repair.py
@@ -46,9 +46,19 @@ from typing import Any, Callable
 import numpy as np
 
 from . import adjust
-from .adjust import (ANCHOR_TOL, FLOOR_OUT_TOL, SEPARATION, Move, check,
-                     _floor_triangles, _inside_floor, _obb,
-                     _support, ground, reseat_openings)
+from .adjust import (
+    ANCHOR_TOL,
+    FLOOR_OUT_TOL,
+    SEPARATION,
+    Move,
+    _floor_triangles,
+    _inside_floor,
+    _obb,
+    _support,
+    check,
+    ground,
+    reseat_openings,
+)
 from .graph import build_graph, in_category, obb_mtv, wall_distance
 from .shell import object_footprint, wall_frame
 
@@ -674,8 +684,9 @@ def solve_v12(shell: dict[str, Any], *, detail: bool = False):
     the photo — is the only thing left that geometry does not have. Its answer goes through the
     same gate as everything else: applied to a copy, kept only if the room improves.
     """
-    from .agent import apply_proposals, propose
     from pathlib import Path
+
+    from .agent import apply_proposals, propose
 
     root = Path((shell.get("meta") or {}).get("batch_dir") or ".")
 

--- a/src/litereality_agent/pipeline/scene_init/layout/report.py
+++ b/src/litereality_agent/pipeline/scene_init/layout/report.py
@@ -1,0 +1,512 @@
+"""report.py — the layout pass, drawn, so the run leaves evidence rather than a number.
+
+``layout_report.json`` says ``4 violations -> 0, moved 1, dropped 2``. That is the right thing to
+assert and the wrong thing to trust: a violation count cannot distinguish a repair that put a
+counter back against its wall from one that shoved a table half a metre across the room, and both
+read as zero. So every run writes a picture of what it actually did.
+
+One self-contained HTML file per scan, two floor plans side by side in the SAME projection:
+
+    as scanned          the boxes the capture produced, with every violating object outlined red
+    after the pass      the same room repaired, the scanned positions ghosted underneath in dashed
+                        outline and each correction drawn as an arrow from where the box WAS
+
+Ghost-plus-arrow is the whole design. A before/after pair you have to flick between hides small
+moves and exaggerates large ones; drawn on top of each other, a 3 cm reseat and a 50 cm slide are
+told apart at a glance, which is exactly the judgement the score cannot make.
+
+Deliberately dependency-free: inline SVG built as text, no matplotlib, no CDN, nothing to resolve.
+It renders from ``file://``, survives being emailed, and — since it costs a few milliseconds of
+string building — can run on every scan without anyone deciding whether it is worth it.
+"""
+
+from __future__ import annotations
+
+import html
+import math
+import zlib
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from .shell import facing_yaw, object_footprint, opening_span, wall_frame
+
+__all__ = ["render", "write"]
+
+# One palette shared by both panels, so an object is the same colour before and after and the eye
+# tracks it across the pair. Shared with `physical_engine.plotting` — keep them in step.
+CATEGORY_COLORS = {
+    "wall": "#4a5568", "floor": "#cbd5e0", "ceiling": "#e2e8f0",
+    "door": "#dd6b20", "window": "#3182ce", "opening": "#805ad5",
+    "chair": "#38a169", "stool": "#48bb78", "table": "#d69e2e", "desk": "#b7791f",
+    "sofa": "#9f7aea", "bed": "#ed64a6", "storage": "#0987a0", "cabinet": "#00a3c4",
+    "television": "#e53e3e", "refrigerator": "#2c7a7b", "stove": "#c05621", "oven": "#9c4221",
+    "sink": "#2b6cb0", "toilet": "#4299e1", "bathtub": "#63b3ed", "washer": "#667eea",
+    "dishwasher": "#5a67d8", "fireplace": "#c53030", "stairs": "#718096",
+}
+_FALLBACK = ["#7f9cf5", "#f6ad55", "#68d391", "#fc8181", "#b794f4", "#4fd1c5", "#f687b3"]
+
+BAD = "#e53e3e"          # a violation, before or remaining
+FIXED = "#38a169"        # a violation the pass cleared
+GHOST = "#a0aec0"        # where the scan put it
+
+PANEL_W = 640.0          # px available to one plan
+PANEL_H = 540.0
+MARGIN = 0.45            # metres of room drawn around the outermost geometry
+MOVED_TOL = 0.01         # under a centimetre is arithmetic, not a move
+FLOOR_FACE_CAP = 4000    # a pathological floor mesh must not produce a 50 MB file
+
+
+def category_color(category: str) -> str:
+    """A stable colour for a category, including the compound names a box merge produces.
+
+    ``Oven_Storage_Stove0`` is one object made of three, and colouring it by hash makes the merged
+    unit look unrelated to the run it replaced. Taking the first token that IS a known category
+    keeps it the colour of the thing it mostly is. The fallback hashes with CRC32 rather than
+    ``hash()``, whose string seed is randomised per process — the same room would otherwise come
+    out a different colour on every run, and a picture you cannot compare to yesterday's is worth
+    much less than one you can.
+    """
+    if category in CATEGORY_COLORS:
+        return CATEGORY_COLORS[category]
+    for token in category.split("_"):
+        if token in CATEGORY_COLORS:
+            return CATEGORY_COLORS[token]
+    return _FALLBACK[zlib.crc32(category.encode()) % len(_FALLBACK)]
+
+
+def _e(text: Any) -> str:
+    return html.escape(str(text), quote=True)
+
+
+def _n(value: float) -> str:
+    """Coordinates at 0.1 px. Full float repr triples the file size and shows nothing."""
+    return f"{value:.1f}"
+
+
+class _View:
+    """One world→pixel projection, shared by both panels so they are directly comparable.
+
+    Fitting each panel to its own contents would be the obvious thing and is wrong: the repaired
+    room is very slightly smaller (a dropped duplicate, a trimmed counter), so a per-panel fit
+    scales it up a fraction and every object in the room appears to have shifted.
+    """
+
+    def __init__(self, shells: list[dict[str, Any]]):
+        xs: list[float] = []
+        ys: list[float] = []
+        for shell in shells:
+            for wall in (shell.get("walls") or {}).values():
+                for point in (wall["start"], wall["end"]):
+                    xs.append(float(point[0]))
+                    ys.append(float(point[1]))
+            for vert in ((shell.get("floor") or {}).get("verts") or []):
+                xs.append(float(vert[0]))
+                ys.append(float(vert[1]))
+            for obj in (shell.get("objects") or {}).values():
+                for corner in object_footprint(obj):
+                    xs.append(float(corner[0]))
+                    ys.append(float(corner[1]))
+        if not xs:
+            xs, ys = [0.0, 1.0], [0.0, 1.0]
+        self.min_x, self.max_x = min(xs) - MARGIN, max(xs) + MARGIN
+        self.min_y, self.max_y = min(ys) - MARGIN, max(ys) + MARGIN
+        span_x = max(self.max_x - self.min_x, 1e-3)
+        span_y = max(self.max_y - self.min_y, 1e-3)
+        self.scale = min(PANEL_W / span_x, PANEL_H / span_y)
+        self.width = span_x * self.scale
+        self.height = span_y * self.scale
+
+    def pt(self, x: float, y: float) -> tuple[float, float]:
+        """World metres → SVG pixels. Y is flipped: the plan is Z-up, the canvas is not."""
+        return ((float(x) - self.min_x) * self.scale,
+                (self.max_y - float(y)) * self.scale)
+
+    def poly(self, points) -> str:
+        return " ".join(f"{_n(a)},{_n(b)}" for a, b in (self.pt(p[0], p[1]) for p in points))
+
+
+def _violation_index(violations) -> dict[str, list[str]]:
+    """object id → the violations naming it, both as subject and as the thing it collides with."""
+    index: dict[str, list[str]] = {}
+    for violation in violations or []:
+        text = f"{violation.kind}: {violation.detail}"
+        index.setdefault(violation.object, []).append(text)
+        if violation.other:
+            index.setdefault(violation.other, []).append(text)
+    return index
+
+
+def _floor_path(shell: dict[str, Any], view: _View) -> str:
+    """The floor mesh as ONE path — every triangle wound the same way, which is load-bearing.
+
+    A RoomPlan floor arrives as a triangle soup with no consistent orientation, and SVG's default
+    ``nonzero`` fill rule reads a clockwise triangle laid over a counter-clockwise one as a hole.
+    Emitted as they come, the room's triangles cancel each other out and the plate renders as
+    *nothing at all* — not a wrong shape, an invisible one, which is exactly the kind of bug a
+    picture is supposed to catch rather than contain. Flipping every negative-area triangle makes
+    the winding uniform, so nonzero unions them into the one region meant by the mesh.
+    """
+    verts = (shell.get("floor") or {}).get("verts") or []
+    faces = (shell.get("floor") or {}).get("faces") or []
+    if not verts or not faces:
+        return ""
+    parts: list[str] = []
+    for face in faces[:FLOOR_FACE_CAP]:
+        try:
+            corners = [view.pt(verts[i][0], verts[i][1]) for i in face]
+        except IndexError:
+            continue
+        if len(corners) < 3:
+            continue
+        area = sum(corners[i][0] * corners[(i + 1) % len(corners)][1]
+                   - corners[(i + 1) % len(corners)][0] * corners[i][1]
+                   for i in range(len(corners)))
+        if area < 0:
+            corners.reverse()
+        head = f"M{_n(corners[0][0])} {_n(corners[0][1])}"
+        parts.append(head + "".join(f"L{_n(x)} {_n(y)}" for x, y in corners[1:]) + "Z")
+    if not parts:
+        return ""
+    return f'<path class="floor" d="{"".join(parts)}"/>'
+
+
+def _walls_svg(shell: dict[str, Any], view: _View) -> str:
+    out: list[str] = []
+    walls = shell.get("walls") or {}
+    label = len(walls) <= 20      # past this the labels only overprint each other
+    for wall_id, wall in walls.items():
+        start, _along, normal, length = wall_frame(wall)
+        x1, y1 = view.pt(start[0], start[1])
+        x2, y2 = view.pt(wall["end"][0], wall["end"][1])
+        # RoomPlan emits sub-centimetre stubs at corners; drawn solid they read as real walls.
+        sliver = length < 0.35
+        klass = "wall sliver" if sliver else "wall"
+        out.append(f'<line class="{klass}" x1="{_n(x1)}" y1="{_n(y1)}" '
+                   f'x2="{_n(x2)}" y2="{_n(y2)}"><title>{_e(wall_id)} · '
+                   f'{length:.2f} m</title></line>')
+        if label and not sliver:
+            mid = (start + np.asarray(wall["end"], dtype=float)) / 2.0 + normal * 0.18
+            mx, my = view.pt(mid[0], mid[1])
+            out.append(f'<text class="wall-label" x="{_n(mx)}" y="{_n(my)}">'
+                       f'{_e(wall_id.replace("Wall", "W"))}</text>')
+    return "".join(out)
+
+
+def _openings_svg(shell: dict[str, Any], view: _View) -> str:
+    out: list[str] = []
+    walls = shell.get("walls") or {}
+    for opening_id, opening in (shell.get("openings") or {}).items():
+        wall = walls.get(opening.get("wall") or "")
+        if not wall:
+            continue
+        start, along, _normal, _length = wall_frame(wall)
+        # `offset` is the distance to the opening's CENTRE. See shell.opening_span — reading it as
+        # a leading edge slides every door half its own width along the wall.
+        t0, t1 = opening_span(opening)
+        a, b = start + along * t0, start + along * t1
+        x1, y1 = view.pt(a[0], a[1])
+        x2, y2 = view.pt(b[0], b[1])
+        colour = category_color(opening.get("type", "opening"))
+        out.append(f'<line class="opening" stroke="{colour}" x1="{_n(x1)}" y1="{_n(y1)}" '
+                   f'x2="{_n(x2)}" y2="{_n(y2)}"><title>{_e(opening_id)} · '
+                   f'{opening.get("type", "opening")}</title></line>')
+    return "".join(out)
+
+
+def _object_svg(object_id: str, obj: dict[str, Any], view: _View, *,
+                edge: str | None, note: str = "") -> str:
+    colour = category_color(obj.get("category", ""))
+    points = view.poly(object_footprint(obj))
+    stroke = edge or colour
+    width = 2.4 if edge else 1.0
+    centre_x, centre_y = view.pt(obj["center"][0], obj["center"][1])
+
+    # The arrow is FACING (yaw - 90 deg), not `yaw` — `yaw` is the box's width axis and points
+    # sideways across the object. Capped, or a 3.5 m counter throws an arrow across the room.
+    angle = math.radians(facing_yaw(obj))
+    reach = min(max(obj["size"][0], obj["size"][1]) * 0.55, 0.55) * view.scale
+    tip_x = centre_x + math.cos(angle) * reach
+    tip_y = centre_y - math.sin(angle) * reach       # canvas Y is flipped
+
+    size = obj.get("size", [0, 0, 0])
+    tip = (f'{object_id} · {obj.get("category", "?")}\n'
+           f'{size[0]:.2f} x {size[1]:.2f} x {size[2]:.2f} m\n'
+           f'centre ({obj["center"][0]:.2f}, {obj["center"][1]:.2f}, {obj["center"][2]:.2f})\n'
+           f'yaw {obj.get("yaw", 0.0):.1f} deg')
+    if note:
+        tip += f"\n{note}"
+    return (f'<g class="obj" data-id="{_e(object_id)}"><title>{_e(tip)}</title>'
+            f'<polygon points="{points}" fill="{colour}" fill-opacity="0.42" '
+            f'stroke="{stroke}" stroke-width="{width}"/>'
+            f'<line class="facing" x1="{_n(centre_x)}" y1="{_n(centre_y)}" '
+            f'x2="{_n(tip_x)}" y2="{_n(tip_y)}"/>'
+            f'<text class="obj-label" x="{_n(centre_x)}" y="{_n(centre_y)}">'
+            f'{_e(object_id)}</text></g>')
+
+
+def _panel(shell: dict[str, Any], view: _View, *, highlight: dict[str, str],
+           notes: dict[str, list[str]], ghost: dict[str, Any] | None = None,
+           arrows: list[tuple[str, dict, dict]] | None = None,
+           gone: dict[str, dict] | None = None) -> str:
+    """One floor plan. ``ghost`` underlays a second shell; ``arrows`` draw what moved."""
+    parts = [f'<svg viewBox="0 0 {_n(view.width)} {_n(view.height)}" '
+             f'width="{_n(view.width)}" height="{_n(view.height)}" '
+             f'xmlns="http://www.w3.org/2000/svg" class="plan">',
+             '<defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" '
+             'markerWidth="5" markerHeight="5" orient="auto-start-reverse">'
+             '<path d="M0 0 L10 5 L0 10 z" fill="#1a202c"/></marker></defs>',
+             _floor_path(shell, view), _walls_svg(shell, view), _openings_svg(shell, view)]
+
+    if ghost:
+        # A dropped object is drawn as dropped, not as a ghost — two outlines over the same box
+        # would read as "it moved and also vanished".
+        for object_id, obj in (ghost.get("objects") or {}).items():
+            if object_id in (gone or {}):
+                continue
+            parts.append(f'<polygon class="ghost" points="{view.poly(object_footprint(obj))}"/>')
+
+    for object_id, obj in (gone or {}).items():
+        parts.append(f'<polygon class="dropped" points="{view.poly(object_footprint(obj))}">'
+                     f'<title>{_e(object_id)} — dropped as a duplicate detection</title></polygon>')
+
+    for object_id, obj in (shell.get("objects") or {}).items():
+        parts.append(_object_svg(object_id, obj, view, edge=highlight.get(object_id),
+                                 note="; ".join(notes.get(object_id, []))))
+
+    for object_id, was, now in (arrows or []):
+        x1, y1 = view.pt(was["center"][0], was["center"][1])
+        x2, y2 = view.pt(now["center"][0], now["center"][1])
+        distance = math.dist(was["center"][:2], now["center"][:2])
+        parts.append(f'<line class="move" x1="{_n(x1)}" y1="{_n(y1)}" x2="{_n(x2)}" '
+                     f'y2="{_n(y2)}" marker-end="url(#arrow)"><title>{_e(object_id)} moved '
+                     f'{distance * 100:.0f} cm</title></line>')
+
+    parts.append("</svg>")
+    return "".join(parts)
+
+
+def _legend(shells: list[dict[str, Any]]) -> str:
+    categories = sorted({obj.get("category", "") for shell in shells
+                         for obj in (shell.get("objects") or {}).values()})
+    swatches = "".join(
+        f'<span class="swatch"><i style="background:{category_color(c)}"></i>{_e(c)}</span>'
+        for c in categories if c)
+    return (f'<div class="legend">{swatches}'
+            f'<span class="swatch"><i class="ghost-key"></i>as scanned</span>'
+            f'<span class="swatch"><i style="background:{BAD}"></i>violation</span>'
+            f'<span class="swatch"><i class="dropped-key"></i>dropped</span></div>')
+
+
+def _diff(before: dict[str, Any], after: dict[str, Any]) -> dict[str, Any]:
+    """What changed between the two shells, measured rather than taken on trust.
+
+    The stage already has the summary ``adapter.apply_to_objects`` returned, but that describes the
+    pkl write. This describes the picture, and deriving it here means the drawing can never claim a
+    move the geometry does not show.
+    """
+    old = before.get("objects") or {}
+    new = after.get("objects") or {}
+    moved, resized, arrows = [], [], []
+    for object_id, now in new.items():
+        was = old.get(object_id)
+        if not was:
+            continue
+        distance = math.dist(was["center"][:2], now["center"][:2])
+        if distance > MOVED_TOL:
+            moved.append((object_id, distance))
+            arrows.append((object_id, was, now))
+        if any(abs(a - b) > MOVED_TOL for a, b in zip(was["size"], now["size"])):
+            resized.append((object_id, was["size"], now["size"]))
+    gone = {object_id: obj for object_id, obj in old.items() if object_id not in new}
+    return {"moved": moved, "resized": resized, "gone": gone, "arrows": arrows}
+
+
+def _violation_rows(violations, cleared: set[str]) -> str:
+    rows = []
+    for violation in violations or []:
+        state = "cleared" if str(violation) in cleared else "remaining"
+        colour = FIXED if state == "cleared" else BAD
+        rows.append(f'<tr><td class="mono">{_e(violation.object)}</td>'
+                    f'<td class="mono">{_e(violation.kind)}</td>'
+                    f'<td>{_e(violation.detail)}</td>'
+                    f'<td style="color:{colour}">{state}</td></tr>')
+    return "".join(rows)
+
+
+def render(scan: str, before: dict[str, Any], after: dict[str, Any], *,
+           violations_before=None, violations_after=None,
+           actions: list[dict] | None = None, mode: str = "deterministic") -> str:
+    """The whole report as one HTML string. Pure function — it reads nothing and writes nothing."""
+    from .adjust import check
+
+    if violations_before is None:
+        violations_before = check(before)
+    if violations_after is None:
+        violations_after = check(after)
+    errors_before = [v for v in violations_before if v.severity == "error"]
+    errors_after = [v for v in violations_after if v.severity == "error"]
+    notes_after = [v for v in violations_after if v.severity != "error"]
+
+    view = _View([before, after])
+    change = _diff(before, after)
+    still = {str(v) for v in errors_after}
+
+    left = _panel(before, view,
+                  highlight={v.object: BAD for v in errors_before}
+                  | {v.other: BAD for v in errors_before if v.other},
+                  notes=_violation_index(errors_before))
+    right = _panel(after, view,
+                   highlight={v.object: BAD for v in errors_after}
+                   | {v.other: BAD for v in errors_after if v.other},
+                   notes=_violation_index(errors_after),
+                   ghost=before, arrows=change["arrows"], gone=change["gone"])
+
+    # When the pass changed nothing, a second identical plan is not a comparison — it is the same
+    # picture twice, and printing it invites the reader to hunt for a difference that is not there.
+    touched = bool(change["moved"] or change["resized"] or change["gone"])
+    if touched:
+        left_title = (f'as scanned <em>&mdash; {len(errors_before)} violations, outlined red</em>'
+                      if errors_before else 'as scanned <em>&mdash; no violations</em>')
+        panels = (f'<div class="panel"><h3>{left_title}</h3>{left}</div>'
+                  f'<div class="panel"><h3>after the pass <em>&mdash; dashed = where the scan put '
+                  f'it, arrow = the correction</em></h3>{right}</div>')
+    else:
+        note = ("nothing needed repair" if not errors_before
+                else f"{len(errors_after)} violations the pass could not resolve")
+        panels = (f'<div class="panel"><h3>as scanned, and unchanged by the pass '
+                  f'<em>&mdash; {_e(note)}</em></h3>{left}</div>')
+
+    moved_cm = ", ".join(f"{oid} {d * 100:.0f} cm" for oid, d in change["moved"]) or "—"
+    resized_text = ", ".join(
+        f"{oid} {a[0]:.2f}x{a[1]:.2f}x{a[2]:.2f} → {b[0]:.2f}x{b[1]:.2f}x{b[2]:.2f} m"
+        for oid, a, b in change["resized"]) or "—"
+    dropped_text = ", ".join(change["gone"]) or "—"
+
+    action_rows = "".join(
+        f'<tr><td class="mono">{_e(a.get("action", "?"))}</td>'
+        f'<td>{_e(a.get("detail", ""))}</td></tr>' for a in (actions or [])
+    ) or '<tr><td colspan="2" class="quiet">nothing to do — the scan was already sound</td></tr>'
+
+    note_rows = "".join(
+        f'<tr><td class="mono">{_e(v.object)}</td><td class="mono">{_e(v.kind)}</td>'
+        f'<td>{_e(v.detail)}</td></tr>' for v in notes_after)
+
+    verdict = ("clean" if not errors_after else f"{len(errors_after)} unresolved")
+    verdict_colour = FIXED if not errors_after else BAD
+
+    # Everything the template interpolates is computed here. An f-string cannot carry a
+    # multi-line expression on every version this runs under, and a template with logic in it is
+    # unreadable anyway.
+    cleared = {str(v) for v in errors_before} - still
+    violation_rows = (_violation_rows(errors_before, cleared)
+                      or '<tr><td colspan="4" class="quiet">none — the scan was already '
+                         'sound</td></tr>')
+    note_rows = note_rows or '<tr><td colspan="3" class="quiet">none</td></tr>'
+    n_objects = len(after.get("objects") or {})
+    n_walls = len(after.get("walls") or {})
+    legend = _legend([before, after])
+
+    return f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<title>layout · {_e(scan)}</title>
+<style>
+  :root {{ color-scheme: light; }}
+  body {{ margin: 0; padding: 26px 30px 60px; background: #f7fafc; color: #1a202c;
+         font: 13px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }}
+  h1 {{ font-size: 19px; margin: 0 0 2px; font-weight: 650; }}
+  h2 {{ font-size: 13px; margin: 30px 0 8px; font-weight: 650; letter-spacing: .02em;
+        text-transform: uppercase; color: #4a5568; }}
+  .sub {{ color: #718096; margin: 0 0 18px; }}
+  .stats {{ display: flex; flex-wrap: wrap; gap: 26px; margin: 0 0 20px; padding: 12px 16px;
+            background: #fff; border: 1px solid #e2e8f0; border-radius: 6px; }}
+  .stat b {{ display: block; font-size: 19px; font-weight: 650; }}
+  .stat span {{ color: #718096; font-size: 11px; text-transform: uppercase; letter-spacing: .04em; }}
+  .panels {{ display: flex; flex-wrap: wrap; gap: 18px; }}
+  .panel {{ background: #fff; border: 1px solid #e2e8f0; border-radius: 6px; padding: 12px 14px 8px; }}
+  .panel h3 {{ font-size: 12.5px; margin: 0 0 8px; font-weight: 650; }}
+  .panel h3 em {{ font-style: normal; color: #718096; font-weight: 400; }}
+  svg.plan {{ display: block; max-width: 100%; height: auto; }}
+  /* Fill only, no stroke: the plate is a triangle MESH, and stroking each triangle draws every
+     internal edge as a starburst across the room that reads as geometry rather than tessellation.
+     Unstroked, the triangles merge into the one shape that matters — where the floor actually is,
+     which is what an `outside_room` violation is measured against. */
+  .floor {{ fill: #e4ebf3; stroke: none; }}
+  .wall {{ stroke: #2d3748; stroke-width: 4; stroke-linecap: butt; opacity: .9; }}
+  .wall.sliver {{ stroke-width: 1.5; stroke-dasharray: 2 3; }}
+  .opening {{ stroke-width: 6; stroke-linecap: butt; }}
+  .wall-label {{ font-size: 8px; fill: #4a5568; text-anchor: middle; dominant-baseline: middle; }}
+  /* A white halo under the text, so a label over a dark box or a neighbour's edge stays readable
+     without moving it somewhere that no longer identifies the box it names. */
+  .obj-label {{ font-size: 8px; fill: #1a202c; text-anchor: middle; dominant-baseline: middle;
+                pointer-events: none; paint-order: stroke; stroke: #fff; stroke-width: 2.2px;
+                stroke-linejoin: round; }}
+  .facing {{ stroke: #1a202c; stroke-width: 1.2; opacity: .85; }}
+  .ghost {{ fill: none; stroke: {GHOST}; stroke-width: 1.2; stroke-dasharray: 4 3; }}
+  .dropped {{ fill: {BAD}; fill-opacity: .10; stroke: {BAD}; stroke-width: 1.4;
+              stroke-dasharray: 3 3; }}
+  .move {{ stroke: #1a202c; stroke-width: 1.8; }}
+  .obj:hover polygon {{ fill-opacity: .75; }}
+  .legend {{ display: flex; flex-wrap: wrap; gap: 12px; margin: 14px 0 0; color: #4a5568;
+             font-size: 11px; }}
+  .swatch {{ display: inline-flex; align-items: center; gap: 5px; }}
+  .swatch i {{ width: 11px; height: 11px; border-radius: 2px; display: inline-block; }}
+  .ghost-key {{ border: 1px dashed {GHOST}; }}
+  .dropped-key {{ border: 1px dashed {BAD}; background: rgba(229,62,62,.12); }}
+  table {{ border-collapse: collapse; background: #fff; border: 1px solid #e2e8f0;
+           border-radius: 6px; font-size: 12px; min-width: 520px; }}
+  th, td {{ text-align: left; padding: 6px 12px; border-bottom: 1px solid #edf2f7; }}
+  th {{ color: #718096; font-weight: 600; font-size: 11px; text-transform: uppercase; }}
+  tr:last-child td {{ border-bottom: 0; }}
+  .mono {{ font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }}
+  .quiet {{ color: #a0aec0; }}
+  dl {{ display: grid; grid-template-columns: max-content 1fr; gap: 4px 18px; margin: 0;
+        background: #fff; border: 1px solid #e2e8f0; border-radius: 6px; padding: 12px 16px; }}
+  dt {{ color: #718096; }}
+  dd {{ margin: 0; }}
+</style></head><body>
+<h1>{_e(scan)} — layout</h1>
+<p class="sub">scene_init step 1c · repaired on boxes, before crops and reconstruction · {_e(mode)}</p>
+
+<div class="stats">
+  <div class="stat"><b>{len(errors_before)} &rarr; {len(errors_after)}</b><span>violations</span></div>
+  <div class="stat"><b style="color:{verdict_colour}">{_e(verdict)}</b><span>verdict</span></div>
+  <div class="stat"><b>{len(change["moved"])}</b><span>moved</span></div>
+  <div class="stat"><b>{len(change["resized"])}</b><span>resized</span></div>
+  <div class="stat"><b>{len(change["gone"])}</b><span>dropped</span></div>
+  <div class="stat"><b>{n_objects}</b><span>objects</span></div>
+  <div class="stat"><b>{n_walls}</b><span>walls</span></div>
+</div>
+
+<div class="panels">{panels}</div>
+{legend}
+
+<h2>what changed</h2>
+<dl>
+  <dt>moved</dt><dd class="mono">{_e(moved_cm)}</dd>
+  <dt>resized</dt><dd class="mono">{_e(resized_text)}</dd>
+  <dt>dropped</dt><dd class="mono">{_e(dropped_text)}</dd>
+</dl>
+
+<h2>actions taken</h2>
+<table><tr><th>action</th><th>detail</th></tr>{action_rows}</table>
+
+<h2>violations</h2>
+<table><tr><th>object</th><th>kind</th><th>detail</th><th>after</th></tr>
+{violation_rows}</table>
+
+<h2>noted, not defects</h2>
+<table><tr><th>object</th><th>kind</th><th>detail</th></tr>
+{note_rows}</table>
+</body></html>
+"""
+
+
+def write(path: str | Path, scan: str, before: dict[str, Any], after: dict[str, Any],
+          **kwargs) -> Path:
+    """Render and save. Returns the path written."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(render(scan, before, after, **kwargs), encoding="utf-8")
+    return path

--- a/src/litereality_agent/pipeline/scene_init/layout/scene_data.py
+++ b/src/litereality_agent/pipeline/scene_init/layout/scene_data.py
@@ -22,13 +22,12 @@ geometry is preferred; otherwise the raw scene_data is converted in-memory.
 """
 from __future__ import annotations
 
+import logging
 import math
 import os
 import pickle
 
 import numpy as np
-
-import logging
 
 log = logging.getLogger(__name__)
 

--- a/src/litereality_agent/pipeline/scene_init/layout/scene_data.py
+++ b/src/litereality_agent/pipeline/scene_init/layout/scene_data.py
@@ -1,0 +1,417 @@
+"""scene_data.py — read the RoomPlan pkl set that `extract_scene` writes.
+
+Ported from the physics-agent branch (`agent/physics/scene_loader.py`), which had already solved
+the part that is easy to get subtly wrong: walls arrive as a centre, a Y-rotation and a bbox, and
+recovering their centreline needs the transform matrix rather than the Euler angle, because
+`R = Ry(theta) . Rz(180)` does not decompose the naive way. Re-deriving that by hand invites a sign
+error that would put every wall in the room a few degrees out.
+
+Original docstring follows.
+
+Scene geometry / object I/O (port of the pipeline's _geom_io).
+
+Input data lives under  input/<project>/  (one folder per scene, the former
+result/<project>/preprocess contents):
+    input/<project>/scene_data/{walls,wall_holes,floor,objects}.pkl
+    input/<project>/object_stage/<obj>/images_boxed/   (photos for the agent)
+    input/<project>/parsed_images/<obj>/
+
+Outputs still go to result/<project>/stage2/ (commit contract unchanged).
+When a previous stage2/phase1 run exists under result/, its organized wall
+geometry is preferred; otherwise the raw scene_data is converted in-memory.
+"""
+from __future__ import annotations
+
+import math
+import os
+import pickle
+
+import numpy as np
+
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def resolve_scene_data(input_root: str, project: str) -> str:
+    """Locate a scan's scene_data dir under either supported layout.
+
+    The Concerto-R bundle used ``<input_root>/<project>/scene_data``; the
+    scene_init work tree uses ``<input_root>/scene_data/<project>``. Return
+    whichever exists (preferring the bundle layout), else the bundle spelling
+    so error messages name the canonical path.
+    """
+    for candidate in (os.path.join(input_root, project, "scene_data"),
+                      os.path.join(input_root, "scene_data", project)):
+        if os.path.isdir(candidate):
+            return candidate
+    return os.path.join(input_root, project, "scene_data")
+
+
+def _clip_floor_to_walls(floor_verts_3d: list, walls_org: dict,
+                         close_radius: float = 0.8) -> list | None:
+    """Clip a rectangular floor polygon to the wall envelope.
+
+    AEO scans give a single rectangular floor that covers the scan extent,
+    so the floor often pokes out beyond walled rooms. We rebuild it by
+    morphological closing on the wall footprints (bridges door openings)
+    then take the outer hull of every component, intersected with the
+    original rect. Returns a list of polygon-vertex-lists (one per patch)
+    or None if clipping failed / wasn't beneficial.
+    """
+    try:
+        from shapely.geometry import MultiPolygon, Polygon
+        from shapely.ops import unary_union
+    except ImportError:
+        return None
+
+    if len(floor_verts_3d) < 3 or len(walls_org) < 4:
+        return None
+
+    floor_y = float(floor_verts_3d[0][1])
+    floor_rect = Polygon([(float(v[0]), float(v[2])) for v in floor_verts_3d])
+    if not floor_rect.is_valid or floor_rect.area < 1e-6:
+        return None
+
+    wall_polys = []
+    for w in walls_org.values():
+        pose = w["pose"]
+        line = pose.get("2d_line")
+        if line is None:
+            continue
+        try:
+            thickness = float(pose["bbox"][2])
+        except (KeyError, IndexError, TypeError):
+            thickness = 0.16
+        (x0, z0), (x1, z1) = line
+        dx, dz = x1 - x0, z1 - z0
+        L = math.hypot(dx, dz)
+        if L < 1e-6:
+            continue
+        tx, tz = dx / L, dz / L
+        nx, nz = -tz, tx
+        h = thickness / 2.0
+        wall_polys.append(Polygon([
+            (x0 + nx * h, z0 + nz * h),
+            (x1 + nx * h, z1 + nz * h),
+            (x1 - nx * h, z1 - nz * h),
+            (x0 - nx * h, z0 - nz * h),
+        ]))
+    if not wall_polys:
+        return None
+
+    wall_union = unary_union(wall_polys)
+    # Closing bridges door gaps and corner gaps so adjacent walls become
+    # one connected ring per "room cluster".
+    closed = wall_union.buffer(close_radius, join_style=2).buffer(
+        -close_radius, join_style=2)
+    if closed.is_empty:
+        return None
+    components = list(closed.geoms) if isinstance(closed, MultiPolygon) \
+        else [closed]
+    envelopes = [Polygon(list(c.exterior.coords)) for c in components
+                 if c.area > 0.5]
+    if not envelopes:
+        return None
+    envelope = unary_union(envelopes)
+
+    # Adaptive choice: hull/envelope ratio measures how "open" the layout
+    # is. Closed scenes have ratio ≈ 1.0–1.15 (envelope is a tight fit);
+    # open scenes (U-shape, partial enclosures) have ratio ≥ 1.2 where the
+    # convex hull covers the implied interior the envelope misses.
+    hull = wall_union.convex_hull
+    ratio = hull.area / envelope.area if envelope.area > 0 else 1.0
+    open_threshold = float(os.environ.get("AEO_FLOOR_CLIP_OPEN_RATIO", "1.20"))
+    mode = os.environ.get("AEO_FLOOR_CLIP_MODE", "auto").lower()
+    if mode == "tight":
+        coverage, scheme = envelope, "tight (forced)"
+    elif mode == "loose":
+        coverage, scheme = hull, "loose (forced)"
+    elif ratio >= open_threshold:
+        coverage, scheme = hull, f"loose (open layout, ratio={ratio:.2f})"
+    else:
+        coverage, scheme = envelope, f"tight (closed layout, ratio={ratio:.2f})"
+
+    clipped = coverage.intersection(floor_rect)
+    if clipped.is_empty:
+        return None
+    patches = list(clipped.geoms) if isinstance(clipped, MultiPolygon) \
+        else [clipped]
+    patches = [p for p in patches if isinstance(p, Polygon)
+               and p.area >= 1e-3]
+    if not patches:
+        return None
+
+    total = sum(p.area for p in patches)
+    # Skip if clipping removed less than 2% — not worth the topology change.
+    if total > 0.98 * floor_rect.area:
+        return None
+
+    out = []
+    for p in patches:
+        out.append([[float(x), floor_y, float(z)]
+                    for (x, z) in list(p.exterior.coords)[:-1]])
+    parts = ", ".join(f"{p.area:.2f}" for p in patches)
+    log.info(f"  [geom] floor clipped: {floor_rect.area:.2f} -> "
+          f"{total:.2f} m^2 ({len(patches)} patch[es]: {parts}, "
+          f"r={close_radius}, scheme={scheme})")
+    return out
+
+
+def _apply_uniform_wall_height(walls_org: dict, walls_hole: dict) -> None:
+    """Raise every wall's height to max(bbox[1]) in-place, preserving each
+    wall's world-Y bottom and every hole's world-Y position.
+    Toggle with env var UNIFORM_WALL_HEIGHT=1.
+    """
+    if os.environ.get("UNIFORM_WALL_HEIGHT", "").lower() not in \
+            ("1", "true", "yes"):
+        return
+    if not walls_org:
+        return
+
+    max_h = max(float(w["pose"]["bbox"][1]) for w in walls_org.values())
+    n_changed = 0
+    for idx, w in walls_org.items():
+        pose = w["pose"]
+        old_h = float(pose["bbox"][1])
+        old_cy = float(pose["position"][1])
+        bottom = old_cy - old_h / 2.0
+        new_cy = bottom + max_h / 2.0
+        if abs(new_cy - old_cy) < 1e-6 and abs(old_h - max_h) < 1e-6:
+            continue
+        new_bbox = list(pose["bbox"])
+        new_bbox[1] = max_h
+        pose["bbox"] = new_bbox
+        new_pos = list(pose["position"])
+        new_pos[1] = new_cy
+        pose["position"] = new_pos
+        # Compensate every hole in this wall: keep hole world-Y identical.
+        # old_world_v = old_cy + old_v   →   new_v = old_cy + old_v - new_cy
+        delta = old_cy - new_cy
+        hole_entry = walls_hole.get(idx)
+        if isinstance(hole_entry, dict):
+            holes = hole_entry.get("holes")
+            if isinstance(holes, dict):
+                dims = holes.get("dimension")
+                if dims:
+                    new_dims = []
+                    for ((u_min, v_min), (u_max, v_max)) in dims:
+                        new_dims.append((
+                            (float(u_min), float(v_min) + delta),
+                            (float(u_max), float(v_max) + delta),
+                        ))
+                    holes["dimension"] = new_dims
+        n_changed += 1
+    if n_changed:
+        log.info(f"  [uniform-wall-height] raised {n_changed}/{len(walls_org)} "
+              f"walls to h={max_h:.3f} m")
+
+
+def _wall_yaw_and_line(pose: dict, length: float) -> tuple[float, list]:
+    """Extract yaw (deg, LiteReality Ry convention) and XZ centerline from a
+    stage1 wall pose dict. Uses the transform matrix when available so
+    R ≈ Ry(θ)·Rz(180°) decomposes correctly."""
+    position = [float(v) for v in pose["position"]]
+    if "transform" in pose and pose["transform"] is not None:
+        R = np.asarray(pose["transform"])[:3, :3]
+        length_dir = R @ np.array([1.0, 0.0, 0.0])
+        ux, uz = float(length_dir[0]), float(length_dir[2])
+        n = math.hypot(ux, uz)
+        if n < 1e-9:
+            ux, uz = 1.0, 0.0
+        else:
+            ux, uz = ux / n, uz / n
+        yaw_deg = math.degrees(math.atan2(-uz, ux))
+    else:
+        rot = pose.get("rotation", [0, 0, 0])
+        yaw_deg = float(rot[1]) if hasattr(rot, "__len__") and len(rot) >= 3 \
+            else float(rot)
+        yaw_rad = math.radians(yaw_deg)
+        ux, uz = math.cos(yaw_rad), -math.sin(yaw_rad)
+
+    cx, cz = position[0], position[2]
+    dx, dz = ux * length / 2.0, uz * length / 2.0
+    line = [[cx - dx, cz - dz], [cx + dx, cz + dz]]
+    return yaw_deg, line
+
+
+def _build_from_scene_data(scene_data_dir: str,
+                           thickness: float = 0.16) -> dict:
+    """Convert stage1 scene_data/*.pkl → in-memory PHASE1-equivalent dicts."""
+    walls_src = pickle.load(
+        open(os.path.join(scene_data_dir, "walls.pkl"), "rb"))
+    wall_holes_src = pickle.load(
+        open(os.path.join(scene_data_dir, "wall_holes.pkl"), "rb"))
+    floor_src = None
+    floor_pkl_path = os.path.join(scene_data_dir, "floor.pkl")
+    if os.path.exists(floor_pkl_path):
+        floor_src = pickle.load(open(floor_pkl_path, "rb"))
+
+    walls_org: dict = {}
+    walls_hole: dict = {}
+    wall_hole_reorder: list = []
+
+    for idx, wall in enumerate(walls_src):
+        pose = wall["pose"]
+        bbox = [float(v) for v in pose["bbox"]]
+        length = float(bbox[0])
+        yaw_deg, line = _wall_yaw_and_line(pose, length)
+
+        walls_org[idx] = {
+            "file": idx,
+            "pose": {
+                "position": [float(v) for v in pose["position"]],
+                "rotation": [0.0, yaw_deg, 0.0],
+                "bbox": [length, float(bbox[1]), thickness],
+                "2d_line": line,
+                "area_belongs": [0],
+            },
+        }
+
+        wall_key = wall.get("file", f"aeo://wall_{idx}.usda")
+        holes = wall_holes_src.get(wall_key, []) \
+            if isinstance(wall_holes_src, dict) else []
+        if isinstance(holes, dict) and holes.get("dimension"):
+            wall_hole_reorder.append(wall_key.split("/")[-1].split(".")[0])
+            walls_hole[idx] = {"file": idx, "holes": holes}
+        else:
+            walls_hole[idx] = {"file": idx, "holes": []}
+
+    floor_pkl: dict = {}
+    if floor_src is not None:
+        fpos = np.asarray(floor_src.get("position", [0, 0, 0]), dtype=float)
+        floor_y = float(fpos[1])
+        # AEO's floor.position[1] is the slab CENTER, not the top surface;
+        # snap to the median wall bottom so the floor mesh meets the walls
+        # flush. Opt out with AEO_NO_FLOOR_SNAP=1.
+        if walls_org and os.environ.get("AEO_NO_FLOOR_SNAP") != "1":
+            wall_bottoms = []
+            for w in walls_org.values():
+                wp = w["pose"]
+                wpos, wbb = wp.get("position"), wp.get("bbox")
+                if wpos is None or wbb is None or len(wpos) < 2 or len(wbb) < 2:
+                    continue
+                wall_bottoms.append(float(wpos[1]) - float(wbb[1]) / 2.0)
+            if wall_bottoms:
+                snapped = float(np.median(wall_bottoms))
+                if abs(snapped - floor_y) > 1e-3:
+                    log.info(f"  [floor-snap] floor_y {floor_y:.4f} → "
+                          f"{snapped:.4f} (median of {len(wall_bottoms)} "
+                          f"wall bottoms)")
+                floor_y = snapped
+        tdr = floor_src.get("top_down_rect")
+        if tdr is not None:
+            verts_3d = [[float(x), floor_y, float(z)] for (x, z) in tdr]
+        else:
+            fbbox = np.asarray(floor_src.get("bbox", [1, 0.02, 1]),
+                               dtype=float)
+            # The thickness axis is whichever bbox dim is smallest; the floor
+            # rectangle lies in the plane perpendicular to it. LiteReality
+            # stores floors Y-up (thickness=bbox[1]); AEO/RoomPlan Z-up
+            # (thickness=bbox[2]). Detect from bbox so both work.
+            thickness_idx = int(np.argmin(fbbox))
+            half = fbbox / 2.0
+            corners_local = np.zeros((4, 3))
+            ax = [i for i in range(3) if i != thickness_idx]
+            signs = [(+1, +1), (+1, -1), (-1, -1), (-1, +1)]
+            for k, (s0, s1) in enumerate(signs):
+                corners_local[k, ax[0]] = s0 * half[ax[0]]
+                corners_local[k, ax[1]] = s1 * half[ax[1]]
+            # Prefer the full transform matrix (captures rpy beyond pure yaw,
+            # e.g. the Rx(180) flip commonly seen on AEO floors).
+            T = floor_src.get("transform")
+            if T is not None:
+                R = np.asarray(T)[:3, :3]
+            else:
+                rot = floor_src.get("rotation", [0, 0, 0])
+                yaw_deg = float(rot[1]) \
+                    if hasattr(rot, "__len__") and len(rot) >= 3 else float(rot)
+                yaw = math.radians(yaw_deg)
+                c, s = math.cos(yaw), math.sin(yaw)
+                R = np.array([[c, 0.0, s], [0.0, 1.0, 0.0], [-s, 0.0, c]])
+            corners_world = (R @ corners_local.T).T + fpos.reshape(1, 3)
+            verts_3d = [[float(p[0]), floor_y, float(p[2])]
+                        for p in corners_world]
+
+        floor_pkl = {0: verts_3d}
+        if os.environ.get("AEO_NO_FLOOR_CLIP") != "1":
+            try:
+                radius = float(os.environ.get("AEO_FLOOR_CLIP_RADIUS", "0.8"))
+            except ValueError:
+                radius = 0.8
+            clipped_patches = _clip_floor_to_walls(verts_3d, walls_org,
+                                                   close_radius=radius)
+            if clipped_patches:
+                floor_pkl = {i: patch for i, patch in
+                             enumerate(clipped_patches)}
+
+    _apply_uniform_wall_height(walls_org, walls_hole)
+
+    return {
+        "walls_org": walls_org,
+        "walls_hole": walls_hole,
+        "floor_pkl": floor_pkl,
+        "wall_hole_reorder": wall_hole_reorder,
+    }
+
+
+def load_geometry(project: str, input_root: str, result_root: str,
+                  thickness: float = 0.16) -> dict:
+    """Return walls_org / walls_hole / floor_pkl / wall_hole_reorder.
+
+    Prefers a previous stage2/phase1 output under result_root; falls back
+    to the raw scan at input_root/<project>/scene_data.
+    """
+    phase1 = os.path.join(result_root, project, "stage2", "phase1")
+    walls_path = os.path.join(phase1, "walls_organized.pkl")
+
+    if os.path.exists(walls_path):
+        walls_org = pickle.load(open(walls_path, "rb"))
+        walls_hole = pickle.load(
+            open(os.path.join(phase1, "walls_hole_organized.pkl"), "rb"))
+        floor_path = os.path.join(phase1, "floor_new_final.pkl")
+        floor_pkl = pickle.load(open(floor_path, "rb")) \
+            if os.path.exists(floor_path) else {}
+        reorder_path = os.path.join(phase1, "wall_hole_reorder.txt")
+        wall_hole_reorder = []
+        if os.path.exists(reorder_path):
+            wall_hole_reorder = [ln.strip() for ln in open(reorder_path)
+                                 if ln.strip()]
+        log.info("  [geom] source: stage2/phase1")
+        _apply_uniform_wall_height(walls_org, walls_hole)
+        return {
+            "walls_org": walls_org,
+            "walls_hole": walls_hole,
+            "floor_pkl": floor_pkl,
+            "wall_hole_reorder": wall_hole_reorder,
+        }
+
+    scene_data = resolve_scene_data(input_root, project)
+    if not os.path.exists(os.path.join(scene_data, "walls.pkl")):
+        raise FileNotFoundError(
+            f"No geometry found: neither {walls_path} nor "
+            f"{scene_data}/walls.pkl")
+    log.info(f"  [geom] source: {scene_data} (raw scan)")
+    return _build_from_scene_data(scene_data, thickness=thickness)
+
+
+def load_objects(project: str, input_root: str, result_root: str) -> list:
+    """Load object list. Prefer stage5 augmented > stage2/phase3 optimized >
+    stage2/phase1 step1 > the raw scene_data objects.pkl."""
+    candidates = [
+        os.path.join(result_root, project, "stage5",
+                     "objects_augmented.pkl"),
+        os.path.join(result_root, project, "stage2", "phase3",
+                     "objects_optimized.pkl"),
+        os.path.join(result_root, project, "stage2", "phase1",
+                     "objects_step1.pkl"),
+        os.path.join(resolve_scene_data(input_root, project), "objects.pkl"),
+    ]
+    for path in candidates:
+        if os.path.exists(path):
+            objs = pickle.load(open(path, "rb"))
+            rel = os.path.relpath(path)
+            log.info(f"  [geom] objects: {len(objs)} from {rel}")
+            return objs
+    log.info("  [geom] objects: 0 (no source file found)")
+    return []

--- a/src/litereality_agent/pipeline/scene_init/layout/shell.py
+++ b/src/litereality_agent/pipeline/scene_init/layout/shell.py
@@ -42,11 +42,8 @@ from typing import Any
 
 import numpy as np
 
-
 __all__ = [
     "ARKIT_TO_Z_UP",
-    "shell_from_layout",
-    "shell_from_scan",
     "load_shell",
     "save_shell",
     "read_room_py_shell",
@@ -82,7 +79,7 @@ def _box_frame(matrix: np.ndarray, prefer_long: bool) -> tuple[np.ndarray, np.nd
     """
     cols = [matrix[:3, k] for k in range(3)]
     lengths = [float(np.linalg.norm(c)) for c in cols]
-    units = [c / (l if l > 1e-12 else 1.0) for c, l in zip(cols, lengths)]
+    units = [c / (n if n > 1e-12 else 1.0) for c, n in zip(cols, lengths)]
 
     vertical = max(range(3), key=lambda k: abs(units[k][2]))
     horizontal = [k for k in range(3) if k != vertical]
@@ -228,7 +225,7 @@ def shell_summary(shell: dict[str, Any]) -> dict[str, Any]:
     return {
         "walls": len(walls),
         "wall_length_total": _r(sum(lengths.values()), 2),
-        "sliver_walls": sorted(w for w, l in lengths.items() if l < 0.35),
+        "sliver_walls": sorted(w for w, n in lengths.items() if n < 0.35),
         "openings": {k: sum(1 for o in openings.values() if o["type"] == k)
                      for k in ("door", "window", "opening")},
         "objects": len(objects),

--- a/src/litereality_agent/pipeline/scene_init/layout/shell.py
+++ b/src/litereality_agent/pipeline/scene_init/layout/shell.py
@@ -1,0 +1,238 @@
+"""shell.py — the RoomPlan layout → the SHELL: a flat, editable, Z-up floor plan.
+
+STAGE 1b. :mod:`physical_engine.roomplan` gives 4x4 matrices in ARKit's Y-up frame — faithful, but
+nothing you can reason about. The SHELL is the same room stated as floor-plan semantics::
+
+    walls:    WallN  -> {start: [x, y], end: [x, y], thickness}      (height = ceiling_z - floor_z)
+    openings: DoorN  -> {wall, type, offset, width, height, sill}    offset = metres along the wall
+    objects:  ChairN -> {category, center: [x, y, z], size: [w, d, h], yaw}   yaw in degrees
+    floor:    {verts, faces}                    + floor_z / ceiling_z / root_matrix
+
+This is deliberately **the exact schema** ``LiteReality-Agent`` writes into ``Room.py`` as its
+``SHELL`` dict, so anything produced here drops straight into that pipeline and anything it has
+already produced can be read back here.
+
+The difference is how it is computed. Upstream, ``room_ops/export/extract_shell.py`` imports the
+usdz into **Blender** and reads ``matrix_world`` off the imported objects. That is a 400 MB
+dependency and a subprocess for what is, underneath, one rotation and some trigonometry. Here the
+Blender frame is reconstructed directly:
+
+* Blender's USD importer turns the stage's ``upAxis = "Y"`` into a +90 degrees X rotation on the
+  root prim — that is exactly the ``root_matrix`` upstream records, and :data:`ARKIT_TO_Z_UP`
+  reproduces it: ``(x, y, z)_arkit -> (x, -z, y)``.
+* Extents and orientation come from the columns of the world matrix, whose lengths ARE the box
+  extents (RoomPlan's rotation part is orthonormal).
+
+Two axis conventions are preserved from upstream because they encode real fixes:
+
+* **Walls** take their long horizontal axis as the wall direction. A wall's local X is its length,
+  so this agrees with the file and stays right for the degenerate stubs RoomPlan emits at corners.
+* **Objects** keep their OWN local axes instead. Picking the longer axis rotates any object whose
+  local Y is longer by 90 degrees — the chair-orientation bug. The matrix already carries the
+  RoomPlan rotation; re-deriving it is what breaks it.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+__all__ = [
+    "ARKIT_TO_Z_UP",
+    "shell_from_layout",
+    "shell_from_scan",
+    "load_shell",
+    "save_shell",
+    "read_room_py_shell",
+    "wall_frame",
+    "opening_span",
+    "facing_yaw",
+    "object_footprint",
+    "shell_summary",
+]
+
+# ARKit (Y-up, right-handed) -> Blender/USD Z-up. Identical to the ``root_matrix`` Blender's USD
+# importer writes onto the root prim, and recorded in the SHELL so downstream cameras — which are
+# still in ARKit space, straight off ``cameraPoseARFrame`` — can be brought into the same frame.
+ARKIT_TO_Z_UP = np.array([
+    [1.0, 0.0, 0.0, 0.0],
+    [0.0, 0.0, -1.0, 0.0],
+    [0.0, 1.0, 0.0, 0.0],
+    [0.0, 0.0, 0.0, 1.0],
+])
+
+_ROUND = 4
+
+
+def _r(value: float, digits: int = _ROUND) -> float:
+    return round(float(value), digits)
+
+
+def _box_frame(matrix: np.ndarray, prefer_long: bool) -> tuple[np.ndarray, np.ndarray, float, float, float]:
+    """Decompose a Z-up world box matrix → (centre, along-axis unit vector, width, depth, height).
+
+    ``prefer_long`` picks the longer horizontal axis as "width" (right for walls, wrong for
+    objects — see the module docstring).
+    """
+    cols = [matrix[:3, k] for k in range(3)]
+    lengths = [float(np.linalg.norm(c)) for c in cols]
+    units = [c / (l if l > 1e-12 else 1.0) for c, l in zip(cols, lengths)]
+
+    vertical = max(range(3), key=lambda k: abs(units[k][2]))
+    horizontal = [k for k in range(3) if k != vertical]
+    if prefer_long and lengths[horizontal[1]] > lengths[horizontal[0]]:
+        horizontal = horizontal[::-1]
+    wi, di = horizontal
+
+    along = np.array([cols[wi][0], cols[wi][1], 0.0])
+    if np.linalg.norm(along) < 1e-9:
+        along = np.array([1.0, 0.0, 0.0])
+    along = along / np.linalg.norm(along)
+    return matrix[:3, 3], along, lengths[wi], lengths[di], lengths[vertical]
+
+
+def save_shell(shell: dict[str, Any], path: str | Path) -> Path:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(shell, indent=2), encoding="utf-8")
+    return path
+
+
+def load_shell(path: str | Path) -> dict[str, Any]:
+    """Read a SHELL from ``shell.json`` or straight out of a LiteReality ``Room.py``."""
+    path = Path(path)
+    if path.suffix == ".py" or path.name == "Room.py":
+        return read_room_py_shell(path)
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def read_room_py_shell(path: str | Path) -> dict[str, Any]:
+    """Extract the ``SHELL = {...}`` literal from a LiteReality ``Room.py``.
+
+    Brace-matched rather than regex-terminated, and parsed as a Python literal before JSON: the
+    authoring agent edits ``SHELL`` as Python and readily writes something valid-Python-but-not-
+    JSON (a trailing comma, an adjacent-string note), at which point a JSON-only reader returns
+    ``{}`` and every downstream check silently passes on an empty room.
+    """
+    import ast
+
+    source = Path(path).read_text(encoding="utf-8")
+    match = re.search(r"\bSHELL\s*=\s*\{", source)
+    if not match:
+        return {}
+    start = source.index("{", match.start())
+    depth = 0
+    for i in range(start, len(source)):
+        if source[i] == "{":
+            depth += 1
+        elif source[i] == "}":
+            depth -= 1
+            if depth == 0:
+                blob = source[start:i + 1]
+                for parse in (json.loads, ast.literal_eval):
+                    try:
+                        return parse(blob)
+                    except Exception:  # noqa: BLE001
+                        continue
+                return {}
+    return {}
+
+
+# ── small geometric helpers every later stage shares ─────────────────────────
+def wall_frame(wall: dict[str, Any]) -> tuple[np.ndarray, np.ndarray, np.ndarray, float]:
+    """(start, along-unit, outward-normal-unit, length) for one SHELL wall."""
+    start = np.asarray(wall["start"], dtype=float)
+    end = np.asarray(wall["end"], dtype=float)
+    delta = end - start
+    length = float(np.linalg.norm(delta))
+    along = delta / length if length > 1e-9 else np.array([1.0, 0.0])
+    normal = np.array([along[1], -along[0]])
+    return start, along, normal, length
+
+
+def facing_yaw(obj: dict[str, Any]) -> float:
+    """Which way an object FACES, in degrees. **Not** the same as its ``yaw``.
+
+    ``yaw`` is the heading of the box's local **+X** axis — its WIDTH direction. RoomPlan puts an
+    object's front along its local **+Z** (depth) axis, and because the frame is right-handed with
+    local +Y mapped to world +Z::
+
+        Z_world = X_world x Y_world = (cos y, sin y, 0) x (0, 0, 1) = (sin y, -cos y, 0)
+
+    the front is exactly ``yaw - 90 deg``. Verified two ways: the rotation determinant is +1.000000
+    for all 102 objects sampled, and the +Z column sits within 0.005 deg of ``yaw - 90`` for every
+    one of them. Independently, across six scans, ``yaw - 90`` matches the room-facing wall normal
+    to 0.0 deg for 19 of the 22 objects that stand against a wall (a TV, a sofa, a fridge, a run of
+    kitchen units all face out of the wall behind them).
+
+    The remaining few are off by 180 deg: RoomPlan cannot always tell an object's front from its
+    back, so treat this as an AXIS with a probable sign, not a guarantee. Drawing ``yaw`` itself as
+    an arrow is simply wrong — it points sideways across the object.
+    """
+    return (obj.get("yaw", 0.0) - 90.0 + 180.0) % 360.0 - 180.0
+
+
+def opening_span(opening: dict[str, Any]) -> tuple[float, float]:
+    """An opening's real extent along its wall → (t0, t1) metres from the wall's start.
+
+    READ THIS BEFORE USING ``offset``. In this schema — and in LiteReality's ``Room.py``, which
+    defines it — ``offset`` is the distance to the opening's **CENTRE**, not to its leading edge::
+
+        t0 = offset - width / 2        t1 = offset + width / 2
+
+    ``room_ops/export/extract_shell.py:113`` writes the centre projection, and
+    ``room_ops/compile/build_room.py:582`` reads it back as a centre, so the compiled room is
+    correct. But ``Room.md`` describes it only as "distance along the wall from its start", and
+    ``pipeline/room_qc/checks.py:156`` takes that literally (``o0, o1 = offset, offset + width``),
+    which slides the tested interval half an opening-width toward the wall's end. Its
+    ``fixture_over_opening`` check therefore compares against the wrong patch of wall, and any
+    plot drawn the same way shows doors overhanging corners that they do not actually overhang.
+
+    Every consumer in this package goes through here so the mistake cannot be made twice.
+    """
+    half = opening["width"] / 2.0
+    return opening["offset"] - half, opening["offset"] + half
+
+
+def object_footprint(obj: dict[str, Any]) -> np.ndarray:
+    """The 4 XY corners of an object's oriented footprint, counter-clockwise."""
+    cx, cy = obj["center"][0], obj["center"][1]
+    hw, hd = obj["size"][0] / 2.0, obj["size"][1] / 2.0
+    yaw = math.radians(obj.get("yaw", 0.0))
+    c, s = math.cos(yaw), math.sin(yaw)
+    local = np.array([[-hw, -hd], [hw, -hd], [hw, hd], [-hw, hd]])
+    rotation = np.array([[c, -s], [s, c]])
+    return local @ rotation.T + np.array([cx, cy])
+
+
+def shell_summary(shell: dict[str, Any]) -> dict[str, Any]:
+    """Counts + room extents, for the report line at the end of extraction."""
+    walls = shell.get("walls") or {}
+    objects = shell.get("objects") or {}
+    openings = shell.get("openings") or {}
+    lengths = {wid: float(np.linalg.norm(np.asarray(w["end"], float) - np.asarray(w["start"], float)))
+               for wid, w in walls.items()}
+    categories: dict[str, int] = {}
+    for obj in objects.values():
+        categories[obj["category"]] = categories.get(obj["category"], 0) + 1
+    verts = np.asarray((shell.get("floor") or {}).get("verts") or [], dtype=float)
+    extent = None
+    if len(verts):
+        extent = [_r(v) for v in (verts[:, :2].max(axis=0) - verts[:, :2].min(axis=0))]
+    return {
+        "walls": len(walls),
+        "wall_length_total": _r(sum(lengths.values()), 2),
+        "sliver_walls": sorted(w for w, l in lengths.items() if l < 0.35),
+        "openings": {k: sum(1 for o in openings.values() if o["type"] == k)
+                     for k in ("door", "window", "opening")},
+        "objects": len(objects),
+        "object_categories": dict(sorted(categories.items())),
+        "height": _r(shell["ceiling_z"] - shell["floor_z"]),
+        "floor_extent_xy": extent,
+    }

--- a/src/litereality_agent/pipeline/scene_init/layout/stage.py
+++ b/src/litereality_agent/pipeline/scene_init/layout/stage.py
@@ -1,0 +1,91 @@
+"""stage.py — the layout pass as the pipeline calls it.
+
+One function, `run_layout(scan)`, run from `scene_init/flow.py` in the window immediately after the
+box merge and before crops. It is written to the same contract as the merge it follows: it never
+raises into the caller. A layout pass that fails must leave the scan exactly as it found it and let
+the run continue unrepaired, because the alternative — taking down an otherwise good reconstruction
+over a geometry edge case — is worse than the misplacement it was trying to fix.
+
+    LR_LAYOUT=0        skip the pass entirely
+    LR_LAYOUT_AGENT=1  let the agent look at the reference photographs for what geometry cannot
+                       settle (off by default: it costs model calls, and the deterministic pass
+                       already clears 19 of 21 captures on its own)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pickle
+from pathlib import Path
+from typing import Any
+
+__all__ = ["run_layout"]
+
+
+def _enabled(name: str, default: str = "1") -> bool:
+    return os.environ.get(name, default) not in ("0", "false", "no", "")
+
+
+def run_layout(scan: str, *, scene_data_dir: str | Path | None = None,
+               use_agent: bool | None = None) -> dict[str, Any]:
+    """Repair one scan's layout in place. Returns a summary; never raises."""
+    if not _enabled("LR_LAYOUT"):
+        print("  [layout] disabled ($LR_LAYOUT=0)", flush=True)
+        return {"disabled": True}
+
+    try:
+        from . import adapter
+        from .adjust import check
+        from .repair import repair
+
+        if scene_data_dir is None:
+            from litereality_agent.pipeline.scene_init import paths as config
+            scene_data_dir = config.scene_data_dir(scan)
+        scene_data_dir = Path(scene_data_dir)
+        pkl = scene_data_dir / "objects.pkl"
+        if not pkl.is_file():
+            print(f"  [layout] no objects.pkl at {pkl} — skipping", flush=True)
+            return {"skipped": "no objects.pkl"}
+
+        shell = adapter.shell_from_scene_data(scene_data_dir)
+        before = [v for v in check(shell) if v.severity == "error"]
+        if not before:
+            print(f"  [layout] {len(shell['objects'])} objects, already sound", flush=True)
+            return {"before": 0, "after": 0, "moved": [], "resized": [], "dropped": []}
+
+        if use_agent is None:
+            use_agent = _enabled("LR_LAYOUT_AGENT", "0")
+        if use_agent:
+            shell.setdefault("meta", {})["batch_dir"] = str(scene_data_dir)
+            from .repair import solve_v13
+            repaired, _moves, actions = solve_v13(shell, detail=True)
+        else:
+            repaired, _moves, actions = repair(shell)
+
+        after = [v for v in check(repaired) if v.severity == "error"]
+        entries = pickle.load(open(pkl, "rb"))
+        changed = adapter.apply_to_objects(entries, repaired)
+
+        backup = pkl.with_suffix(".pre_layout.pkl")
+        if not backup.exists():
+            backup.write_bytes(pkl.read_bytes())
+        with open(pkl, "wb") as handle:
+            pickle.dump(entries, handle)
+
+        report = {"before": len(before), "after": len(after),
+                  "actions": [a.get("action") for a in actions], **changed,
+                  "remaining": [str(v) for v in after]}
+        (scene_data_dir / "layout_report.json").write_text(
+            json.dumps(report, indent=2), encoding="utf-8")
+
+        print(f"  [layout] {len(before)} violations -> {len(after)}   "
+              f"moved {len(changed['moved'])}, resized {len(changed['resized'])}, "
+              f"dropped {len(changed['dropped'])}", flush=True)
+        for line in report["remaining"]:
+            print(f"  [layout]   unresolved: {line}", flush=True)
+        return report
+    except Exception as exc:                    # noqa: BLE001 — never break init over the layout
+        print(f"  [layout] FAILED (non-fatal, continuing unrepaired): "
+              f"{type(exc).__name__}: {exc}", flush=True)
+        return {"error": str(exc)}

--- a/src/litereality_agent/pipeline/scene_init/layout/stage.py
+++ b/src/litereality_agent/pipeline/scene_init/layout/stage.py
@@ -69,6 +69,44 @@ def _visualize(scan: str, before: dict[str, Any], after: dict[str, Any],
         return None
 
 
+def _publish_shell(shell: dict[str, Any], scene_data_dir: Path, dropped: list[str]) -> None:
+    """Write the boxes the object stage was built against, for the room export to place into.
+
+    The scene stage does NOT read objects.pkl. `export_room` re-extracts the room from `room.usdz`
+    under Blender and embeds THAT as the SHELL in `Room.py`, which is what places every GLB — so a
+    repair made here reached the crops, the references and the generated extents, and then the
+    assembler put the asset back in the unrepaired box. A counter trimmed to 63 cm was generated at
+    63 cm and scaled into the 87 cm box the scan measured, which is the "generated at the wrong
+    extent and then squashed to fit" failure this stage exists to prevent, reintroduced one stage
+    later.
+
+    Objects only, and deliberately so. Walls, openings and the floor stay the export's, because the
+    layout pass never touches them and has no business being their source of truth.
+    """
+    # Its own guard, for the reason `_visualize` has one: by the time this runs the repair is
+    # already on disk, and failing to publish a hand-off file must not report it as failed.
+    try:
+        _write_shell(shell, scene_data_dir, dropped)
+    except Exception as exc:                # noqa: BLE001
+        print(f"  [layout] could not publish layout_shell.json (non-fatal): "
+              f"{type(exc).__name__}: {exc}", flush=True)
+
+
+def _write_shell(shell: dict[str, Any], scene_data_dir: Path, dropped: list[str]) -> None:
+    payload = {
+        "scan": scene_data_dir.name,
+        "source": "scene_init/layout",
+        "note": "object boxes AFTER the layout pass — the boxes the crops, references and "
+                "generated GLBs were built against. Overlaid onto the SHELL by room_ops export.",
+        "objects": {oid: {"category": o.get("category"), "center": list(o["center"]),
+                          "size": list(o["size"]), "yaw": o.get("yaw", 0.0)}
+                    for oid, o in (shell.get("objects") or {}).items()},
+        "dropped": list(dropped),
+    }
+    (scene_data_dir / "layout_shell.json").write_text(
+        json.dumps(payload, indent=2), encoding="utf-8")
+
+
 def run_layout(scan: str, *, scene_data_dir: str | Path | None = None,
                use_agent: bool | None = None) -> dict[str, Any]:
     """Repair one scan's layout in place. Returns a summary; never raises."""
@@ -99,6 +137,7 @@ def run_layout(scan: str, *, scene_data_dir: str | Path | None = None,
             # object set and a correctly placed one both report zero violations.
             print(f"  [layout] {len(shell['objects'])} objects, already sound", flush=True)
             summary = {"before": 0, "after": 0, "moved": [], "resized": [], "dropped": []}
+            _publish_shell(shell, scene_data_dir, [])
             drawn = _visualize(scan, shell, shell, scene_data_dir, violations_before=found,
                                violations_after=found, actions=[], mode="nothing to repair")
             if drawn:
@@ -128,6 +167,7 @@ def run_layout(scan: str, *, scene_data_dir: str | Path | None = None,
         report = {"before": len(before), "after": len(after),
                   "actions": [a.get("action") for a in actions], **changed,
                   "remaining": [str(v) for v in after]}
+        _publish_shell(repaired, scene_data_dir, changed["dropped"])
         drawn = _visualize(scan, shell, repaired, scene_data_dir, violations_before=found,
                            violations_after=settled, actions=actions,
                            mode="agent-assisted" if use_agent else "deterministic")

--- a/src/litereality_agent/pipeline/scene_init/layout/stage.py
+++ b/src/litereality_agent/pipeline/scene_init/layout/stage.py
@@ -10,6 +10,11 @@ over a geometry edge case — is worse than the misplacement it was trying to fi
     LR_LAYOUT_AGENT=1  let the agent look at the reference photographs for what geometry cannot
                        settle (off by default: it costs model calls, and the deterministic pass
                        already clears 19 of 21 captures on its own)
+    LR_LAYOUT_DROP=1   allow the pass to DELETE a duplicate detection (off by default: a wrong
+                       deletion is the one failure here that nothing downstream reports)
+    LR_LAYOUT_VIZ=0    do not draw the before/after plan (on by default — see report.py; it is
+                       string building, costs milliseconds, and a run that repairs a room without
+                       leaving a picture of the repair cannot be checked afterwards)
 """
 
 from __future__ import annotations
@@ -25,6 +30,43 @@ __all__ = ["run_layout"]
 
 def _enabled(name: str, default: str = "1") -> bool:
     return os.environ.get(name, default) not in ("0", "false", "no", "")
+
+
+def _visualize(scan: str, before: dict[str, Any], after: dict[str, Any],
+               scene_data_dir: Path, **kwargs) -> str | None:
+    """Draw the pass and save it. Returns the path, or None if it was off or could not be drawn.
+
+    The canonical copy sits beside ``layout_report.json``, tied to the data it describes. A second
+    goes under ``traces/``, which is where a person browsing a finished run actually looks — the
+    stage log for this pass is already there, and a plan filed three levels deeper inside the
+    preprocessing work tree is one nobody opens.
+
+    Its own try/except, deliberately narrow: the repair has already been written to disk by the
+    time this runs, and failing to draw a picture of a completed repair must not report the repair
+    as failed.
+    """
+    if not _enabled("LR_LAYOUT_VIZ"):
+        return None
+    try:
+        from . import report
+
+        path = report.write(scene_data_dir / "layout.html", scan, before, after, **kwargs)
+        try:
+            from litereality_agent.pipeline.scene_init import paths as config
+
+            traces = config.traces_dir(scan) / "layout.html"
+            if traces.resolve() != path.resolve():
+                traces.parent.mkdir(parents=True, exist_ok=True)
+                traces.write_bytes(path.read_bytes())
+                path = traces
+        except Exception:       # noqa: BLE001 — a standalone run has no traces tree; keep the first
+            pass
+        print(f"  [layout] plan written to {path}", flush=True)
+        return str(path)
+    except Exception as exc:    # noqa: BLE001
+        print(f"  [layout] visualization unavailable (non-fatal): "
+              f"{type(exc).__name__}: {exc}", flush=True)
+        return None
 
 
 def run_layout(scan: str, *, scene_data_dir: str | Path | None = None,
@@ -49,10 +91,19 @@ def run_layout(scan: str, *, scene_data_dir: str | Path | None = None,
             return {"skipped": "no objects.pkl"}
 
         shell = adapter.shell_from_scene_data(scene_data_dir)
-        before = [v for v in check(shell) if v.severity == "error"]
+        found = check(shell)
+        before = [v for v in found if v.severity == "error"]
         if not before:
+            # Still draw it. "Already sound" is a claim about the room, and the plan is what lets
+            # someone see that the room it is a claim about is the room they scanned — an empty
+            # object set and a correctly placed one both report zero violations.
             print(f"  [layout] {len(shell['objects'])} objects, already sound", flush=True)
-            return {"before": 0, "after": 0, "moved": [], "resized": [], "dropped": []}
+            summary = {"before": 0, "after": 0, "moved": [], "resized": [], "dropped": []}
+            drawn = _visualize(scan, shell, shell, scene_data_dir, violations_before=found,
+                               violations_after=found, actions=[], mode="nothing to repair")
+            if drawn:
+                summary["visualization"] = drawn
+            return summary
 
         if use_agent is None:
             use_agent = _enabled("LR_LAYOUT_AGENT", "0")
@@ -63,7 +114,8 @@ def run_layout(scan: str, *, scene_data_dir: str | Path | None = None,
         else:
             repaired, _moves, actions = repair(shell)
 
-        after = [v for v in check(repaired) if v.severity == "error"]
+        settled = check(repaired)
+        after = [v for v in settled if v.severity == "error"]
         entries = pickle.load(open(pkl, "rb"))
         changed = adapter.apply_to_objects(entries, repaired)
 
@@ -76,6 +128,11 @@ def run_layout(scan: str, *, scene_data_dir: str | Path | None = None,
         report = {"before": len(before), "after": len(after),
                   "actions": [a.get("action") for a in actions], **changed,
                   "remaining": [str(v) for v in after]}
+        drawn = _visualize(scan, shell, repaired, scene_data_dir, violations_before=found,
+                           violations_after=settled, actions=actions,
+                           mode="agent-assisted" if use_agent else "deterministic")
+        if drawn:
+            report["visualization"] = drawn
         (scene_data_dir / "layout_report.json").write_text(
             json.dumps(report, indent=2), encoding="utf-8")
 

--- a/src/litereality_agent/pipeline/scene_init/layout/toolcli.py
+++ b/src/litereality_agent/pipeline/scene_init/layout/toolcli.py
@@ -29,9 +29,9 @@ import sys
 from pathlib import Path
 
 from .adjust import check
+from .graph import wall_distance
 from .repair import _corner_fit, _snap_delta, attachments, score
 from .shell import load_shell, save_shell, wall_frame
-from .graph import wall_distance
 
 
 def _paths(session: Path):

--- a/src/litereality_agent/pipeline/scene_init/layout/toolcli.py
+++ b/src/litereality_agent/pipeline/scene_init/layout/toolcli.py
@@ -1,0 +1,197 @@
+"""toolcli.py — the tool surface a reasoning agent uses to repair a room.
+
+The deterministic solver decides what to do from the geometry alone, and on the hard scenes that is
+not enough: it can tell that a wardrobe overlaps a table, but not that the wardrobe belongs in the
+corner and the table does not belong where the scan put it. That judgement needs someone to look at
+the photographs and think, which is what this file is for.
+
+It is a COMMAND LINE, not a JSON schema, because an agent that can run commands can look before it
+acts, act, look again, and change its mind — and every one of those steps is recorded. The agent
+never edits the layout: it calls these verbs, and the geometry underneath them keeps the arithmetic
+honest (a snap computes its own distance; a corner fit computes its own trim; every mutation is
+scored and can be undone).
+
+    python -m physical_engine.toolcli <session> summary
+    python -m physical_engine.toolcli <session> object Storage1
+    python -m physical_engine.toolcli <session> attach Storage1 Wall3 Wall7
+    python -m physical_engine.toolcli <session> undo
+
+Every mutating verb prints the score before and after, so the agent always knows whether what it
+just did helped. Lower is better, and the first number — defects — is collisions plus units knocked
+off their wall plus furniture moved implausibly far.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import sys
+from pathlib import Path
+
+from .adjust import check
+from .repair import _corner_fit, _snap_delta, attachments, score
+from .shell import load_shell, save_shell, wall_frame
+from .graph import wall_distance
+
+
+def _paths(session: Path):
+    return session / "state.json", session / "baseline.json", session / "history.json"
+
+
+def _load(session: Path):
+    state_p, base_p, _ = _paths(session)
+    state, baseline = load_shell(state_p), load_shell(base_p)
+    held = {oid: set(attachments(o, baseline.get("walls") or {}))
+            for oid, o in (baseline.get("objects") or {}).items()}
+    return state, baseline, {k: v for k, v in held.items() if v}
+
+
+def _save(session: Path, state, note: str):
+    state_p, _, hist_p = _paths(session)
+    history = json.loads(hist_p.read_text()) if hist_p.is_file() else []
+    history.append({"note": note, "state": state})
+    hist_p.write_text(json.dumps(history[-25:]), encoding="utf-8")
+    save_shell(state, state_p)
+
+
+def _score_line(state, baseline, held, prefix="score") -> str:
+    defects, penetration, moved = score(state, baseline, held)
+    return (f"{prefix}: defects={defects} penetration={penetration:.3f}m "
+            f"displacement={moved:.3f}m")
+
+
+def _violations(state) -> list[str]:
+    return [f"{v.object} {v.kind} ({v.other or '-'}) {v.detail}"
+            for v in check(state) if v.severity == "error"]
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 3:
+        print(__doc__)
+        return 2
+    session, verb, args = Path(argv[1]), argv[2], argv[3:]
+    state, baseline, held = _load(session)
+    walls = state.get("walls") or {}
+    objects = state.get("objects") or {}
+
+    def finish(note):
+        before = _score_line(_load(session)[0], baseline, held, "before")
+        _save(session, state, note)
+        print(before)
+        print(_score_line(state, baseline, held, "after "))
+        remaining = _violations(state)
+        print(f"violations remaining: {len(remaining)}")
+        for line in remaining:
+            print("  " + line)
+        return 0
+
+    if verb == "summary":
+        print(f"room: {len(walls)} walls, {len(objects)} objects")
+        print(_score_line(state, baseline, held))
+        print("\nobjects (category, size, walls it is installed against):")
+        for oid, obj in sorted(objects.items()):
+            held_now = sorted(attachments(obj, walls))
+            print(f"  {oid:14} {obj.get('category',''):12} "
+                  f"size={[round(v,2) for v in obj['size']]} walls={held_now or '-'}")
+        print("\nviolations:")
+        for line in _violations(state):
+            print("  " + line)
+        return 0
+
+    if verb == "object":
+        oid = args[0]
+        obj = objects.get(oid)
+        if not obj:
+            print(f"no such object: {oid}")
+            return 1
+        print(json.dumps({"id": oid, "category": obj.get("category"),
+                          "size": [round(v, 3) for v in obj["size"]],
+                          "center": [round(v, 3) for v in obj["center"]],
+                          "yaw": obj.get("yaw")}, indent=2))
+        print("\nwalls (gap from this object's face, negative = it is inside the wall):")
+        for wall_id, wall in sorted(walls.items()):
+            measured = wall_distance(obj, wall)
+            length = wall_frame(wall)[3]
+            if measured is not None and abs(measured[0]) < 1.5:
+                print(f"  {wall_id:8} gap {measured[0]*100:+7.1f} cm   length {length:.2f} m")
+        print("\nneighbours within 2 m:")
+        for other_id, other in sorted(objects.items()):
+            if other_id == oid:
+                continue
+            d = math.dist(other["center"][:2], obj["center"][:2])
+            if d < 2.0:
+                print(f"  {other_id:14} {other.get('category',''):12} {d:.2f} m")
+        refs = sorted((session / "references" / oid).glob("rank*.jpg"))[:3]
+        print("\nreference photographs (this object's box drawn on the scan) — Read them:")
+        for ref in refs:
+            print(f"  {ref}")
+        if not refs:
+            print("  (none)")
+        return 0
+
+    if verb == "check":
+        for line in _violations(state):
+            print(line)
+        print(_score_line(state, baseline, held))
+        return 0
+
+    if verb == "attach":
+        oid, names = args[0], [a for a in args[1:] if a in walls]
+        obj = objects.get(oid)
+        if not obj or not names:
+            print("usage: attach <object> <wall> [wall2]   (wall2 makes it a corner fit)")
+            return 1
+        if len(names) == 2:
+            fitted = _corner_fit(obj, walls[names[0]], walls[names[1]])
+            if fitted:
+                obj["size"] = fitted
+        for wall_id in names:
+            delta = _snap_delta(obj, walls[wall_id])
+            obj["center"][0] = round(obj["center"][0] + float(delta[0]), 4)
+            obj["center"][1] = round(obj["center"][1] + float(delta[1]), 4)
+        return finish(f"attach {oid} {' '.join(names)}")
+
+    if verb == "move":
+        oid, dx, dy = args[0], float(args[1]), float(args[2])
+        obj = objects.get(oid)
+        if not obj:
+            return 1
+        obj["center"][0] = round(obj["center"][0] + dx, 4)
+        obj["center"][1] = round(obj["center"][1] + dy, 4)
+        return finish(f"move {oid} {dx} {dy}")
+
+    if verb == "resize":
+        oid = args[0]
+        obj = objects.get(oid)
+        if not obj:
+            return 1
+        obj["size"] = [round(float(v), 4) for v in args[1:4]]
+        return finish(f"resize {oid} {obj['size']}")
+
+    if verb == "drop":
+        oid = args[0]
+        if oid not in objects:
+            return 1
+        objects.pop(oid)
+        return finish(f"drop {oid} ({' '.join(args[1:]) or 'no reason given'})")
+
+    if verb == "undo":
+        _, _, hist_p = _paths(session)
+        history = json.loads(hist_p.read_text()) if hist_p.is_file() else []
+        if len(history) < 2:
+            print("nothing to undo")
+            return 1
+        history.pop()
+        save_shell(history[-1]["state"], _paths(session)[0])
+        hist_p.write_text(json.dumps(history), encoding="utf-8")
+        state, baseline, held = _load(session)
+        print(f"undone. now: {history[-1]['note']}")
+        print(_score_line(state, baseline, held))
+        return 0
+
+    print(f"unknown verb: {verb}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/src/litereality_agent/room_ops/export/export_room.py
+++ b/src/litereality_agent/room_ops/export/export_room.py
@@ -236,6 +236,56 @@ def _apply_shell_merges(shell: dict, scan: str) -> None:
     shell["objects"] = objs
 
 
+def _apply_layout(shell: dict, scan: str) -> None:
+    """In place: adopt the object boxes the layout pass settled, from `scene_data/layout_shell.json`.
+
+    The SHELL above is re-extracted from `room.usdz` under Blender, which is right for walls,
+    openings and the floor and wrong for the objects. `scene_init/layout` repairs the object boxes
+    at ingest — before crops — so every crop, reference image and generated GLB is built against the
+    REPAIRED box. Placing those assets back into the scanned box undoes the repair at the last step
+    and, worse, disagrees with the asset it is placing: Kitchen's counter run was generated for a
+    63 cm depth and would be scaled into the 87 cm box the scan measured.
+
+    So the object boxes come from the layout pass and everything else keeps coming from the usdz.
+    On the merged units this also settles a disagreement between two union computations —
+    `merge_boxes._union_obb` unions the ARKit pkl entries, `_union_box` above unions the extracted
+    SHELL boxes, and on Kitchen they land 33 cm apart. The pkl-derived one wins because it is the
+    box the object stage actually used.
+
+    Never raises: a missing or malformed file leaves the export exactly as it was.
+    """
+    path = config.scene_data_dir(scan) / "layout_shell.json"
+    if not path.is_file():
+        return
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        print(f"  [layout] ignoring unreadable {path.name}: {exc}")
+        return
+
+    objs = shell.get("objects") or {}
+    adopted, moved = 0, 0
+    for name, box in (payload.get("objects") or {}).items():
+        current = objs.get(name)
+        if not current or "center" not in box or "size" not in box:
+            continue
+        if (current.get("center") != box["center"] or current.get("size") != box["size"]
+                or current.get("yaw") != box.get("yaw")):
+            moved += 1
+        current["center"] = list(box["center"])
+        current["size"] = list(box["size"])
+        if box.get("yaw") is not None:
+            current["yaw"] = box["yaw"]
+        adopted += 1
+    for name in (payload.get("dropped") or []):
+        if objs.pop(name, None) is not None:
+            print(f"  [layout] SHELL box {name} removed — the layout pass dropped it")
+    shell["objects"] = objs
+    if adopted:
+        print(f"  [layout] SHELL adopted {adopted} object boxes from the layout pass "
+              f"({moved} differ from the scan)")
+
+
 def export(scan: str, out_root: Path | None = None) -> Path | None:
     scan = config.scan_name(scan)  # accept a name or a path to the scan folder
     recon = config.reconstruct_dir(scan)
@@ -270,6 +320,9 @@ def export(scan: str, out_root: Path | None = None) -> Path | None:
     # object's members.json) into the SHELL's object boxes, so the assembler has a box named for the
     # merged object to place its GLB into (else the merged GLB has no box and is dropped).
     _apply_shell_merges(shell, scan)
+    # AFTER the merges: the layout pass works on merged units, so its box for `Sink_Storage0` only
+    # has somewhere to land once the merge has created that name in the SHELL.
+    _apply_layout(shell, scan)
     # build_room.py lives in room_ops/compile; HERE is room_ops/export.
     room_py = (HERE.parent / "compile" / "build_room.py").read_text(encoding="utf-8")
     # SHELL MUST be defined BEFORE `ROOM = main()` runs — else _load_shell can't see the embedded

--- a/tests/test_box_merge.py
+++ b/tests/test_box_merge.py
@@ -131,6 +131,116 @@ def test_threshold_is_a_fraction_of_the_smaller_box():
     assert merge_boxes._footprint_overlap(small, big) == 1.0
 
 
+# --------------------------------------------------------------------------- the wall guard
+
+
+def wall(x1: float, z1: float, x2: float, z2: float):
+    """One wall centreline as `wall_segments` returns it: a 2-D segment in the ARKit ground plane."""
+    return ((x1, z1), (x2, z2))
+
+
+def test_a_wall_between_two_boxes_stops_the_merge():
+    """Two boxes whose footprints overlap are still not one object if a wall stands between them.
+
+    This is the horizontal twin of the vertical gate. Both boxes are the same height here, so the
+    height rule has nothing to say — only the wall does.
+    """
+    objs = [
+        box("Storage0", (0.0, 0, 0.0), (1.0, 0.8, 1.0)),
+        box("Storage1", (0.6, 0, 0.0), (1.0, 0.8, 1.0)),
+    ]
+    assert merge_boxes.auto_groups(objs) == [["Storage0", "Storage1"]]
+    between = [wall(0.3, -2.0, 0.3, 2.0)]
+    assert merge_boxes.auto_groups(objs, walls=between) == []
+
+
+def test_a_wall_beside_the_run_does_not_stop_it():
+    """A counter run is normally installed ALONG a wall. A wall the run merely lies against, rather
+    than crosses, must leave the merge alone — otherwise the guard would break every kitchen."""
+    objs = [
+        box("Sink0", (0.0, 0, 0.0), (1.0, 0.3, 1.0)),
+        box("Storage0", (0.6, 0, 0.0), (1.0, 0.8, 1.0)),
+    ]
+    alongside = [wall(-2.0, 0.7, 2.0, 0.7), wall(-2.0, -0.7, 2.0, -0.7)]
+    assert merge_boxes.auto_groups(objs, walls=alongside) == [["Sink0", "Storage0"]]
+
+
+def test_a_smeared_box_cannot_bridge_two_rooms():
+    """The Kitchen-Xiaoyang_Lyu bug, in miniature.
+
+    RoomPlan detected one oven twice and recorded the second copy far too deep — deep enough to
+    reach through the wall behind it. That copy overlaps the real run on one side AND a unit on the
+    far side, so union-find welds both runs into a single box spanning the wall. Nothing downstream
+    can recover from that: the layout pass reads the result as a counter recorded too deep.
+
+    The near-side pair must survive; only the member across the wall is released.
+    """
+    objs = [
+        box("Storage3", (0.0, 0, 0.0), (2.0, 0.9, 0.6)),      # the real counter run
+        box("Oven2", (0.2, 0, 0.5), (0.6, 0.9, 1.6)),         # one oven, smeared through the wall
+        box("Storage0", (0.3, 0, 1.1), (1.2, 0.9, 0.6)),      # a unit on the FAR side
+    ]
+    assert merge_boxes.auto_groups(objs) == [["Oven2", "Storage0", "Storage3"]]
+    partition = [wall(-3.0, 0.8, 3.0, 0.8)]
+    assert merge_boxes.auto_groups(objs, walls=partition) == [["Oven2", "Storage3"]]
+
+
+def test_only_a_wall_that_actually_stands_between_them_counts():
+    """The test is against the wall SEGMENT, not the infinite line through it.
+
+    A room is full of walls whose infinite lines cut everything in half. Scoring against the line
+    would refuse merges all over the room; scoring against the segment asks the only question that
+    matters, which is whether a wall is physically in the way.
+    """
+    objs = [
+        box("Storage0", (0.0, 0, 0.0), (1.0, 0.8, 1.0)),
+        box("Storage1", (0.6, 0, 0.0), (1.0, 0.8, 1.0)),
+    ]
+    stops_short = [wall(0.3, 1.5, 0.3, 4.0)]      # same line as the separating wall, but elsewhere
+    assert merge_boxes.auto_groups(objs, walls=stops_short) == [["Storage0", "Storage1"]]
+
+
+def test_no_walls_means_exactly_the_old_behaviour():
+    """The guard can only ever REMOVE a merge, and it is inert without walls. A scan whose room
+    geometry is missing or unreadable must merge exactly as it did before the guard existed."""
+    for walls in (None, []):
+        assert merge_boxes.auto_groups(FALLSIDE, walls=walls) == [["Sink0", "Storage2"]]
+
+
+def test_wall_segments_degrades_to_empty_instead_of_raising(tmp_path, capsys):
+    """No room on disk is not a merge failure. `wall_segments` says so and returns nothing, because
+    taking down the merge over missing wall geometry would be worse than the bug it prevents."""
+    assert merge_boxes.wall_segments(tmp_path) == []
+    assert "wall guard" in capsys.readouterr().out
+
+
+def test_the_guard_is_on_by_default_and_opt_outable(monkeypatch, tmp_path):
+    """It ships on. `$LR_BOX_MERGE_WALL_GUARD=0` is the escape hatch if a scan's walls are wrong."""
+    import litereality_agent.pipeline.scene_init.paths as config
+
+    scene = tmp_path / "scene"
+    scene.mkdir()
+    objs = [
+        box("Storage0", (0.0, 0, 0.0), (1.0, 0.8, 1.0)),
+        box("Storage1", (0.6, 0, 0.0), (1.0, 0.8, 1.0)),
+    ]
+    pickle.dump(objs, open(scene / "objects.pkl", "wb"))
+    monkeypatch.setattr(config, "scene_data_dir", lambda scan: scene)
+    monkeypatch.setattr(config, "object_refs_root", lambda: tmp_path / "refs")
+    seen = {}
+    real = merge_boxes.auto_groups
+    monkeypatch.setattr(merge_boxes, "auto_groups",
+                        lambda o, th=None, vg=None, walls=None: seen.setdefault("walls", walls) or [])
+    merge_boxes.merge_for_scan("scan")
+    assert seen["walls"] == []          # asked for walls; this scan has none
+
+    seen.clear()
+    monkeypatch.setenv("LR_BOX_MERGE_WALL_GUARD", "0")
+    merge_boxes.merge_for_scan("scan")
+    assert seen["walls"] == []
+    monkeypatch.setattr(merge_boxes, "auto_groups", real)
+
+
 # --------------------------------------------------------------------------- union geometry
 
 

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -7,15 +7,19 @@ scan, no Blender, no model.
 
 from __future__ import annotations
 
+import copy
 import math
 import pickle
+import re
 
 import numpy as np
 import pytest
 
-from litereality_agent.pipeline.scene_init.layout import adapter
+from litereality_agent.pipeline.scene_init.layout import adapter, report
 from litereality_agent.pipeline.scene_init.layout.adjust import check
-from litereality_agent.pipeline.scene_init.layout.repair import repair, score, attachments
+from litereality_agent.pipeline.scene_init.layout.graph import expected_pair, in_category
+from litereality_agent.pipeline.scene_init.layout.repair import (SHRINKABLE, attachments,
+                                                                 duplicates, repair, score)
 from litereality_agent.pipeline.scene_init.layout.stage import run_layout
 
 
@@ -109,3 +113,159 @@ def test_a_dropped_object_is_removed_and_nothing_is_invented():
     changed = adapter.apply_to_objects(entries, shell)
     assert changed["dropped"] == ["B"]
     assert [e["object_type"] for e in entries] == ["A"]
+
+
+# ── the drawn report ─────────────────────────────────────────────────────────
+def test_the_report_draws_both_rooms_and_names_every_object():
+    before = room({"Storage0": box(2.0, 2.0), "Table0": box(4.0, 4.0, category="table")})
+    after = room({"Storage0": box(2.4, 2.0), "Table0": box(4.0, 4.0, category="table")})
+    page = report.render("scan", before, after)
+    assert page.count("<svg") == 2, "a change was made, so both plans belong on the page"
+    for object_id in ("Storage0", "Table0"):
+        assert page.count(object_id) >= 2
+    assert 'class="ghost"' in page, "the scanned position has to stay visible under the repair"
+    assert 'class="move"' in page, "and the correction has to be drawn as a move"
+
+
+def test_an_unchanged_room_is_drawn_once():
+    """Two identical plans are not a comparison — they invite a hunt for a difference."""
+    shell = room({"Storage0": box(2.0, 2.0)})
+    page = report.render("scan", shell, shell)
+    assert page.count("<svg") == 1
+    assert 'class="move"' not in page
+
+
+def test_a_mixed_winding_floor_still_fills():
+    """The floor is one path, and SVG's nonzero rule reads opposed triangles as a hole.
+
+    RoomPlan's floor mesh has no consistent orientation, so emitted as they come the room's own
+    triangles cancel and the plate renders as nothing at all — an invisible failure a picture is
+    meant to catch rather than contain. Every triangle must leave here wound the same way.
+    """
+    shell = room({})
+    shell["floor"]["faces"] = [[0, 1, 2], [2, 1, 0], [0, 2, 3]]   # deliberately opposed
+    page = report.render("scan", shell, shell)
+    path = re.search(r'class="floor" d="([^"]+)"', page).group(1)
+    for subpath in path.split("Z")[:-1]:
+        points = [tuple(map(float, p.split())) for p in subpath.lstrip("M").split("L") if p.strip()]
+        area = sum(points[i][0] * points[(i + 1) % len(points)][1]
+                   - points[(i + 1) % len(points)][0] * points[i][1]
+                   for i in range(len(points)))
+        assert area >= 0, f"triangle wound the other way: {subpath}"
+
+
+def test_a_dropped_object_is_drawn_where_it_was():
+    """Deleting a duplicate is the most invisible thing the pass does and the easiest to get wrong."""
+    before = room({"Storage0": box(2.0, 2.0), "Storage1": box(2.05, 2.0)})
+    after = room({"Storage0": box(2.0, 2.0)})
+    page = report.render("scan", before, after)
+    assert 'class="dropped"' in page
+    assert "Storage1" in page
+
+
+def scene_data(monkeypatch, tmp_path, objects):
+    """A scan directory the stage will accept, without a RoomPlan capture to build one from.
+
+    `shell_from_scene_data` is the loader's job and is tested where the loader is; these are about
+    what the STAGE does with the shell it gets back, so it is handed one directly.
+    """
+    shell = room(objects)
+    monkeypatch.setattr(adapter, "shell_from_scene_data",
+                        lambda *args, **kwargs: copy.deepcopy(shell))
+    entries = [{"object_type": oid, "position": np.array([o["center"][0], o["center"][2],
+                                                          -o["center"][1]]),
+                "bbox": np.array([o["size"][0], o["size"][2], o["size"][1]]),
+                "rotation": 0.0, "mesh_id": oid} for oid, o in objects.items()]
+    (tmp_path / "objects.pkl").write_bytes(pickle.dumps(entries))
+    return shell
+
+
+def test_the_stage_writes_the_plan_and_can_be_told_not_to(tmp_path, monkeypatch):
+    scene_data(monkeypatch, tmp_path, {"Storage0": box(2.0, 2.0)})
+
+    monkeypatch.setenv("LR_LAYOUT_VIZ", "0")
+    assert "visualization" not in run_layout("scan", scene_data_dir=tmp_path)
+    assert not (tmp_path / "layout.html").exists()
+
+    monkeypatch.setenv("LR_LAYOUT_VIZ", "1")
+    result = run_layout("scan", scene_data_dir=tmp_path)
+    assert (tmp_path / "layout.html").is_file(), "a sound room is a claim, and needs its picture too"
+    assert result["visualization"].endswith("layout.html")
+
+
+def test_a_failed_drawing_does_not_fail_the_repair(tmp_path, monkeypatch):
+    """The pkl is already written by the time the plan is drawn. A broken picture is not a broken
+    repair, and reporting it as one would send a good room back through init."""
+    scene_data(monkeypatch, tmp_path,
+               {"Storage0": box(2.0, 2.0), "Storage1": box(2.05, 2.0)})
+    monkeypatch.setattr(report, "render", lambda *args, **kwargs: 1 / 0)
+
+    result = run_layout("scan", scene_data_dir=tmp_path)
+    assert "error" not in result
+    assert "visualization" not in result
+    assert result["after"] == 0, "the repair itself still has to have happened"
+    assert (tmp_path / "layout_report.json").is_file()
+
+
+# ── what may be deleted, and what a merged run is ────────────────────────────
+def test_nothing_is_ever_deleted_by_default():
+    """Two boxes on the same spot ARE one object detected twice, and it still keeps both.
+
+    A redundant generated asset is visible, cheap and reversible. A wrong deletion is an object
+    that is simply not in the room, and nothing downstream reports the absence.
+    """
+    shell = room({"Storage0": box(2.0, 2.0), "Storage1": box(2.05, 2.02)})
+    assert duplicates(shell), "it can still SEE the duplicate"
+    out, _moves, log = repair(shell)
+    assert "drop" not in [a["action"] for a in log]
+    assert set(out["objects"]) == {"Storage0", "Storage1"}
+
+
+def test_dropping_can_be_armed_deliberately(monkeypatch):
+    monkeypatch.setenv("LR_LAYOUT_DROP", "1")
+    shell = room({"Storage0": box(2.0, 2.0), "Storage1": box(2.05, 2.02)})
+    out, _moves, log = repair(shell)
+    assert [a["action"] for a in log] == ["drop"]
+    assert len(out["objects"]) == 1
+
+
+def test_a_run_that_merely_contains_a_smaller_box_is_not_a_duplicate():
+    """Kitchen's failure, as geometry: a cabinet standing inside a counter run.
+
+    Overlap normalised by the smaller box is 1.00 for containment — indistinguishable from a
+    perfect duplicate by that measure alone, which is why size has to be part of the test.
+    """
+    shell = room({"Storage0": box(2.0, 2.0, w=1.23, d=0.67, h=0.89),
+                  "Oven_Storage_Stove0": box(2.0, 2.0, w=2.53, d=1.62, h=1.05,
+                                             category="oven_storage_stove")})
+    assert not duplicates(shell)
+
+
+def test_a_merged_run_is_never_the_box_that_gets_deleted(monkeypatch):
+    """Even armed, the merge fused this unit on evidence the repair does not have."""
+    monkeypatch.setenv("LR_LAYOUT_DROP", "1")
+    merged = box(2.0, 2.0)
+    merged["merged_from"] = ["Oven1", "Oven2", "Stove0"]
+    shell = room({"Oven_Storage_Stove0": merged, "Storage1": box(2.05, 2.02)})
+    out, _moves, log = repair(shell)
+    assert [a["action"] for a in log] == ["drop"]
+    assert "Oven_Storage_Stove0" in out["objects"], "it deleted the assembled unit"
+    assert "Storage1" not in out["objects"]
+
+
+def test_the_category_tables_see_through_a_merged_name():
+    """A merged run is named after its members, and every category rule keyed on an exact string
+    silently stopped applying to it — no error, just knowledge switching off."""
+    assert expected_pair("sink", "sink_storage"), "a basin in its own counter run"
+    assert expected_pair("storage", "oven_storage_stove"), "a cabinet in a counter run"
+    assert in_category("sink_storage", SHRINKABLE), "the shrink action exists FOR merged runs"
+    assert not expected_pair("sink_storage", "oven_storage_stove"), \
+        "two runs matched loosely enough would exempt a genuine interpenetration"
+
+
+def test_a_cabinet_inside_a_merged_counter_run_is_not_a_collision():
+    """The whole chain: it was reported as a clash, and the repair answered by deleting the run."""
+    shell = room({"Storage0": box(2.0, 2.0, w=1.23, d=0.67, h=0.89),
+                  "Oven_Storage_Stove0": box(2.0, 2.0, w=2.53, d=1.62, h=1.05,
+                                             category="oven_storage_stove")})
+    assert not [v for v in errors(shell) if v.kind == "object_clash"]

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -95,9 +95,11 @@ def test_objects_pkl_round_trips_through_the_shell(tmp_path):
     assert changed["moved"] == ["Storage0"]
     assert entries[0]["file"] == "./x.usda" and entries[0]["mesh_id"] == "Storage0"
     assert entries[0]["top_down_rect"] == [(0, 0)]
-    # ARKit y stays the height, x/z the floor plane
+    # SHELL (x, y, z) -> ARKit (x, z, -y): height swaps back to ARKit's y, and the plan axis is
+    # negated, because ARKIT_TO_Z_UP is (x, y, z) -> (x, -z, y) and this is its inverse.
     assert entries[0]["position"][0] == pytest.approx(1.5)
-    assert entries[0]["position"][2] == pytest.approx(2.0)
+    assert entries[0]["position"][1] == pytest.approx(0.4)
+    assert entries[0]["position"][2] == pytest.approx(-2.0)
 
 
 def test_a_dropped_object_is_removed_and_nothing_is_invented():

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -19,8 +19,13 @@ import pytest
 from litereality_agent.pipeline.scene_init.layout import adapter, report
 from litereality_agent.pipeline.scene_init.layout.adjust import check
 from litereality_agent.pipeline.scene_init.layout.graph import expected_pair, in_category
-from litereality_agent.pipeline.scene_init.layout.repair import (SHRINKABLE, attachments,
-                                                                 duplicates, repair, score)
+from litereality_agent.pipeline.scene_init.layout.repair import (
+    SHRINKABLE,
+    attachments,
+    duplicates,
+    repair,
+    score,
+)
 from litereality_agent.pipeline.scene_init.layout.stage import run_layout
 from litereality_agent.room_ops.export import export_room
 

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -8,6 +8,7 @@ scan, no Blender, no model.
 from __future__ import annotations
 
 import copy
+import json
 import math
 import pickle
 import re
@@ -21,6 +22,7 @@ from litereality_agent.pipeline.scene_init.layout.graph import expected_pair, in
 from litereality_agent.pipeline.scene_init.layout.repair import (SHRINKABLE, attachments,
                                                                  duplicates, repair, score)
 from litereality_agent.pipeline.scene_init.layout.stage import run_layout
+from litereality_agent.room_ops.export import export_room
 
 
 def errors(shell):
@@ -269,3 +271,71 @@ def test_a_cabinet_inside_a_merged_counter_run_is_not_a_collision():
                   "Oven_Storage_Stove0": box(2.0, 2.0, w=2.53, d=1.62, h=1.05,
                                              category="oven_storage_stove")})
     assert not [v for v in errors(shell) if v.kind == "object_clash"]
+
+
+# ── the hand-off to the scene stage ──────────────────────────────────────────
+def shell_json(objects):
+    """A SHELL in the shape `export_room` embeds into Room.py."""
+    return {"floor_z": 0.0, "ceiling_z": 2.5, "walls": {"Wall0": {"start": [0, 0], "end": [4, 0]}},
+            "openings": {}, "objects": objects, "floor": {"verts": [], "faces": []}}
+
+
+def test_the_layout_publishes_the_boxes_the_object_stage_used(tmp_path, monkeypatch):
+    """Everything downstream of the crop was built against these; the room has to place into them."""
+    scene_data(monkeypatch, tmp_path, {"Storage0": box(2.0, 2.0)})
+    run_layout("scan", scene_data_dir=tmp_path)
+
+    published = json.loads((tmp_path / "layout_shell.json").read_text())
+    assert published["objects"]["Storage0"]["center"] == [2.0, 2.0, 0.4]
+    assert published["objects"]["Storage0"]["size"] == [0.8, 0.6, 0.8]
+    assert published["dropped"] == []
+
+
+def test_the_room_export_adopts_the_layout_boxes(tmp_path, monkeypatch):
+    """The SHELL is re-extracted from room.usdz, so without this the repair never reaches the room."""
+    monkeypatch.setattr(export_room.config, "scene_data_dir", lambda scan: tmp_path)
+    (tmp_path / "layout_shell.json").write_text(json.dumps({
+        "objects": {"Storage0": {"center": [2.4, 2.0, 0.4], "size": [0.7, 0.6, 0.8], "yaw": 15.0}},
+        "dropped": []}))
+
+    shell = shell_json({"Storage0": {"category": "storage", "center": [2.0, 2.0, 0.4],
+                                     "size": [0.8, 0.6, 0.8], "yaw": 0.0},
+                        "Table0": {"category": "table", "center": [1.0, 1.0, 0.4],
+                                   "size": [1.2, 0.8, 0.7], "yaw": 0.0}})
+    export_room._apply_layout(shell, "scan")
+
+    assert shell["objects"]["Storage0"]["center"] == [2.4, 2.0, 0.4]
+    assert shell["objects"]["Storage0"]["size"] == [0.7, 0.6, 0.8]
+    assert shell["objects"]["Storage0"]["yaw"] == 15.0
+    assert shell["objects"]["Table0"]["center"] == [1.0, 1.0, 0.4], "it touched a box it was not given"
+    assert shell["walls"], "walls, openings and the floor stay the usdz's"
+
+
+def test_the_room_export_survives_a_missing_or_broken_hand_off(tmp_path, monkeypatch):
+    """A room that cannot read the layout's file must still export, unrepaired."""
+    monkeypatch.setattr(export_room.config, "scene_data_dir", lambda scan: tmp_path)
+    original = {"Storage0": {"category": "storage", "center": [2.0, 2.0, 0.4],
+                             "size": [0.8, 0.6, 0.8], "yaw": 0.0}}
+
+    shell = shell_json(copy.deepcopy(original))
+    export_room._apply_layout(shell, "scan")                       # no file at all
+    assert shell["objects"] == original
+
+    (tmp_path / "layout_shell.json").write_text("{not json")
+    shell = shell_json(copy.deepcopy(original))
+    export_room._apply_layout(shell, "scan")
+    assert shell["objects"] == original
+
+
+def test_a_box_the_layout_dropped_leaves_the_room(tmp_path, monkeypatch):
+    """Only reachable with $LR_LAYOUT_DROP=1, but the room must not keep a box whose asset is gone."""
+    monkeypatch.setattr(export_room.config, "scene_data_dir", lambda scan: tmp_path)
+    (tmp_path / "layout_shell.json").write_text(
+        json.dumps({"objects": {}, "dropped": ["Storage1"]}))
+
+    shell = shell_json({"Storage0": {"category": "storage", "center": [2.0, 2.0, 0.4],
+                                     "size": [0.8, 0.6, 0.8], "yaw": 0.0},
+                        "Storage1": {"category": "storage", "center": [2.05, 2.0, 0.4],
+                                     "size": [0.8, 0.6, 0.8], "yaw": 0.0}})
+    export_room._apply_layout(shell, "scan")
+    assert set(shell["objects"]) == {"Storage0"}

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1,0 +1,109 @@
+"""The layout stage's two contracts: it never makes a room worse, and it never breaks a run.
+
+Both are properties rather than examples, because the stage runs by default on every scan and the
+failure modes that matter are the ones no fixture would happen to contain. Fast and offline — no
+scan, no Blender, no model.
+"""
+
+from __future__ import annotations
+
+import math
+import pickle
+
+import numpy as np
+import pytest
+
+from litereality_agent.pipeline.scene_init.layout import adapter
+from litereality_agent.pipeline.scene_init.layout.adjust import check
+from litereality_agent.pipeline.scene_init.layout.repair import repair, score, attachments
+from litereality_agent.pipeline.scene_init.layout.stage import run_layout
+
+
+def errors(shell):
+    return [v for v in check(shell) if v.severity == "error"]
+
+
+def room(objects, size=6.0):
+    """A square room with the given objects, in SHELL form."""
+    corners = [(0.0, 0.0), (size, 0.0), (size, size), (0.0, size)]
+    walls = {}
+    for i in range(4):
+        walls[f"Wall{i}"] = {"start": list(corners[i]), "end": list(corners[(i + 1) % 4]),
+                             "thickness": 0.1, "height": 2.5}
+    verts = [[x, y, 0.0] for x, y in corners]
+    return {"walls": walls, "openings": {}, "objects": objects,
+            "floor": {"verts": verts, "faces": [[0, 1, 2], [0, 2, 3]]},
+            "floor_z": 0.0, "ceiling_z": 2.5}
+
+
+def box(x, y, w=0.8, d=0.6, h=0.8, category="storage", yaw=0.0):
+    return {"category": category, "center": [x, y, h / 2], "size": [w, d, h], "yaw": yaw}
+
+
+def test_a_sound_room_is_left_alone():
+    shell = room({"Storage0": box(2.0, 2.0), "Table0": box(4.0, 4.0, category="table")})
+    assert not errors(shell)
+    out, _moves, log = repair(shell)
+    assert not log, f"nothing to do, but it acted: {log}"
+    for oid, obj in out["objects"].items():
+        assert math.dist(obj["center"][:2], shell["objects"][oid]["center"][:2]) < 1e-6
+
+
+@pytest.mark.parametrize("seed", range(12))
+def test_repair_never_returns_a_worse_room(seed):
+    """The contract the whole action-and-gate design exists to provide.
+
+    Randomised because the interesting failures are compositional: a push that separates one pair
+    drives an object into a third, and a fixture that only ever ran on the captures we happened to
+    have would not show it.
+    """
+    rng = np.random.default_rng(seed)
+    objects = {}
+    for i in range(rng.integers(3, 8)):
+        objects[f"Storage{i}"] = box(float(rng.uniform(0.2, 5.8)), float(rng.uniform(0.2, 5.8)),
+                                     w=float(rng.uniform(0.4, 1.6)), d=float(rng.uniform(0.4, 1.2)),
+                                     yaw=float(rng.uniform(-180, 180)))
+    shell = room(objects)
+    held = {oid: set(attachments(o, shell["walls"])) for oid, o in shell["objects"].items()}
+    held = {k: v for k, v in held.items() if v}
+    out, _moves, _log = repair(shell)
+    assert score(out, shell, held) <= score(shell, shell, held)
+
+
+def test_the_stage_never_raises_into_the_pipeline(tmp_path):
+    """A layout failure must degrade to an unrepaired run, never take init down."""
+    (tmp_path / "objects.pkl").write_bytes(b"not a pickle")
+    result = run_layout("broken", scene_data_dir=tmp_path)
+    assert "error" in result or "skipped" in result
+
+    assert run_layout("empty", scene_data_dir=tmp_path / "nope").get("skipped")
+
+
+def test_the_stage_can_be_switched_off(tmp_path, monkeypatch):
+    monkeypatch.setenv("LR_LAYOUT", "0")
+    assert run_layout("anything", scene_data_dir=tmp_path).get("disabled")
+
+
+def test_objects_pkl_round_trips_through_the_shell(tmp_path):
+    """Every field extraction wrote must survive, and only pose and size may change."""
+    entries = [{"object_type": "Storage0", "position": np.array([1.0, 0.4, 2.0]),
+                "bbox": np.array([0.8, 0.8, 0.6]), "rotation": 0.0,
+                "file": "./x.usda", "mesh_id": "Storage0", "top_down_rect": [(0, 0)]}]
+    shell = room({"Storage0": box(1.0, 2.0)})
+    shell["objects"]["Storage0"]["center"] = [1.5, 2.0, 0.4]      # pretend the repair moved it
+    changed = adapter.apply_to_objects(entries, shell)
+    assert changed["moved"] == ["Storage0"]
+    assert entries[0]["file"] == "./x.usda" and entries[0]["mesh_id"] == "Storage0"
+    assert entries[0]["top_down_rect"] == [(0, 0)]
+    # ARKit y stays the height, x/z the floor plane
+    assert entries[0]["position"][0] == pytest.approx(1.5)
+    assert entries[0]["position"][2] == pytest.approx(2.0)
+
+
+def test_a_dropped_object_is_removed_and_nothing_is_invented():
+    entries = [{"object_type": "A", "position": np.zeros(3), "bbox": np.ones(3), "rotation": 0.0},
+               {"object_type": "B", "position": np.zeros(3), "bbox": np.ones(3), "rotation": 0.0}]
+    shell = room({"A": box(1.0, 1.0)})                            # B was dropped by the repair
+    changed = adapter.apply_to_objects(entries, shell)
+    assert changed["dropped"] == ["B"]
+    assert [e["object_type"] for e in entries] == ["A"]


### PR DESCRIPTION
RoomPlan's boxes are a measurement, so they overlap, sit inside walls, hang off the floor plate, and occasionally describe one wardrobe twice. Nothing downstream was checking that before spending money on it: a duplicate became two generated assets, a counter run recorded half a metre too deep became an asset generated at the wrong extent and then squashed to fit, and a box that moved after its crop was cut left the reference image describing geometry that no longer existed.

This adds a `layout` stage inside ingest, immediately after `merge_boxes` and before crops — the same window the merge already occupies, for the same reason. On boxes a correction is free; after reconstruction it is paid for several times over, and the crop, the reference image, the chair clustering and the complexity route all inherit the fix for nothing.

## What it does

`adjust.check` states what "sound" means and is also what the repair optimises against: nothing overlapping that should not (a chair tucked into its own table excepted), no footprint crossing a wall line, nothing off the floor plate, nothing floating or through the ceiling.

`repair` is a search over legal **actions** rather than a displacement field:

| action | when |
|---|---|
| `drop` | **off by default** — see below (`LR_LAYOUT_DROP=1` arms it) |
| `snap` / `corner_fit` | seat a unit against its wall, or fit it into its corner, trimming if it must |
| `push` / `slide` | out of the wall it is inside, or along the wall it is on until clear |
| `dewrap` | two units on the same wall separate *along* it — a 1-D problem |
| `separate` | MTV push, carrying the object's group so a table takes its chairs |
| `joint_shrink` | a few cm off *each* of two correctly-placed objects, capped at 12% |
| `resize` | a real trim — only for categories RoomPlan over-merges, never a standalone table |

Every action is applied to a copy and kept only if the room provably improves, so **a repair cannot return a worse room**. Freedom is read from the room itself: a unit in a corner does not move, one against a wall slides along it, and moving furniture implausibly far counts as a defect alongside the collisions it was meant to fix.

The optional model-assisted pass is for what geometry cannot settle — whether a box is the wrong *size* rather than in the wrong place, which two boxes are one object, which corner something belongs in. It reads the reference photographs, names the walls, and lets the geometry compute the centimetres; its answer goes through the same gate. Off by default (`LR_LAYOUT_AGENT=1`).

`adapter` is the only place the two coordinate conventions meet: `scene_data` is ARKit's Y-up, the SHELL is Z-up. `scene_data` is taken from the `physics-agent` branch, which had already solved the part that is easy to get subtly wrong — a wall's centreline comes from its transform matrix, not its Euler angle, because `R = Ry(t).Rz(180)` does not decompose the obvious way.

## Safety

Follows the merge's contract and **never raises into the caller**: a layout failure leaves the scan exactly as it found it and the run continues unrepaired. `LR_LAYOUT=0` opts out. `objects.pkl` is backed up to `objects.pre_layout.pkl` before rewriting, and only `position` and `bbox` are touched — every other field extraction wrote survives untouched. A `layout_report.json` records every action.

## Verified

Run through the real CLI (`litereality stage ingest example-scans/<scan>`), stopping short of reconstruction:

```
Office_room    5 violations -> 1    return, drop, separate      (1 duplicate dropped)
Tea_room      12 violations -> 3    return, push, snap, corner_fit, slide, separate, resize
```

554 tests pass, including 17 new ones — among them a randomised property test asserting the repair can never return a worse room. Two pre-existing failures are unrelated (they fail identically with this branch stashed).

The second commit fixes a false-positive found during that verification: one capture's floor entity collapses under its own transform to 0.27 m², which made every object report as off the plate. A plate covering less than a third of the area its own walls enclose is now declined rather than trusted.

## Every run draws what it did

A violation count cannot tell a counter put back against its wall from a table shoved half a metre across the room. Both read as zero. So the pass now writes a picture of itself: the scanned room and the repaired one **in the same projection**, the scanned positions ghosted underneath in dashed outline, and each correction drawn as an arrow from where the box was. Ghost-plus-arrow rather than a before/after pair you flick between — drawn on top of each other, a 3 cm reseat and a 50 cm slide are told apart at a glance.

One self-contained HTML file per scan at `traces/layout.html`: inline SVG, no matplotlib, no CDN, nothing to resolve. It renders from `file://`, survives being emailed, and costs a few milliseconds of string building, so it runs on every scan rather than on request. `LR_LAYOUT_VIZ=0` opts out. It draws even when the room was already sound — "already sound" is a claim, and an empty object set reports zero violations exactly like a correct one.

## The pass no longer deletes anything

The picture's first finding was the pass deleting Kitchen's kitchen. Two counter runs went — one assembled by `box_merge` from five detections, two ovens and two stoves among them — and no GLB was ever built for either. Nothing reported the absence, which is the whole problem with a deletion.

**The root cause was not the drop rule.** `check` already exempts a basin in its own counter through `EXPECTED_CONTAINMENT`, and the exemption missed because the box merge names a fused run after its members: `sink_storage`, `oven_storage_stove`. Every category table in the package is keyed on an exact string, so the merge silently switched off the knowledge that applied to exactly the objects most in need of it — `SHRINKABLE` included, whose `shrink` action exists *for* merged runs and could not match one. Compound names are now expanded to their members, on **one side only**, or any two runs would find some member pair in the table and exempt a genuine interpenetration between them.

Deletion itself is now off. It is the one action here with no visible failure mode: a move that goes wrong is a box in an odd place, a wrong deletion is an oven that is not in the room. A duplicate left standing costs one redundant generated asset — visible, cheap, reversible. The trade is not close. `LR_LAYOUT_DROP=1` arms it, and even armed it will not delete a unit the merge assembled: provenance travels on the box as `merged_from` rather than being guessed from its name.

| Kitchen-Xiaoyang_Lyu | before | after |
|---|---|---|
| violations | 4 → 0 | 2 → 0 |
| objects deleted | 2 | **none** |
| objects kept | 8 of 10 | **10 of 10** |

Two of those four violations were never real. What remains is genuine — two objects off the floor plate — and is now fixed by `corner_fit` and `return` instead of by deletion. Office_room is unchanged: 2 → 0, one slide, nothing dropped.

566 tests pass, 11 of them new: the report draws both rooms and ghosts the scan; an unchanged room is drawn once; a mixed-winding floor still fills; nothing is ever deleted by default; a merged run is never the box deleted even when dropping is armed; the category tables see through a merged name.

## Not included

This is not collision QC. Small box-on-box overlap is a physics concern; what is settled here is visible in any render and expensive to discover later.

## Attribution

The layout pass's tool-CLI shape and its score-gated commit follow the physics agent on the `physics-agent` branch (`9be87ad`, @acse-yl222) — a persistent CLI so an agent can look, act, look again and change its mind, and a result kept only if it scores no worse than the baseline. Credited on every commit here.

@acse-yl222 — please sanity-check the attribution and flag anything you would rather see referenced differently.
