### PR TITLE
docs: Articraft links to the repo, and a little emoji on the news

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ turns it into a complete, graphics-ready scene with articulated assets.
 
 - **2026-09-09 — Procedural reconstruction with sim-ready physics.** Articulated objects now carry
   their own mass, inertia, colliders and joints, following
-  [Articraft](https://arxiv.org/abs/2605.15187), and export to URDF and MJCF.
+  [Articraft](https://github.com/articraftresearch/Articraft), and export to URDF and MJCF.
 - **2026-09-07 — Layout agents.** The noisy layout of a raw scan is settled into a collision-free,
   simulation-ready layout before anything is built from it.
 - **2026-08-01 — LiteReality-Agent 0.0.** Turn your room scans from the LiteReality Scanner app

--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ turns it into a complete, graphics-ready scene with articulated assets.
 
 ## News
 
-- **2026-09-09 — Procedural reconstruction with sim-ready physics.** Articulated objects now carry
+- ⚙️ **2026-09-09 — Procedural reconstruction with sim-ready physics.** Articulated objects now carry
   their own mass, inertia, colliders and joints, following
   [Articraft](https://github.com/articraftresearch/Articraft), and export to URDF and MJCF.
-- **2026-09-07 — Layout agents.** The noisy layout of a raw scan is settled into a collision-free,
+- 📐 **2026-09-07 — Layout agents.** The noisy layout of a raw scan is settled into a collision-free,
   simulation-ready layout before anything is built from it.
-- **2026-08-01 — LiteReality-Agent 0.0.** Turn your room scans from the LiteReality Scanner app
+- 🚀 **2026-08-01 — LiteReality-Agent 0.0.** Turn your room scans from the LiteReality Scanner app
   into interactive, realistic 3D.
 
 ## How to use


### PR DESCRIPTION
Two small README changes.

**Articraft now links the repo**, not the arXiv paper: `https://github.com/articraftresearch/Articraft`. The spelling in the request was missing its trailing `t` — `/Articraf` 404s — so I used the one that resolves.

**One emoji per news line**: 🚀 for the launch, 📐 for layout, ⚙️ for the object physics.