### PR TITLE
WIP: the room as a MuJoCo scene, built from the objects' own physics

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,19 @@ uv run litereality stage author run/<scan> --force --polish --live
 viewer starts before the room exists and waits for it, so it works on a scene's first authoring
 run; it prints its url again once the first build lands.
 
+## Simulate it
+
+The finished room as a MuJoCo scene — bodies rather than one baked mesh, each with the mass,
+inertia, friction, colliders and joints its own generated asset was compiled and solver-gated with.
+
+```bash
+uv run litereality stage simulate run/<scan>            # -> realism_authoring/mujoco/scene.xml
+uv run litereality stage simulate run/<scan> --shake     # ...and measure what actually moves
+```
+
+[`doc/Sim-Ready-intergration/Mujoco.md`](doc/Sim-Ready-intergration/Mujoco.md) covers where each
+number comes from and what happens to an object that has no compiled physics.
+
 ## See the results
 
 ```bash

--- a/doc/Sim-Ready-intergration/Mujoco.md
+++ b/doc/Sim-Ready-intergration/Mujoco.md
@@ -13,6 +13,31 @@ uv run litereality stage simulate run/<scan> --shake  # ...and measure what move
 uv run litereality run <scan> --through simulate      # the whole pipeline, ending here
 ```
 
+**Without the authoring stage at all.** Authoring adds materials, wall fixtures and the small
+objects — appearance and clutter. The physical scene is complete without any of it: the shell with
+its openings cut out, and every reconstructed object in its measured box carrying the mass,
+friction, colliders and joints its own build compiled. `--from-seed` exports that room instead, out
+of `scene_init`, into `mujoco_seed/`:
+
+```bash
+uv run litereality stage simulate run/<scan> --from-seed
+```
+
+It is the fastest way to get a scan into a simulator, and the cleanest test of the objects
+themselves — nothing in the scene came from anywhere but the reconstruction. Measured over 5 s of
+gravity with nothing touching them, four scans exported this way:
+
+| room | bodies | free | articulated | mass | drift over 5 s |
+|---|---|---|---|---|---|
+| Office-Elliott | 15 | 5 | 4 | 172 kg | 91 mm |
+| fallside-kitchen | 24 | 4 | 9 | 313 kg | 7 mm |
+| fallside-office | 12 | 3 | 2 | 515 kg | 107 mm |
+| MIL-Meeting | 32 | 16 | 6 | 484 kg | 1234 mm |
+
+MIL-Meeting is the outlier and it is not an export fault: one chair was scanned 44 mm inside a
+window reveal, and a 3.6 kg body squeezed out of static geometry travels. That is authored (here,
+scanned) interpenetration, and it belongs upstream in the layout repair.
+
 Directly, without the pipeline:
 
 ```bash

--- a/doc/Sim-Ready-intergration/Mujoco.md
+++ b/doc/Sim-Ready-intergration/Mujoco.md
@@ -1,0 +1,124 @@
+# The room as a MuJoCo scene
+
+`Room.glb` is a picture of a room. One file, every object baked into it, no notion of what is
+furniture and what is wall, no mass, no joints. Training anything in it needs the opposite — a
+scene of **bodies**, each with its own collision geometry, its own mass and inertia, and a joint
+(or deliberately none) saying how it may move.
+
+The `simulate` stage produces that:
+
+```bash
+uv run litereality stage simulate run/<scan>          # -> realism_authoring/mujoco/scene.xml
+uv run litereality stage simulate run/<scan> --shake  # ...and measure what moves
+uv run litereality run <scan> --through simulate      # the whole pipeline, ending here
+```
+
+Directly, without the pipeline:
+
+```bash
+uv run python -m litereality_agent.room_ops.export.mujoco_scene --room run/<scan>/realism_authoring/room
+uv run python -m litereality_agent.room_ops.export.mujoco_shake --scene .../mujoco/scene.xml --cutaway --video shake.mp4
+```
+
+## Where the physics comes from
+
+Nothing in the export invents a physical number that the assets already state. Four files are read
+together, and each answers the question it is the authority on:
+
+| file | what it settles |
+|---|---|
+| `Room.py` → `SHELL` | walls, openings, floor and ceiling heights — metric and exact |
+| `room_layout.json` | every object's pose and category, and its `rests_on` / `attached_to` |
+| `Room.glb` | the appearance, per named handle |
+| `Objects/<name>/sim/<name>.physics.json` | **the object's own physics** |
+
+That last one is the difference between a scene that happens to load in MuJoCo and a scene that is
+sim-ready. It is written at reconstruct time by
+[`models/object_generation/sim`](../../src/litereality_agent/models/object_generation/sim), from
+the GLB the recipe actually built, and gated by a solver *before* the object was ever placed in a
+room. It carries, per link:
+
+- **mass** — occupancy density over the object's own bounding box, or a figure the recipe read off
+  a real label, then split across the links by volume;
+- **inertia** and **centre of mass**, integrated from the mesh;
+- **friction** and **restitution**, from the material the recipe deliberately chose — glass grips
+  at 0.30, carpet at 0.85;
+- **convex colliders**, already decomposed;
+
+and per joint: **type, axis, pivot, limits, damping, joint friction, effort and velocity**.
+
+### Placing it
+
+An object is built in its own frame and then *fitted* into the RoomPlan box it belongs to — a
+rotation about the vertical and a per-axis scale, because the box the scan measured and the
+proportions the asset was built to rarely agree. So every number has to travel through one affine
+on the way in. That affine is recovered exactly, not estimated:
+
+```
+T = T_room(node) · T_object(node)⁻¹
+```
+
+for any single node present in both `Room.glb` and the object's own GLB. trimesh renames duplicated
+nodes with a random suffix on every load, so only names that are unique inside their own file can
+be matched across the two — one is enough, and every other node then maps through it.
+
+Two things follow from the scale being non-uniform:
+
+- a **derived** mass is multiplied by the volume ratio (occupancy density over a box is a rule, so
+  at a different size it is a different mass); an **authored** mass is a fact about the real object
+  and survives unchanged;
+- the inertia tensor is recomputed from the placed geometry rather than transformed, which is both
+  simpler and more honest than pushing a tensor through a non-uniform scale.
+
+The result is then **checked before it is trusted**: the union of the placed colliders has to land
+on the bounding box the room recorded for that handle. It is derived from one node, so a room that
+had moved an object's parts relative to each other would otherwise be silently mis-collided.
+
+### When there is no sidecar
+
+Objects the authoring agent wrote directly into `Room.py` — the mugs, the cables, the signage —
+have no object package and therefore no compiled physics. So do rooms exported before any of this
+existed. Those fall back to what the export did before: a mass from a category occupancy table, a
+CoACD decomposition run at export time, one friction for the whole building, and a hinge pivot
+inferred from the shape of the leaf.
+
+That fallback is a worse scene, not a broken one, and `export_report.json` says exactly which
+objects took it (`from_sidecar`, `no_sidecar`, `unplaceable`, `placement_rejected`). The stage
+repeats the counts as warnings rather than burying them.
+
+## The four kinds of body
+
+Decided from the data, not from guessing at names.
+
+| kind | what it is | how it is emitted |
+|---|---|---|
+| `structure` | walls, floor, ceiling | static **boxes** built from the `SHELL` numbers, with openings subtracted — a wall with a door becomes jamb / jamb / lintel, so the door has somewhere to swing |
+| `articulated` | doors, windows, drawers | frame static; each moving part its own body on a hinge or slide, at the pivot the recipe authored |
+| `free` | anything that `rests_on` something | a free joint, mesh colliders, and its own mass — the things that can be pushed and knocked over |
+| `attached` | anything `attached_to` a wall or ceiling | static geometry. A socket is not a rigid body that can fall off |
+
+Collision is never the visual mesh. MuJoCo collides a mesh as its **convex hull**, and the hull of
+a table is a solid block — a chair tucked under it would be launched on the first step, and a shelf
+would be a filled cupboard. Every concave body is therefore several convex pieces, and the original
+mesh is kept as a visual-only geom.
+
+The room itself is a body on three slide joints and a yaw hinge, driven by stiff position servos.
+That is what makes `--shake` an earthquake rather than a change in the direction of gravity: the
+floor really accelerates under the furniture, and a hung door really swings because its frame is
+what is being shaken.
+
+## Reading the result
+
+`realism_authoring/mujoco/` holds `scene.xml`, its `meshes/`, and `export_report.json`. The
+support relations the authoring pass recorded are what make the scene start **at rest**: an object
+whose `rests_on` surface is genuinely under it does not fall, and one authored floating does. That
+is reported rather than silently corrected — a scene that needs 200 steps to stop twitching is
+telling you something true about the room.
+
+## Related
+
+- [`meta_data.md`](meta_data.md) — what an asset has to carry to be sim-ready.
+- [`QC/supporting_relationship.md`](../QC/supporting_relationship.md) — how `rests_on` /
+  `attached_to` are checked.
+- [`QC/collision_check.md`](../QC/collision_check.md) — nothing may interpenetrate before it is
+  simulated.

--- a/doc/modules.md
+++ b/doc/modules.md
@@ -50,5 +50,7 @@ LiteReality-Agent
 - **QC checks** — [`QC/`](QC): [collision check](QC/collision_check.md), [supporting relationship](QC/supporting_relationship.md).
 - **Agent tools** — [`Tools/`](Tools): one page per tool, named after the tool.
 - **Layout Agents** 
-- **Sim-Ready-Intergation**
+- **Sim-Ready-Intergation** — [`Sim-Ready-intergration/`](Sim-Ready-intergration):
+  [what an asset must carry](Sim-Ready-intergration/meta_data.md),
+  [the room as a MuJoCo scene](Sim-Ready-intergration/Mujoco.md).
 

--- a/scripts/simready/finish_room.sh
+++ b/scripts/simready/finish_room.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# finish_room.sh <scan> — everything after `reconstruct`, without re-authoring.
+#
+# The four rooms in run-simready/ are being rebuilt from freshly generated objects, but their
+# AUTHORING is being reused: the brief that produces `rests_on`/`attached_to`, the small objects
+# and the real luminaires is not on this branch, so re-running the author agent would return a
+# strictly worse room. So the seed room is exported fresh (which is what carries each object's
+# new `sim/` physics sidecar into the Room package) and the authored `Room.py` — plus the
+# materials it fetched — is laid over the top of it.
+#
+#   seed        -> scene_init/scene_stage/room_init/room       (Objects/ + sim/, from the new glbs)
+#   merge       -> realism_authoring/room                      (that, + the authored Room.py)
+#   publish     -> realism_authoring/room_preview/Room.glb + room_layout.json
+#   simulate    -> realism_authoring/mujoco/scene.xml
+set -euo pipefail
+
+SCAN="${1:?usage: finish_room.sh <scan>}"
+ROOT="run-simready"
+PY="${PY:-.venv/bin/python}"
+SCENE="$ROOT/$SCAN"
+AUTHORED="$SCENE/realism_authoring/_authored_room"
+ROOM="$SCENE/realism_authoring/room"
+
+[ -f "$AUTHORED/Room.py" ] || { echo "!! no stashed authored room at $AUTHORED"; exit 1; }
+
+echo "── seed · $SCAN ───────────────────────────────────────────"
+$PY -m litereality_agent stage seed "$SCENE" --output-root "$ROOT" --force
+
+SEED="$SCENE/scene_init/scene_stage/room_init/room"
+[ -f "$SEED/Room.py" ] || { echo "!! seed produced no Room.py"; exit 1; }
+
+echo "── merge · the new objects under the authored room ────────"
+rm -rf "$ROOM"; mkdir -p "$(dirname "$ROOM")"
+cp -a "$SEED" "$ROOM"                      # Objects/ (with sim/), manifest.json, Room.md
+cp -a "$AUTHORED/Room.py" "$ROOM/Room.py"  # the authored shell, fixtures and props
+[ -d "$AUTHORED/materials" ] && cp -a "$AUTHORED/materials" "$ROOM/materials"
+[ -f "$AUTHORED/textures.json" ] && cp -a "$AUTHORED/textures.json" "$ROOM/textures.json"
+echo "   objects: $(ls "$ROOM/Objects"/*/ -d 2>/dev/null | wc -l) dirs, \
+$(ls -d "$ROOM/Objects"/*/*/sim 2>/dev/null | wc -l) with physics; \
+support declarations in Room.py: $(grep -c 'rests_on=\|attached_to=' "$ROOM/Room.py" || true)"
+
+echo "── publish · build the room ───────────────────────────────"
+$PY -m litereality_agent stage publish "$SCENE" --output-root "$ROOT" --compare-frames 0
+
+echo "── simulate · MJCF ────────────────────────────────────────"
+$PY -m litereality_agent stage simulate "$SCENE" --output-root "$ROOT"
+
+echo "── done · $SCAN ───────────────────────────────────────────"
+cat "$SCENE/realism_authoring/mujoco/export_report.json" 2>/dev/null || true

--- a/scripts/simready/render_scene.py
+++ b/scripts/simready/render_scene.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""render_scene.py — look at a room that is actually being simulated.
+
+    <python> render_scene.py <mujoco/scene.xml> --out <dir> [--settle 2.0]
+
+Not a picture of the geometry: the scene is STEPPED first, so what comes out is the room as the
+physics engine holds it rather than as the exporter wrote it. If a shelf is not really under the
+mug, this is where you see the mug on the floor.
+
+Four views, because no single one answers the question:
+
+``eye``        standing in the room at 1.68 m. The only view that says whether it looks like the
+               place. Walls and ceiling are kept, because they are most of what you see.
+``overview``   the same corner, just under the ceiling.
+``dollhouse``  from outside and above, walls and ceiling hidden. Shows the whole plan and every
+               object's footprint at once — the view that shows something standing in mid-air.
+``topdown``    straight down. Best coverage of the floor, and the honest check on layout.
+
+The cutaway is a VIEW, not a change to the model: the walls stay in the scene and keep colliding,
+they are simply not drawn. MuJoCo's default `geomgroup` hides groups 3-5, so the walls (group 1)
+and ceiling (group 0) are turned off explicitly rather than by moving them.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+os.environ.setdefault("MUJOCO_GL", "egl")   # headless: no display on this machine
+
+import mujoco  # noqa: E402
+import numpy as np  # noqa: E402
+
+WIDTH, HEIGHT = 1280, 960
+# What each view hides. The room body's own walls are group 1 and the ceiling slab group 0; the
+# collision geoms are group 3 and are never drawn.
+CUTAWAY = {0, 1}
+VIEWS = (("eye", frozenset()), ("overview", frozenset()),
+         ("dollhouse", frozenset(CUTAWAY)), ("topdown", frozenset({0})))
+
+
+def _pin_room(model, data) -> None:
+    """Hold the room's drive joints at zero.
+
+    The room is a 50 t body on position servos, so with no controls set it sags under its own
+    weight for the first few hundred steps and the whole building drifts down through the render.
+    """
+    for name in ("room_x", "room_y", "room_z", "room_yaw"):
+        joint = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, name)
+        if joint >= 0:
+            data.qpos[model.jnt_qposadr[joint]] = 0.0
+            data.qvel[model.jnt_dofadr[joint]] = 0.0
+
+
+def _ceiling_cut(model, data) -> float:
+    """The height above which a doll's house view should draw nothing.
+
+    Hiding the ceiling SLAB is not enough: the suspended grid, the downlights and the service
+    boxing are authored fixtures in their own right, so they go on being drawn and a plan view
+    ends up looking through a lattice. The exporter puts its `topdown` camera 150 mm under the
+    ceiling, which is the one number in the file that says where the ceiling is.
+    """
+    camera = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_CAMERA, "topdown")
+    if camera >= 0:
+        return float(model.cam_pos[camera][2]) - 0.30
+    return float(np.max(data.geom_xpos[:, 2])) - 0.30 if model.ngeom else 1e9
+
+
+def _geom_floor(model, data, geom: int) -> float:
+    """The lowest point a geom reaches, in world z.
+
+    Not `geom_rbound`, which is the radius of the geom's bounding SPHERE: a suspended ceiling grid
+    is a single wide, flat mesh, so its sphere reaches most of the way to the floor and the geom
+    tests as low-lying however high it hangs. The grid survived the cutaway for exactly that
+    reason. `geom_aabb` is the box, and its eight corners carried through the geom's own rotation
+    are where the thing actually is.
+    """
+    centre = model.geom_aabb[geom][:3]
+    half = model.geom_aabb[geom][3:]
+    corners = np.array([[centre[0] + sx * half[0], centre[1] + sy * half[1], centre[2] + sz * half[2]]
+                        for sx in (-1, 1) for sy in (-1, 1) for sz in (-1, 1)])
+    world = corners @ np.asarray(data.geom_xmat[geom]).reshape(3, 3).T + data.geom_xpos[geom]
+    return float(world[:, 2].min())
+
+
+def render(scene: Path, out: Path, *, settle: float = 2.0, views=VIEWS,
+           hide_above: float | None = None) -> list[Path]:
+    model = mujoco.MjModel.from_xml_path(str(scene))
+    data = mujoco.MjData(model)
+    mujoco.mj_forward(model, data)
+
+    moved = {}
+    if settle > 0:
+        start = data.xpos.copy()
+        for _ in range(int(settle / model.opt.timestep)):
+            _pin_room(model, data)
+            mujoco.mj_step(model, data)
+        moved = {b: float(np.linalg.norm(data.xpos[b] - start[b])) for b in range(1, model.nbody)}
+
+    # Everything at ceiling height, remembered so it can be put back between views. Moving a geom
+    # into a group nothing draws is a change to the VIEW; the geometry stays in the model and goes
+    # on colliding, which is the whole difference between a cutaway and a room with no ceiling.
+    cut = _ceiling_cut(model, data) if hide_above is None else hide_above
+    original = model.geom_group.copy()
+    high = [g for g in range(model.ngeom) if _geom_floor(model, data, g) > cut]
+
+    out.mkdir(parents=True, exist_ok=True)
+    written = []
+    renderer = mujoco.Renderer(model, height=HEIGHT, width=WIDTH)
+    for name, hidden in views:
+        camera = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_CAMERA, name)
+        if camera < 0:
+            continue
+        options = mujoco.MjvOption()
+        mujoco.mjv_defaultOption(options)
+        for group in hidden:
+            options.geomgroup[group] = 0
+        model.geom_group[:] = original
+        if hidden:                       # a cutaway view: lose the ceiling fittings as well
+            for g in high:
+                model.geom_group[g] = 5
+        renderer.update_scene(data, camera=camera, scene_option=options)
+        path = out / f"{name}.png"
+        _save(renderer.render(), path)
+        written.append(path)
+    renderer.close()
+    model.geom_group[:] = original
+
+    if moved:
+        worst = sorted(moved.items(), key=lambda kv: -kv[1])[:5]
+        names = [(mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, b) or "?", v) for b, v in worst]
+        print(f"  settled {settle:.1f}s — worst movers: "
+              + ", ".join(f"{n} {v * 1000:.0f}mm" for n, v in names))
+    return written
+
+
+def _save(pixels, path: Path) -> None:
+    from PIL import Image
+
+    Image.fromarray(pixels).save(path)
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("scene", type=Path)
+    ap.add_argument("--out", type=Path, required=True)
+    ap.add_argument("--settle", type=float, default=2.0,
+                    help="seconds of gravity before rendering (0 shows the export as written)")
+    ap.add_argument("--hide-above", type=float, default=None,
+                    help="cutaway views draw nothing above this z (default: just under the ceiling)")
+    a = ap.parse_args(argv)
+    for path in render(a.scene, a.out, settle=a.settle, hide_above=a.hide_above):
+        print(f"  {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/simready/stability.py
+++ b/scripts/simready/stability.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""stability.py — does this scene blow up? The question a drift number does not answer.
+
+    <python> stability.py <scene.xml> [<scene.xml> ...] [--seconds 30] [--resets 8]
+
+"Total motion over 5 s" says the room settles. It says nothing about whether the SOLVER is healthy,
+and a scene can post a small drift while quietly doing something that will destroy a training run
+the first time an episode resets somewhere slightly different. So this asks the questions a
+simulator actually cares about at initialisation:
+
+``warnings``     MuJoCo's own counters. `BADQACC`, `BADQPOS`, `BADQVEL` are the engine saying it
+                 produced a number it does not believe; `CONTACTFULL` and `CNSTRFULL` mean it
+                 silently DROPPED contacts, so the scene you are stepping is not the scene you
+                 wrote. Any of them non-zero is a failure however good the room looks.
+``qacc``         peak |acceleration| over the run. A room at rest sits near g. Anything in the
+                 thousands is a contact the solver cannot satisfy, and it is the leading indicator
+                 of an ejection — it spikes before anything visibly moves.
+``penetration``  deepest overlap at t=0 and the worst reached while stepping. Overlap at t=0 is
+                 stored energy: the solver reads it as a compressed spring.
+``escape``       anything that leaves the room's own bounding box. This is the "blow up" everyone
+                 means — a body reaching 175 m — and it is worth naming separately because it does
+                 not always show up in a mean.
+``resets``       the same scene re-initialised with each free body nudged, the way an episode reset
+                 would. A scene that is stable only from its one authored pose is not sim-ready;
+                 an RL run will find the poses it is not stable from within an hour.
+
+Exit status is 0 only if every scene passes every check.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+os.environ.setdefault("MUJOCO_GL", "egl")
+
+import mujoco  # noqa: E402
+import numpy as np  # noqa: E402
+
+# A body at rest experiences g. Contact resolution spikes above that legitimately, but a scene
+# that is quietly fighting itself sits orders of magnitude higher — the threshold is deliberately
+# generous so that tripping it means something.
+QACC_LIMIT = 5_000.0
+PENETRATION_LIMIT = 0.010        # m — deeper than this at t=0 is stored energy, not solver slack
+ESCAPE_MARGIN = 1.0              # m outside the room's own bounds counts as having left it
+# Read off the enum rather than written out: the set differs between MuJoCo versions (3.13 has no
+# VGEOMFULL), and a hardcoded list either misses a warning or indexes past the end of the array.
+WARNINGS = [name for _i, name in sorted(
+    (int(getattr(mujoco.mjtWarning, n)), n.removeprefix("mjWARN_"))
+    for n in dir(mujoco.mjtWarning) if n.startswith("mjWARN_"))]
+
+
+def _free_bodies(model):
+    out = {}
+    for b in range(1, model.nbody):
+        for j in range(int(model.body_jntadr[b]), int(model.body_jntadr[b]) + int(model.body_jntnum[b])):
+            if int(model.jnt_type[j]) == int(mujoco.mjtJoint.mjJNT_FREE):
+                out[b] = int(model.jnt_qposadr[j])
+    return out
+
+
+def _pin_room(model, data):
+    for name in ("room_x", "room_y", "room_z", "room_yaw"):
+        j = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, name)
+        if j >= 0:
+            data.qpos[model.jnt_qposadr[j]] = 0.0
+            data.qvel[model.jnt_dofadr[j]] = 0.0
+
+
+def _deepest(data) -> float:
+    return min((float(data.contact[c].dist) for c in range(data.ncon)), default=0.0)
+
+
+def _warnings(model, data) -> dict:
+    return {WARNINGS[i]: int(data.warning[i].number)
+            for i in range(min(len(WARNINGS), len(data.warning)))
+            if data.warning[i].number}
+
+
+def _run(model, data, steps: int, bounds) -> dict:
+    peak_qacc, worst_pen, escaped = 0.0, 0.0, []
+    lo, hi = bounds
+    for _ in range(steps):
+        _pin_room(model, data)
+        mujoco.mj_step(model, data)
+        peak_qacc = max(peak_qacc, float(np.abs(data.qacc).max()))
+        worst_pen = min(worst_pen, _deepest(data))
+        if not np.isfinite(data.qpos).all():
+            escaped.append("NON-FINITE qpos")
+            break
+    for b in range(1, model.nbody):
+        p = data.xpos[b]
+        if np.any(p < lo - ESCAPE_MARGIN) or np.any(p > hi + ESCAPE_MARGIN):
+            escaped.append(mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, b) or f"body{b}")
+    # Read BEFORE the next `mj_resetData`, which clears the counters — otherwise only the last
+    # trial's warnings survive and a scene that blew up on trial 2 reports clean.
+    return {"peak_qacc": peak_qacc, "worst_penetration_mm": worst_pen * 1000, "escaped": escaped,
+            "warnings": _warnings(model, data)}
+
+
+def check(scene: Path, *, seconds: float = 30.0, resets: int = 8, jitter: float = 0.02) -> dict:
+    model = mujoco.MjModel.from_xml_path(str(scene))
+    data = mujoco.MjData(model)
+    mujoco.mj_forward(model, data)
+
+    # The room's own extent, so "escaped" means left the building rather than moved a lot.
+    finite = data.xpos[np.isfinite(data.xpos).all(axis=1)]
+    bounds = (finite.min(axis=0), finite.max(axis=0))
+
+    row: dict = {
+        "scene": str(scene), "bodies": int(model.nbody), "geoms": int(model.ngeom),
+        "contacts_at_rest": int(data.ncon),
+        "initial_penetration_mm": round(_deepest(data) * 1000, 2),
+        "initial_qacc": round(float(np.abs(data.qacc).max()), 1),
+        "nan_at_init": not (np.isfinite(data.qpos).all() and np.isfinite(data.qacc).all()),
+    }
+
+    steps = int(seconds / model.opt.timestep)
+    free = _free_bodies(model)
+    runs = []
+    rng = np.random.default_rng(0)
+    for trial in range(max(1, resets)):
+        mujoco.mj_resetData(model, data)
+        if trial:                       # trial 0 is the authored pose; the rest are episode resets
+            for _b, adr in free.items():
+                data.qpos[adr:adr + 3] += rng.uniform(-jitter, jitter, 3)
+        mujoco.mj_forward(model, data)
+        runs.append(_run(model, data, steps, bounds))
+
+    row["peak_qacc"] = round(max(r["peak_qacc"] for r in runs), 1)
+    row["worst_penetration_mm"] = round(min(r["worst_penetration_mm"] for r in runs), 2)
+    row["escaped"] = sorted({n for r in runs for n in r["escaped"]})
+    merged: dict = {}
+    for r in runs:
+        for name, count in r["warnings"].items():
+            merged[name] = merged.get(name, 0) + count
+    row["warnings"] = merged
+    row["resets"] = len(runs)
+
+    row["failures"] = failures = []
+    if row["nan_at_init"]:
+        failures.append("non-finite state at initialisation")
+    if row["warnings"]:
+        failures.append(f"solver warnings: {', '.join(row['warnings'])}")
+    if row["peak_qacc"] > QACC_LIMIT:
+        failures.append(f"peak |qacc| {row['peak_qacc']:.0f} over {QACC_LIMIT:.0f}")
+    if -row["initial_penetration_mm"] / 1000 > PENETRATION_LIMIT:
+        failures.append(f"starts {-row['initial_penetration_mm']:.0f} mm interpenetrating")
+    if row["escaped"]:
+        failures.append(f"left the room: {', '.join(row['escaped'][:4])}")
+    row["pass"] = not failures
+    return row
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("scenes", nargs="+", type=Path)
+    ap.add_argument("--seconds", type=float, default=30.0)
+    ap.add_argument("--resets", type=int, default=8)
+    ap.add_argument("--json", type=Path)
+    a = ap.parse_args(argv)
+
+    rows = []
+    for scene in a.scenes:
+        row = check(scene, seconds=a.seconds, resets=a.resets)
+        rows.append(row)
+        mark = "PASS" if row["pass"] else "FAIL"
+        print(f"{mark}  {scene.parent.parent.name if scene.parent.name.startswith('mujoco') else scene}")
+        print(f"      init: {row['contacts_at_rest']} contacts, deepest "
+              f"{row['initial_penetration_mm']:.1f} mm, |qacc| {row['initial_qacc']:.1f}")
+        print(f"      {a.seconds:.0f}s x{row['resets']}: peak |qacc| {row['peak_qacc']:.0f}, "
+              f"worst penetration {row['worst_penetration_mm']:.1f} mm, "
+              f"warnings {row['warnings'] or 'none'}, escaped {row['escaped'] or 'none'}")
+        for f in row["failures"]:
+            print(f"      ! {f}")
+    if a.json:
+        a.json.write_text(json.dumps(rows, indent=2))
+    return 0 if all(r["pass"] for r in rows) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/simready/survey.py
+++ b/scripts/simready/survey.py
@@ -19,7 +19,6 @@ os.environ.setdefault("MUJOCO_GL", "egl")
 
 import mujoco  # noqa: E402
 import numpy as np  # noqa: E402
-
 import render_scene  # noqa: E402  — sibling
 
 

--- a/scripts/simready/survey.py
+++ b/scripts/simready/survey.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""survey.py — render every exported room and measure whether it holds still.
+
+    <python> survey.py <scan> [<scan> ...] --root run-simready --out <dir>
+
+One row per room: what the scene is made of, where its physics came from, and what happens over
+5 s of gravity with nothing touching it. The last of those is the only number that says whether a
+room is usable — a scene that renders beautifully and then throws its contents across the floor is
+a picture, not an environment.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+os.environ.setdefault("MUJOCO_GL", "egl")
+
+import mujoco  # noqa: E402
+import numpy as np  # noqa: E402
+
+import render_scene  # noqa: E402  — sibling
+
+
+def _pin(model, data):
+    for name in ("room_x", "room_y", "room_z", "room_yaw"):
+        j = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, name)
+        if j >= 0:
+            data.qpos[model.jnt_qposadr[j]] = 0.0
+            data.qvel[model.jnt_dofadr[j]] = 0.0
+
+
+def measure(scene: Path, seconds: float = 5.0) -> dict:
+    model = mujoco.MjModel.from_xml_path(str(scene))
+    data = mujoco.MjData(model)
+    mujoco.mj_forward(model, data)
+    name = lambda t, i: mujoco.mj_id2name(model, t, i) or "?"       # noqa: E731
+
+    free = [b for b in range(1, model.nbody)
+            if any(model.jnt_type[j] == 0
+                   for j in range(model.body_jntadr[b], model.body_jntadr[b] + model.body_jntnum[b]))]
+    hinges = [j for j in range(model.njnt)
+              if model.jnt_type[j] in (2, 3)
+              and not (name(mujoco.mjtObj.mjOBJ_JOINT, j) or "").startswith("room")]
+    deep = sum(1 for c in range(data.ncon) if data.contact[c].dist < -0.005)
+
+    start = {b: data.xpos[b].copy() for b in free}
+    for _ in range(int(seconds / model.opt.timestep)):
+        _pin(model, data)
+        mujoco.mj_step(model, data)
+    moved = sorted(((float(np.linalg.norm(data.xpos[b] - start[b])),
+                     name(mujoco.mjtObj.mjOBJ_BODY, b)) for b in free), reverse=True)
+
+    return {
+        "bodies": int(model.nbody), "geoms": int(model.ngeom),
+        "free": len(free), "articulated": len(hinges),
+        "joints": [{"name": name(mujoco.mjtObj.mjOBJ_JOINT, j),
+                    "type": "slide" if model.jnt_type[j] == 2 else "hinge",
+                    "range_deg": [round(float(np.degrees(v)), 1) for v in model.jnt_range[j]]}
+                   for j in hinges],
+        "mass_kg": round(float(sum(model.body_mass)) - 50000.0, 1),   # less the room's own ballast
+        "deep_overlaps": deep,
+        "moved_over_10mm": sum(1 for v, _ in moved if v > 0.010),
+        "total_motion_mm": round(sum(v for v, _ in moved) * 1000, 1),
+        "worst": [{"body": n, "mm": round(v * 1000, 1)} for v, n in moved[:5]],
+    }
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("scans", nargs="+")
+    ap.add_argument("--root", default="run-simready")
+    ap.add_argument("--scene-dir", default="realism_authoring/mujoco",
+                    help="where the scene.xml sits under <root>/<scan> "
+                         "(use mujoco_seed for the un-authored room)")
+    ap.add_argument("--out", type=Path, required=True)
+    ap.add_argument("--settle", type=float, default=2.0)
+    a = ap.parse_args(argv)
+
+    a.out.mkdir(parents=True, exist_ok=True)
+    rows = {}
+    for scan in a.scans:
+        scene = Path(a.root) / scan / a.scene_dir / "scene.xml"
+        if not scene.is_file():
+            print(f"  ! {scan}: no scene.xml")
+            continue
+        print(f"── {scan} ──")
+        row = measure(scene)
+        report = scene.parent / "export_report.json"
+        if report.is_file():
+            row["export"] = json.loads(report.read_text())
+        render_scene.render(scene, a.out / scan, settle=a.settle)
+        row["views"] = [p.name for p in sorted((a.out / scan).glob("*.png"))]
+        rows[scan] = row
+        print(f"   {row['bodies']} bodies, {row['free']} free, {row['articulated']} articulated, "
+              f"{row['mass_kg']} kg | 5 s gravity: {row['moved_over_10mm']} moved, "
+              f"{row['total_motion_mm']:.0f} mm")
+    (a.out / "survey.json").write_text(json.dumps(rows, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/litereality_agent/cli.py
+++ b/src/litereality_agent/cli.py
@@ -127,6 +127,7 @@ def _add_author_options(parser: argparse.ArgumentParser) -> None:
 def _simulate_options(args) -> dict:
     return {
         "shake": getattr(args, "shake", False),
+        "from_seed": getattr(args, "from_seed", False),
         "reuse_meshes": getattr(args, "reuse_meshes", False),
         "no_decompose": getattr(args, "no_decompose", False),
     }
@@ -141,6 +142,11 @@ def _add_simulate_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--reuse-meshes", action="store_true",
         help="keep the collider meshes already exported and only rewrite scene.xml",
+    )
+    parser.add_argument(
+        "--from-seed", action="store_true",
+        help="export the room straight out of scene_init instead of the authored one — the shell "
+             "plus the reconstructed objects, with no materials, fixtures or props",
     )
     parser.add_argument(
         "--no-decompose", action="store_true",

--- a/src/litereality_agent/cli.py
+++ b/src/litereality_agent/cli.py
@@ -124,6 +124,31 @@ def _add_author_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--quality-pass", action="store_true")
 
 
+def _simulate_options(args) -> dict:
+    return {
+        "shake": getattr(args, "shake", False),
+        "reuse_meshes": getattr(args, "reuse_meshes", False),
+        "no_decompose": getattr(args, "no_decompose", False),
+    }
+
+
+def _add_simulate_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--shake", action="store_true",
+        help="after exporting, step the scene under a rising ground acceleration and report what "
+             "moved — the measurement that says whether the room's supports are true",
+    )
+    parser.add_argument(
+        "--reuse-meshes", action="store_true",
+        help="keep the collider meshes already exported and only rewrite scene.xml",
+    )
+    parser.add_argument(
+        "--no-decompose", action="store_true",
+        help="skip convex decomposition for objects with no compiled physics — faster, but a "
+             "concave body then collides as its hull (a table becomes a solid block)",
+    )
+
+
 def _add_publish_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--compare-frames", type=int, default=None,
@@ -217,7 +242,8 @@ def _run(args) -> int:
             through=args.through,
             force=set(args.force or ()),
             strict=args.strict,
-            options={"author": _author_options(args), "publish": _publish_options(args)},
+            options={"author": _author_options(args), "publish": _publish_options(args),
+                     "simulate": _simulate_options(args)},
         )
         rc = _print_results(results)
         finished("run finished" if not rc else "run failed")
@@ -238,6 +264,7 @@ def _stage(args) -> int:
                 "skip_image_generation": args.skip_image_generation,
                 **_author_options(args),
                 **_publish_options(args),
+                **_simulate_options(args),
             },
         )
         rc = _print_results([result])
@@ -323,6 +350,7 @@ def _parser() -> argparse.ArgumentParser:
     _add_author_options(run)
     _add_live_options(run)
     _add_publish_options(run)
+    _add_simulate_options(run)
     run.set_defaults(handler=_run)
 
     stage = commands.add_parser("stage", help="run exactly one pipeline stage")
@@ -335,6 +363,7 @@ def _parser() -> argparse.ArgumentParser:
     _add_author_options(stage)
     _add_live_options(stage)
     _add_publish_options(stage)
+    _add_simulate_options(stage)
     stage.set_defaults(handler=_stage)
 
     view = commands.add_parser("view", help="walk a published room in the browser")

--- a/src/litereality_agent/models/object_generation/sim/properties.py
+++ b/src/litereality_agent/models/object_generation/sim/properties.py
@@ -304,6 +304,7 @@ def _part_budget(mass: float) -> int:
 
 
 def _colliders(mesh, name: str, out_dir: Path, mass: float, decompose: bool):
+    """`name` must be unique across every object that shares `out_dir` — see `build_model`."""
     import trimesh
 
     written = []
@@ -432,9 +433,17 @@ def build_model(glb: Path, out_dir: Path, *, category: str = "", decompose: bool
         mass = max(float(mass), MIN_LINK_MASS)
 
         inertia, com, isource = _inertia_from_geometry(local, mass)
-        visual = out_dir / f"{link}_vis.obj"
+        # NAMED FOR THE OBJECT, NOT JUST THE LINK. A recipe-built object gets its own directory, but
+        # a generative one is a bare glb at the top of `reconstruct/` and `sim/` is then SHARED by
+        # every chair in the room. Both chairs have a `base_link`, so `base_link_col0.obj` was
+        # written twice and the second one won: `ChairCluster0.physics.json` recorded eight
+        # colliders whose volumes were its own and whose files held ChairCluster1's geometry. There
+        # is nothing to see in the report — both objects pass their own gate — and the room gets one
+        # chair collided as another.
+        stem = f"{name}_{link}"
+        visual = out_dir / f"{stem}_vis.obj"
         local.export(visual)
-        colliders = _colliders(local, link, out_dir, mass, decompose)
+        colliders = _colliders(local, stem, out_dir, mass, decompose)
 
         links.append(Link(
             name=link, mass=round(mass, 4), com=[round(float(v), 6) for v in com],

--- a/src/litereality_agent/pipeline/simulate/__init__.py
+++ b/src/litereality_agent/pipeline/simulate/__init__.py
@@ -1,0 +1,104 @@
+"""simulate — the finished room as a MuJoCo scene a robot can be trained in.
+
+`publish` ends with a room that renders: one glb, every object baked into it, no notion of what is
+furniture and what is wall, no mass and no joints. That is a picture of a room. Training anything
+in it needs the opposite — a scene of BODIES, each with its own collision geometry, its own mass
+and inertia, and a joint (or deliberately none) saying how it may move.
+
+This stage produces that, and the point of it running LAST is that by now every piece of the answer
+already exists and has been checked:
+
+    Room.py `SHELL`              the walls, openings and heights, metric and exact
+    room_layout.json             every object's pose, category, and what holds it up
+    Room.glb                     the appearance, per named handle
+    Objects/<name>/sim/          the object's OWN physics — mass, inertia, friction, joints and
+                                 convex colliders, compiled at reconstruct time and gated by a
+                                 solver before it was ever placed in a room
+
+Nothing here re-derives what those files already say. That is the whole difference between a scene
+that happens to load in MuJoCo and one that is sim-ready: a room where the mass of a chair, the
+friction of a worktop and the pivot of a door came out of the asset that was built, rather than out
+of a category table consulted at export time.
+
+The shake is optional and off by default. It is a MEASUREMENT, not a build step — it steps the
+scene under a rising ground acceleration and reports what moved — and it costs minutes. A room that
+exports is usable; a room that also survives a shake is one whose supports are true.
+"""
+
+from __future__ import annotations
+
+import json
+
+from litereality_agent.pipeline.context import RunContext
+from litereality_agent.pipeline.result import StageResult, StageStatus
+from litereality_agent.pipeline.support import run_module
+
+
+def scene_dir(context: RunContext):
+    return context.authoring_root / "mujoco"
+
+
+def complete(context: RunContext) -> bool:
+    return (scene_dir(context) / "scene.xml").is_file()
+
+
+def _report(context: RunContext) -> dict:
+    path = scene_dir(context) / "export_report.json"
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:                                        # noqa: BLE001 — no report, no summary
+        return {}
+
+
+def run(context: RunContext, options: dict) -> StageResult:
+    room = context.authored_room
+    if not (room / "Room.py").is_file():
+        return StageResult("simulate", StageStatus.FAILED,
+                           error=f"no authored room at {room} — run `author` first")
+    if not (context.preview_dir / "Room.glb").is_file():
+        return StageResult("simulate", StageStatus.FAILED,
+                           error=f"no built room at {context.preview_dir / 'Room.glb'} — "
+                                 f"run `publish` first")
+
+    argv = ["--room", str(room), "--out", str(scene_dir(context))]
+    # Decomposition is only reached for objects with NO physics sidecar, and it is the slowest
+    # thing in the export by two orders of magnitude. Turning it off makes those objects collide as
+    # their convex hulls — a table becomes a solid block — so it stays on and is opt-out.
+    if options.get("no_decompose"):
+        argv.append("--no-decompose")
+    if options.get("reuse_meshes"):
+        argv.append("--reuse-meshes")
+    rc, log = run_module(context, "litereality_agent.room_ops.export.mujoco_scene", argv,
+                         log_name="simulate_export")
+    if rc or not complete(context):
+        return StageResult("simulate", StageStatus.FAILED,
+                           error=f"MuJoCo export failed; see {log}")
+
+    warnings: list[str] = []
+    report = _report(context)
+    # An object that fell back to the category table is not a failure — every room built before the
+    # sidecars existed did exactly that — but it IS the difference between a scene whose physics
+    # came from its assets and one whose physics was invented here, so it is said out loud.
+    for key, note in (("no_sidecar", "no compiled physics"),
+                      ("unreadable_sidecar", "unreadable physics sidecar"),
+                      ("unplaceable", "physics could not be placed"),
+                      ("placement_rejected", "physics rejected as mis-placed")):
+        names = report.get(key) or []
+        if names:
+            warnings.append(f"{len(names)} object(s) with {note}: {', '.join(map(str, names[:6]))}")
+
+    if options.get("shake"):
+        # The report is the run's stdout, which `run_module` tees into the log. A video is asked
+        # for because a number saying "Chair0 moved 0.42 m" is not reviewable and a clip is.
+        shake_argv = ["--scene", str(scene_dir(context) / "scene.xml"),
+                      "--video", str(scene_dir(context) / "shake.mp4"), "--cutaway"]
+        shake_rc, shake_log = run_module(context, "litereality_agent.room_ops.export.mujoco_shake",
+                                         shake_argv, log_name="simulate_shake")
+        if shake_rc:
+            warnings.append(f"shake exited {shake_rc}; see {shake_log}")
+
+    details = {"scene": str(scene_dir(context) / "scene.xml"),
+               "from_sidecar": len(report.get("from_sidecar") or []),
+               "bodies": {k: report.get(k) for k in ("structure", "free", "attached",
+                                                     "articulated", "colliders")}}
+    return StageResult("simulate", StageStatus.COMPLETED, details=details, warnings=warnings)

--- a/src/litereality_agent/pipeline/simulate/__init__.py
+++ b/src/litereality_agent/pipeline/simulate/__init__.py
@@ -34,16 +34,38 @@ from litereality_agent.pipeline.result import StageResult, StageStatus
 from litereality_agent.pipeline.support import run_module
 
 
-def scene_dir(context: RunContext):
-    return context.authoring_root / "mujoco"
+def scene_dir(context: RunContext, *, seed: bool = False):
+    return context.scene_dir / "mujoco_seed" if seed else context.authoring_root / "mujoco"
+
+
+def source_room(context: RunContext, *, seed: bool = False):
+    """Which room to export.
+
+    The AUTHORED room by default. But authoring and simulation answer different questions, and a
+    room that has not been authored is still a complete physical scene: the shell with its openings
+    cut out, and every reconstructed object in its measured box carrying the mass, friction,
+    colliders and joints its own build compiled. What authoring adds is materials, wall fixtures and
+    the small objects — appearance and clutter — none of which a policy needs to be trained against.
+
+    So `--from-seed` exports the room straight out of `scene_init`, which is the fastest way to get
+    a scan into a simulator and the cleanest test of the objects themselves: nothing in the scene
+    came from anywhere but the reconstruction.
+    """
+    if seed:
+        return context.seed_room, context.seed_room.parent / "room_preview"
+    return context.authored_room, context.preview_dir
 
 
 def complete(context: RunContext) -> bool:
     return (scene_dir(context) / "scene.xml").is_file()
 
 
-def _report(context: RunContext) -> dict:
-    path = scene_dir(context) / "export_report.json"
+def _report_path(context: RunContext, seed: bool):
+    return scene_dir(context, seed=seed) / "export_report.json"
+
+
+def _report(context: RunContext, seed: bool = False) -> dict:
+    path = _report_path(context, seed)
     try:
         return json.loads(path.read_text(encoding="utf-8"))
     except Exception:                                        # noqa: BLE001 — no report, no summary
@@ -51,16 +73,18 @@ def _report(context: RunContext) -> dict:
 
 
 def run(context: RunContext, options: dict) -> StageResult:
-    room = context.authored_room
+    seed = bool(options.get("from_seed"))
+    room, preview = source_room(context, seed=seed)
     if not (room / "Room.py").is_file():
         return StageResult("simulate", StageStatus.FAILED,
-                           error=f"no authored room at {room} — run `author` first")
-    if not (context.preview_dir / "Room.glb").is_file():
+                           error=f"no room at {room} — run "
+                                 f"`{'seed' if seed else 'author'}` first")
+    if not (preview / "Room.glb").is_file():
         return StageResult("simulate", StageStatus.FAILED,
-                           error=f"no built room at {context.preview_dir / 'Room.glb'} — "
-                                 f"run `publish` first")
+                           error=f"no built room at {preview / 'Room.glb'} — "
+                                 f"run `{'seed' if seed else 'publish'}` first")
 
-    argv = ["--room", str(room), "--out", str(scene_dir(context))]
+    argv = ["--room", str(room), "--out", str(scene_dir(context, seed=seed))]
     # Decomposition is only reached for objects with NO physics sidecar, and it is the slowest
     # thing in the export by two orders of magnitude. Turning it off makes those objects collide as
     # their convex hulls — a table becomes a solid block — so it stays on and is opt-out.
@@ -69,13 +93,13 @@ def run(context: RunContext, options: dict) -> StageResult:
     if options.get("reuse_meshes"):
         argv.append("--reuse-meshes")
     rc, log = run_module(context, "litereality_agent.room_ops.export.mujoco_scene", argv,
-                         log_name="simulate_export")
-    if rc or not complete(context):
+                         log_name="simulate_export_seed" if seed else "simulate_export")
+    if rc or not (scene_dir(context, seed=seed) / "scene.xml").is_file():
         return StageResult("simulate", StageStatus.FAILED,
                            error=f"MuJoCo export failed; see {log}")
 
     warnings: list[str] = []
-    report = _report(context)
+    report = _report(context, seed)
     # An object that fell back to the category table is not a failure — every room built before the
     # sidecars existed did exactly that — but it IS the difference between a scene whose physics
     # came from its assets and one whose physics was invented here, so it is said out loud.
@@ -90,14 +114,15 @@ def run(context: RunContext, options: dict) -> StageResult:
     if options.get("shake"):
         # The report is the run's stdout, which `run_module` tees into the log. A video is asked
         # for because a number saying "Chair0 moved 0.42 m" is not reviewable and a clip is.
-        shake_argv = ["--scene", str(scene_dir(context) / "scene.xml"),
-                      "--video", str(scene_dir(context) / "shake.mp4"), "--cutaway"]
+        shake_argv = ["--scene", str(scene_dir(context, seed=seed) / "scene.xml"),
+                      "--video", str(scene_dir(context, seed=seed) / "shake.mp4"), "--cutaway"]
         shake_rc, shake_log = run_module(context, "litereality_agent.room_ops.export.mujoco_shake",
                                          shake_argv, log_name="simulate_shake")
         if shake_rc:
             warnings.append(f"shake exited {shake_rc}; see {shake_log}")
 
-    details = {"scene": str(scene_dir(context) / "scene.xml"),
+    details = {"scene": str(scene_dir(context, seed=seed) / "scene.xml"),
+               "source": "seed" if seed else "authored",
                "from_sidecar": len(report.get("from_sidecar") or []),
                "bodies": {k: report.get(k) for k in ("structure", "free", "attached",
                                                      "articulated", "colliders")}}

--- a/src/litereality_agent/pipeline/stages.py
+++ b/src/litereality_agent/pipeline/stages.py
@@ -1,5 +1,6 @@
 """The supported pipeline, in execution order."""
 
+from litereality_agent.pipeline import simulate
 from litereality_agent.pipeline.realism_authoring import author
 from litereality_agent.pipeline.room_qc import publish
 from litereality_agent.pipeline.scene_init import ingest, reconstruct, seed
@@ -11,6 +12,11 @@ STAGES = (
     Stage("seed", seed.run, ("reconstruct",), is_complete=seed.complete),
     Stage("author", author.run, ("seed",), is_complete=author.complete),
     Stage("publish", publish.run, ("author",), is_complete=publish.complete),
+    # LAST, and not required. Everything it reads — the shell, the layout, the built glb and each
+    # object's own compiled physics — exists by now, and a room that never reaches a simulator is
+    # still a finished room. Making it required would fail a publish over an optional export.
+    Stage("simulate", simulate.run, ("publish",), required=False,
+          is_complete=simulate.complete),
 )
 
 __all__ = ["STAGES"]

--- a/src/litereality_agent/room_ops/README.md
+++ b/src/litereality_agent/room_ops/README.md
@@ -35,7 +35,8 @@ room_ops/
 ├── surfaces.py            Room.py surface discovery
 ├── procedural_materials.py
 ├── viewer.py              self-contained Three.js HTML export
-├── export/                capture/reconstructed assets → editable Room.py
+├── export/                capture/reconstructed assets → editable Room.py,
+│                          and the authored room → MuJoCo (`mujoco_scene`, `mujoco_shake`)
 ├── compile/               Room.py → Room.glb/Room.blend
 └── rendering/             render and reference-view utilities
 ```
@@ -51,8 +52,15 @@ Room/
 ├── manifest.json          object-to-RoomPlan mapping
 └── Objects/
     ├── Procedural/<name>/  object.py, object.md, textures.json
+    │   └── sim/            the object's own physics: mass, inertia, friction,
+    │                       joints and convex colliders (+ URDF)
     └── Static/<name>/      source GLB plus a uniform object.py wrapper
+        └── sim/            the same, for a generated mesh
 ```
+
+The `sim/` sidecar is what makes a Room package a complete statement of the room including how it
+behaves. `export/mujoco_scene.py` reads it rather than re-deriving mass, friction, colliders and
+hinge pivots at export time — see [`doc/Sim-Ready-intergration/Mujoco.md`](../../../doc/Sim-Ready-intergration/Mujoco.md).
 
 Compilation produces regenerable output separately:
 

--- a/src/litereality_agent/room_ops/compile/build_room.py
+++ b/src/litereality_agent/room_ops/compile/build_room.py
@@ -195,7 +195,8 @@ def move_to_collection(obj, coll):
     coll.objects.link(obj)
 
 
-def group_fixture(name, category, parts, parent_coll="Fixtures"):
+def group_fixture(name, category, parts, parent_coll="Fixtures", *,
+                  rests_on=None, attached_to=None):
     """Bundle a wall/ceiling fixture's part-objects (frame bars, radiator fins, pen tray, faceplate,
     louvre slats …) into ONE named, hide-as-a-unit group — the fixture analogue of `_wrap_handle`
     for furniture. It creates an empty handle `name` (carrying room_id/category custom props),
@@ -213,6 +214,17 @@ def group_fixture(name, category, parts, parent_coll="Fixtures"):
     grp["room_id"] = name
     grp["category"] = category
     grp["fixture"] = True
+    # SIMULATION READINESS. A physics engine needs to know what holds what up: a mug rests on a
+    # desk that rests on the floor, a whiteboard is bolted to a wall. Geometry alone cannot say
+    # which — two boxes touching is not the same as one supporting the other, and a prop authored
+    # a millimetre proud of its surface is indistinguishable from one floating. So the author
+    # states it, and it travels with the object into `room_layout.json` where a simulator (or a
+    # QC pass) can read it back. `rests_on` = the surface it stands on; `attached_to` = what it is
+    # fixed to when it is not resting on anything (a wall, a ceiling).
+    if rests_on:
+        grp["rests_on"] = rests_on
+    if attached_to:
+        grp["attached_to"] = attached_to
     coll = get_or_make_collection(name)
     # nest this fixture's own collection under the shared Fixtures parent, so the outliner shows
     # Whiteboard0 / Radiator0 / … as tidy sub-groups rather than every part loose in one bucket.
@@ -959,7 +971,8 @@ class RoomScene:
         return mat
 
     # ---------------------------------------------------------------- index
-    def _register(self, rid, cat, meshes, source=None, handle=None):
+    def _register(self, rid, cat, meshes, source=None, handle=None,
+                  rests_on=None, attached_to=None):
         mn, mx = world_bbox(meshes)
         self.objects[rid] = {
             "id": rid,
@@ -971,6 +984,8 @@ class RoomScene:
             "size": [round(mx[i] - mn[i], 4) for i in range(3)],
             "top_z": round(mx.z, 4),
             "placeable_surface": cat in PLACEABLE_CATS,
+            "rests_on": rests_on,
+            "attached_to": attached_to,
             "source_glb": source,
         }
 
@@ -988,6 +1003,8 @@ class RoomScene:
                     mesh_descendants(o),
                     source=o.get("source_glb"),
                     handle=o.name,
+                    rests_on=o.get("rests_on"),
+                    attached_to=o.get("attached_to"),
                 )
         return self.objects
 

--- a/src/litereality_agent/room_ops/compile/build_room.py
+++ b/src/litereality_agent/room_ops/compile/build_room.py
@@ -274,10 +274,46 @@ def world_bbox(meshes):
 # ============================================================================
 # Assembly primitives (walls / openings / box-fit) — proven geometry
 # ============================================================================
-def thicken_walls(walls, room_center, target=WALL_THICK):
+def _floor_triangles(floors):
+    """World-space XY triangles of the floor plate, for deciding which side of a wall is inside."""
+    tris = []
+    for f in floors:
+        me = f.data
+        for poly in me.polygons:
+            vs = [(f.matrix_world @ me.vertices[i].co).xy for i in poly.vertices]
+            for k in range(1, len(vs) - 1):
+                tris.append((vs[0], vs[k], vs[k + 1]))
+    return tris
+
+
+def _on_floor(pt, tris):
+    for a, b, c in tris:
+        den = (b.y - c.y) * (a.x - c.x) + (c.x - b.x) * (a.y - c.y)
+        if abs(den) < 1e-12:
+            continue
+        u = ((b.y - c.y) * (pt.x - c.x) + (c.x - b.x) * (pt.y - c.y)) / den
+        v = ((c.y - a.y) * (pt.x - c.x) + (a.x - c.x) * (pt.y - c.y)) / den
+        if u >= -1e-6 and v >= -1e-6 and u + v <= 1.0 + 1e-6:
+            return True
+    return False
+
+
+def thicken_walls(walls, room_center, target=WALL_THICK, floor_tris=None):
     """Extrude each wall's OUTER face outward only, keeping the interior face
     where RoomPlan put it. Interior footprint is unchanged -> inside corners stay
-    clean; the added thickness/overlap goes to the outside, out of view."""
+    clean; the added thickness/overlap goes to the outside, out of view.
+
+    Which face is "outer" is decided by the FLOOR PLATE, not by the room centroid. The centroid
+    test is right for a convex room and wrong exactly where it matters: a wall in the concave notch
+    of an L-shaped plan sits on the far side of the centroid from its own interior, so the extrusion
+    goes inward and the wall grows 10 cm into the room. On tea_room that is Wall7 and Wall8, and it
+    swallows whatever is installed against them — the dishwasher the layout pass had just fitted
+    into that corner ends up 2 cm inside the wall, with the pass reporting the room clean because
+    the box it settled IS clear of the wall line it was given.
+
+    `floor_tris` is optional: without it this falls back to the centroid test, so a caller that has
+    no floor polygon behaves as before rather than failing.
+    """
     n = 0
     for o in walls:
         vs = o.data.vertices
@@ -297,7 +333,14 @@ def thicken_walls(walls, room_center, target=WALL_THICK):
         axis_local = Vector((0.0, 0.0, 0.0))
         axis_local[t] = 1.0
         n_world = (M3 @ axis_local).normalized()
-        outward_plus = n_world.dot(o.matrix_world.translation - room_center) >= 0
+        centre = o.matrix_world.translation
+        outward_plus = n_world.dot(centre - room_center) >= 0
+        if floor_tris:
+            probe = max(target, 0.05) * 2.0
+            plus_in = _on_floor((centre + n_world * probe).xy, floor_tris)
+            minus_in = _on_floor((centre - n_world * probe).xy, floor_tris)
+            if plus_in != minus_in:          # one side is the room; grow away from it
+                outward_plus = minus_in
         for v in vs:
             if outward_plus and v.co[t] > mid:
                 v.co[t] += add_local
@@ -505,7 +548,7 @@ class RoomScene:
         room_center = sum((o.matrix_world.translation for o in walls), Vector()) / max(
             len(walls), 1
         )
-        n_thick = thicken_walls(walls, room_center)
+        n_thick = thicken_walls(walls, room_center, floor_tris=_floor_triangles(floors))
         print(f"  thickened {n_thick} walls outward to ~{WALL_THICK} m")
 
         n_cut = sum(cut_opening(op, wall) for op, wall in mapping.items())

--- a/src/litereality_agent/room_ops/export/export_room.py
+++ b/src/litereality_agent/room_ops/export/export_room.py
@@ -92,6 +92,42 @@ than relying on whatever textures and orientation the mesh arrived with.
 """
 
 
+def copy_sim_sidecar(src_dir: Path, dest: Path, name: str) -> int:
+    """Carry one object's compiled physics into the Room package. Returns the files copied.
+
+    `object_generation.sim` leaves a `sim/` directory beside each generated glb holding the object's
+    own mass, inertia, friction, joints and CONVEX COLLIDERS — the statement of what it is
+    physically, already gated by a solver. Without it in here, a Room directory describes how the
+    room LOOKS and nothing about how it behaves, and the MuJoCo export has to re-derive every
+    number from a category table at the last moment.
+
+    Copied FILE BY FILE from the model rather than as a whole directory, because a generative
+    object (a TRELLIS chair) is a bare glb at the top of `reconstruct/` and shares one `sim/` with
+    every other one: copying the directory would put all six chairs' colliders into each chair.
+    """
+    physics = src_dir / f"{name}.physics.json"
+    if not physics.is_file():
+        return 0
+    try:
+        model = json.loads(physics.read_text(encoding="utf-8"))
+    except Exception as exc:                                  # noqa: BLE001 — never fail an export
+        print(f"  ! {name}: unreadable physics sidecar ({exc})")
+        return 0
+    wanted = {physics.name, f"{name}.urdf", f"{name}.sim_check.json"}
+    for link in model.get("links") or []:
+        wanted.update(c["file"] for c in (link.get("colliders") or []))
+        if link.get("visual"):
+            wanted.add(link["visual"])
+    dest.mkdir(parents=True, exist_ok=True)
+    copied = 0
+    for filename in sorted(wanted):
+        source = src_dir / filename
+        if source.is_file():
+            shutil.copy2(source, dest / filename)
+            copied += 1
+    return copied
+
+
 def reset_dir(d: Path):
     if d.exists():
         shutil.rmtree(d)
@@ -375,6 +411,8 @@ def export(scan: str, out_root: Path | None = None) -> Path | None:
                     for bf in bundled:
                         shutil.copy2(tex / bf, d / "textures" / bf)
                     summary["bundled"] = summary.get("bundled", 0) + len(bundled)
+            summary["sim"] = summary.get("sim", 0) + bool(
+                copy_sim_sidecar(src / "sim", d / "sim", name))
             summary["procedural"] += 1
         else:  # static: the glb is the source; generate the uniform object.py / object.md
             d = static_root / name
@@ -397,6 +435,8 @@ def export(scan: str, out_root: Path | None = None) -> Path | None:
             (d / "object.md").write_text(
                 STATIC_OBJECT_MD.replace("__NAME__", name).replace("__CAT__", cat), encoding="utf-8"
             )
+            summary["sim"] = summary.get("sim", 0) + bool(
+                copy_sim_sidecar(glb_src.parent / "sim", d / "sim", name))
             summary["static"] += 1
 
     # 4. Notes for the room
@@ -407,6 +447,8 @@ def export(scan: str, out_root: Path | None = None) -> Path | None:
         f"  Procedural: {summary['procedural']}  (object.py + textures.json recipe; no glb, no texture files)"
     )
     print(f"  Static:     {summary['static']}  (glb + the uniform object.py)")
+    print(f"  Physics:    {summary.get('sim', 0)} objects carry a compiled sim/ sidecar "
+          f"(mass, inertia, friction, joints, convex colliders)")
     print(
         f"  Texture recipes: {summary.get('recipe_imgs', 0)} rebuildable"
         + (f", {summary['bundled']} stored as files" if summary.get("bundled") else ", 0 stored as files")

--- a/src/litereality_agent/room_ops/export/mujoco_replay.py
+++ b/src/litereality_agent/room_ops/export/mujoco_replay.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""mujoco_replay.py — simulate in MuJoCo, then render the result in Blender.
+
+    python -m litereality_agent.room_ops.export.mujoco_replay --room <room dir> \
+        [--amplitude 1.0] [--frames 0,8,36] [--engine CYCLES]
+
+MuJoCo's renderer is OpenGL: diffuse, specular, shadow maps, and nothing else. No bounced light, no
+ambient occlusion, no normal or roughness maps. The authored room has all of those, and its Blender
+render is the one that looks like a photograph — so the useful division is to let each side do what
+it is actually good at:
+
+    MuJoCo   decides where everything ENDS UP        (contacts, friction, hinges, falling)
+    Blender  decides what that LOOKS like            (the authored materials, real light, Cycles)
+
+This is the bridge. It steps the exported scene, records where every body finished, and writes a
+Blender script that rebuilds the authored room from `Room.py` — full materials, real lamps — moves
+each object to its simulated pose, and renders.
+
+MOVEMENT IS APPLIED AS A DELTA, never as an absolute pose. The two worlds agree on the room but not
+on how each object's origin was chosen: MuJoCo bodies sit at the bbox centre the exporter picked,
+Blender objects keep whatever origin the builder gave them. Sending absolute poses would silently
+teleport every object by its own origin offset. A delta — where it moved FROM, to where it moved TO
+— needs no such agreement, and an object the simulation never touched receives exactly nothing.
+
+ARTICULATED PARTS MOVE SEPARATELY FROM THEIR OBJECT. A door that swung 90 degrees is not a door
+that moved; its leaf rotated about a hinge while the frame stayed in the wall. The exporter gives
+each moving part its own body (`Door0_door_leaf`), and its delta is applied to the part's own
+Blender objects — matched by the node names the room builder produced, hex suffix and all — so the
+render shows a door standing open in its frame rather than a whole door lying at an angle.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import numpy as np
+
+
+def _quat_mul(a, b):
+    w1, x1, y1, z1 = a
+    w2, x2, y2, z2 = b
+    return np.array([
+        w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
+        w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
+        w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
+        w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2])
+
+
+def _quat_conj(q):
+    return np.array([q[0], -q[1], -q[2], -q[3]])
+
+
+def simulate(scene: Path, *, settle_s: float = 1.0, shake_s: float = 5.0, calm_s: float = 3.0,
+             amplitude: float = 1.0, frequency: float = 1.5, ajar: float = 0.25) -> dict:
+    """Run the shake and return each body's motion as a delta from where it started."""
+    import mujoco
+
+    from litereality_agent.room_ops.export import mujoco_shake
+
+    model = mujoco.MjModel.from_xml_path(str(scene))
+    data = mujoco.MjData(model)
+    report = mujoco_shake.run(scene, settle_s=settle_s, shake_s=shake_s, calm_s=calm_s,
+                              amplitude=amplitude, frequency=frequency, ajar=ajar)
+
+    # Re-run in-process so the final state is in hand rather than only its summary. Cheap next to
+    # the render that follows, and it keeps `mujoco_shake` a pure reporter.
+    mujoco.mj_forward(model, data)
+    if ajar:
+        for j in range(model.njnt):
+            if int(model.jnt_type[j]) == int(mujoco.mjtJoint.mjJNT_HINGE):
+                lo, hi = model.jnt_range[j]
+                data.qpos[model.jnt_qposadr[j]] = lo + ajar * (hi - lo)
+        mujoco.mj_forward(model, data)
+    start_pos, start_quat = data.xpos.copy(), data.xquat.copy()
+
+    room_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "room")
+    drives = [mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, f"drive_room_{a}")
+              for a in "xyz"]
+    drives = [d for d in drives if d >= 0]
+    amp_m = amplitude / (2.0 * np.pi * frequency) ** 2
+    dt = model.opt.timestep
+    import math
+
+    for name, seconds, shaking in (("settle", settle_s, False), ("shake", shake_s, True),
+                                   ("calm", calm_s, False)):
+        for step in range(int(seconds / dt)):
+            if shaking and drives:
+                t = step * dt
+                for act, value in zip(drives, (
+                        amp_m * math.sin(2 * math.pi * frequency * t),
+                        amp_m * math.sin(2 * math.pi * frequency * 1.41 * t + 1.1),
+                        0.9 * amp_m * math.sin(2 * math.pi * frequency * 1.93 * t + 2.3))):
+                    data.ctrl[act] = value
+            elif drives:
+                for act in drives:
+                    data.ctrl[act] = 0.0
+            mujoco.mj_step(model, data)
+
+    deltas = {}
+    for b in range(model.nbody):
+        name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, b)
+        if not name or b == room_id:
+            continue
+        d_pos = (data.xpos[b] - start_pos[b]).tolist()
+        d_quat = _quat_mul(data.xquat[b], _quat_conj(start_quat[b]))
+        if np.linalg.norm(d_pos) < 1e-4 and abs(abs(d_quat[0]) - 1.0) < 1e-5:
+            continue                                     # untouched: send nothing
+        deltas[name] = {"pos": [round(v, 5) for v in d_pos],
+                        "quat": [round(float(v), 6) for v in d_quat],
+                        "pivot": data.xpos[b].tolist()}
+    return {"report": report, "deltas": deltas}
+
+
+BLENDER_APPLY = r'''
+import bpy, json, math, os, sys
+from mathutils import Vector, Quaternion
+
+sys.path.insert(0, os.environ["RR_MODULE_DIR"])
+from render_room_cameras import build_scene, render_room_from_cameras   # noqa: E402
+
+state = json.load(open(os.environ["RR_STATE"]))
+scene = build_scene(os.environ["RR_SCAN"], os.environ["RR_ASSETS"], os.environ["RR_OUT"])
+
+# SHELL(x, y, z) is Blender's own frame here — `Room.py` builds directly in it — so a MuJoCo delta
+# needs no change of basis, only the right objects to apply it to.
+def targets(name):
+    """Blender objects belonging to one MuJoCo body name."""
+    exact = [o for o in bpy.data.objects if o.get("room_id") == name]
+    if exact:
+        return [o for h in exact for o in ([h] + list(h.children_recursive))]
+    # an articulated part: `Door0_door_leaf` -> the door's `door_leaf*` nodes, hex suffix and all
+    if "_" in name:
+        handle, part = name.split("_", 1)
+        owner = [o for o in bpy.data.objects if o.get("room_id") == handle]
+        pool = [o for h in owner for o in h.children_recursive] or list(bpy.data.objects)
+        return [o for o in pool if o.name == part or o.name.startswith(part + "_")]
+    return []
+
+applied, missed = 0, []
+for name, d in state["deltas"].items():
+    objs = targets(name)
+    if not objs:
+        missed.append(name); continue
+    shift = Vector(d["pos"])
+    rot = Quaternion(d["quat"])
+    pivot = Vector(d["pivot"]) - shift          # where the body was BEFORE it moved
+    for o in objs:
+        if o.parent is not None and o.parent in objs:
+            continue                             # a parent carries its children already
+        o.matrix_world = (
+            __import__("mathutils").Matrix.Translation(shift + pivot)
+            @ rot.to_matrix().to_4x4()
+            @ __import__("mathutils").Matrix.Translation(-pivot)
+            @ o.matrix_world)
+    applied += 1
+
+print(f"[replay] applied {applied} body deltas, {len(missed)} unmatched: {missed[:8]}")
+frames = [int(f) for f in os.environ.get("RR_FRAMES", "").split(",") if f.strip().isdigit()]
+render_room_from_cameras(scene, os.environ["RR_OUT"], frames=frames or None,
+                         res_div=int(os.environ.get("RR_RESDIV", "2")),
+                         engine=os.environ.get("RR_ENGINE", "EEVEE"))
+'''
+
+
+def render(room: Path, state_path: Path, out: Path, *, scan: Path, frames: str = "",
+           engine: str = "EEVEE", res_div: int = 2) -> int:
+    """Rebuild the authored room in Blender, apply the simulated poses, render."""
+    from litereality_agent.room_ops.paths import find_blender
+    from litereality_agent.room_ops.rendering import room_render
+
+    module_dir = Path(room_render.__file__).parent
+    script = out / "_apply_sim_state.py"
+    out.mkdir(parents=True, exist_ok=True)
+    script.write_text(BLENDER_APPLY, encoding="utf-8")
+
+    env = dict(os.environ)
+    env.update({
+        "RR_MODULE_DIR": str(module_dir), "RR_STATE": str(state_path),
+        "RR_SCAN": str(scan), "RR_ASSETS": str(room.parent / "room_preview"),
+        "RR_OUT": str(out), "RR_FRAMES": frames, "RR_ENGINE": engine,
+        "RR_RESDIV": str(res_div), "SB_ROOM_PY": str(room / "Room.py"),
+        "LITEREALITY_ROOM_DIR": str(room),
+    })
+    binary = find_blender()
+    return subprocess.run([binary, "-b", "--python", str(script)], env=env).returncode
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--room", required=True, type=Path, help="room dir holding Room.py")
+    ap.add_argument("--scene", type=Path, default=None, help="MJCF (default <room>/../mujoco/scene.xml)")
+    ap.add_argument("--scan", type=Path, required=True, help="capture dir (frames + poses)")
+    ap.add_argument("--out", type=Path, default=None)
+    ap.add_argument("--amplitude", type=float, default=1.0)
+    ap.add_argument("--frequency", type=float, default=1.5)
+    ap.add_argument("--ajar", type=float, default=0.25)
+    ap.add_argument("--frames", default="", help="capture frames to render, e.g. 4,12,36")
+    ap.add_argument("--engine", default="EEVEE", choices=["EEVEE", "CYCLES"])
+    ap.add_argument("--res-div", type=int, default=2)
+    a = ap.parse_args(argv)
+
+    scene = a.scene or (a.room.parent / "mujoco" / "scene.xml")
+    out = a.out or (a.room.parent / "sim_render")
+    out.mkdir(parents=True, exist_ok=True)
+
+    result = simulate(scene, amplitude=a.amplitude, frequency=a.frequency, ajar=a.ajar)
+    state_path = out / "sim_state.json"
+    state_path.write_text(json.dumps(result, indent=1), encoding="utf-8")
+    print(f"[replay] {len(result['deltas'])} bodies moved -> {state_path}")
+    return render(a.room, state_path, out, scan=a.scan, frames=a.frames,
+                  engine=a.engine, res_div=a.res_div)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/litereality_agent/room_ops/export/mujoco_scene.py
+++ b/src/litereality_agent/room_ops/export/mujoco_scene.py
@@ -1,0 +1,1651 @@
+#!/usr/bin/env python3
+"""mujoco_scene.py — the authored room as an MJCF a physics engine can actually step.
+
+    python -m litereality_agent.room_ops.export.mujoco_scene --room <room dir> [--out <dir>]
+
+`Room.glb` is a picture of a room: one file, every object baked into it, no notion of what is
+furniture and what is wall, no mass, no joints. MuJoCo needs the opposite — a scene of BODIES, each
+with its own collision geometry, its own mass, and a joint (or deliberately none) saying how it may
+move. This turns one into the other, and the information to do it already exists across three
+files that nothing had yet read together:
+
+    Room.py `SHELL`          walls, openings, floor/ceiling heights — exact metric structure
+    room_layout.json         every object's pose, category, and `rests_on` / `attached_to`
+    Room.glb                 the geometry, per named handle
+    Object/<name>.glb        per-object `extras` — the articulation the room glb drops
+
+Four kinds of body, decided from that data rather than by guessing at names:
+
+``structure``   walls, floor and ceiling become static BOXES built from the SHELL numbers, not from
+                the mesh. A box is exact here (a wall IS a box), collides perfectly, and costs one
+                geom instead of a few thousand triangles. Openings are subtracted, so a wall with a
+                door in it becomes jamb / jamb / lintel and the door has somewhere to swing.
+``articulated`` a door or window: the frame is static, and each part carrying `articulation_type`
+                in its glTF extras becomes its own body on a hinge or slide, with the axis and
+                limits the object's build recipe recorded.
+``free``        anything that `rests_on` something — furniture and every authored prop. A free
+                joint, mesh geometry, and mass from its own volume. These are the things that can
+                be pushed, knocked over, and picked up.
+``attached``    anything `attached_to` a wall or ceiling — sockets, trunking, skirting, shelves,
+                the radiator. Static geometry. A socket is not a rigid body that can fall off.
+
+COLLISION IS NOT THE VISUAL MESH. MuJoCo collides a mesh as its CONVEX HULL, and the hull of a
+table is a solid block — chairs tucked under it would be launched on the first step, and a shelf
+would be a filled cupboard. So every concave body is decomposed into convex parts (CoACD) and the
+parts are the colliders, while the original mesh is kept as a visual-only geom. Convex bodies skip
+the decomposition and use the mesh directly.
+
+The support relations the authoring pass recorded are what make the result start at REST rather
+than settling: an object whose `rests_on` surface is already under it does not fall, and one that
+was authored floating would. That is checked and reported rather than silently corrected — a scene
+that needs 200 steps to stop twitching is telling you something true about the room.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import shutil
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from . import sim_assets
+
+STRUCTURE = {"wall", "floor", "ceiling"}
+# Things HUNG on a wall rather than built into it. A socket is part of the building; a picture is
+# an object someone put there on a nail, and in a room that is being shaken hard enough to move the
+# furniture, the pictures are among the first things to come down. Welding them permanently makes
+# the room less true, not more.
+# Only what hangs on a HOOK. A whiteboard, a pinboard and a sign are screwed through into the
+# wall and a room shaking hard enough to drop them has bigger problems; a socket is part of the
+# building's wiring. Those stay fixed. A picture, a mirror, a clock hangs on one nail.
+HANGING = {"framed_photo", "picture", "painting", "artwork", "photo", "poster", "mirror",
+           "clock", "certificate", "frame"}
+# Newtons of pull a hanging survives before its fixing lets go. A picture hook is rated around
+# 5 kg (~50 N) and the ones in a scanned room are rarely new, so this is deliberately modest.
+HANGING_HOLD_N = 22.0
+
+# Mounted on the CEILING. `is_wall_hung` asks about walls and nothing else, so in a room with no
+# declarations at all every downlight and smoke detector became a free body and rained onto the
+# floor — twelve of them in one kitchen, a 2.96 m drop each. A luminaire at ceiling height is
+# fixed to the ceiling for the same reason a socket is fixed to its wall.
+CEILING_MOUNTED = {"ceiling_light", "downlight", "spotlight", "light", "luminaire", "pendant",
+                   "chandelier", "smoke_detector", "detector", "alarm", "sprinkler", "vent",
+                   "extractor", "fan", "speaker", "projector", "ceiling_rose", "diffuser"}
+CEILING_GAP = 0.30       # m below the ceiling and still counted as mounted on it
+
+# BUILDING FABRIC. These are not objects in a room, they are part of its surfaces: a skirting board
+# is nailed to the wall it runs along and a length of trunking is screwed to it. Left free, a 3 m
+# skirting board slides across the floor like a plank.
+FABRIC = {"skirting", "trunking", "conduit", "rail", "cornice", "coving", "dado", "architrave",
+          "socket", "switch", "data_socket", "power_socket", "radiator", "pipe", "boxing",
+          "shelf_standard", "curtain_rail", "picture_rail", "beam"}
+# Materials whose NAME says they are see-through. glTF carries the pane as an ordinary opaque
+# texture — Blender's transmission does not survive the export — so a window arrives as a solid
+# painted panel and the room has no daylight in it. The name is the only surviving evidence that
+# it was glass, and the authoring pass names its materials deliberately (`Glazing`, `Glass_Centre`).
+# `pane` also matches `panel`, and a recessed LED ceiling PANEL is not glazing: keying glassiness
+# on the node name turned all four of Elliott's luminaires 22% transparent and the ceiling started
+# showing the void above it. The lookahead is the whole fix — every other token is unambiguous.
+GLASSY_RE = re.compile(r"glaz|glass|pane(?!l)|window_gl|sash", re.I)
+GLASS_ALPHA = 0.22
+OPENING = {"door", "window", "opening"}
+
+# kg per cubic metre of the object's BOUNDING BOX — not of its mesh. A real object is mostly air:
+# a chair is four thin legs and a thin seat, so its mesh volume is a few litres and material
+# density gave it 1.5 kg. Everything then behaved like cardboard, and the contact solver threw the
+# lightest bodies across the room — Kitchen's chair reached 175 m. Occupancy density is what makes
+# a chair weigh what a chair weighs, and mass is the single biggest lever on whether a scene is
+# stable, because a heavy body absorbs the contact noise that launches a light one.
+# Calibrated against what the things actually weigh: a stacking chair is ~5 kg in a 0.4 m^3 box,
+# a meeting table ~50 kg in 2.7 m^3. The first pass used 45 and 70 and produced 23 kg chairs and
+# 186 kg tables — furniture that a 2 m/s^2 shake cannot move, which is exactly what it looked like.
+DENSITY = {
+    "default": 45.0,
+    "chair": 14.0, "stool": 14.0, "table": 20.0, "desk": 22.0,
+    "storage": 55.0, "cabinet": 55.0, "wardrobe": 50.0, "shelf": 45.0,
+    "bed": 35.0, "sofa": 30.0, "refrigerator": 110.0, "radiator": 160.0,
+    "television": 90.0, "monitor": 110.0, "laptop": 300.0, "keyboard": 250.0,
+    "mug": 250.0, "lidded_mug": 250.0, "travel_cup": 200.0, "vacuum_flask": 300.0,
+    "glass_bottle": 450.0, "coffee_press": 300.0, "rug": 60.0,
+    "papers": 400.0, "notebook": 400.0, "cardboard_box": 60.0, "storage_box": 60.0,
+    "backpack": 90.0, "jacket": 40.0, "cable": 300.0, "keys": 800.0,
+}
+MIN_BODY_MASS = 0.15     # kg — below this MuJoCo throws anything it touches
+
+# A hull this close to its own mesh is already convex enough to collide as itself.
+CONVEX_TOL = 0.06        # 6% volume difference
+DECOMP_MAX_PARTS = 24
+DECOMP_TIMEOUT = 45.0    # seconds per body — see `_decompose`
+# Below this bounding-box diagonal an object is collided as its convex hull, however concave it is.
+# Decomposition exists so a chair can go UNDER a table and a shelf is not a solid cupboard — it is
+# about the space an object encloses, and a trinket encloses nothing anyone will put anything in.
+# Against that it costs stability: CoACD split a 52 g photo frame into 24 convex parts, several of
+# them 4 mm slivers, and two dozen overlapping thin hulls on a near-weightless body give the solver
+# a stack of simultaneous contacts to satisfy at once. That frame was the object launching itself
+# across the room — and worse at LOW shake amplitudes than high ones, which is the signature of a
+# numerical artefact rather than a push.
+MIN_DECOMP_DIAGONAL = 0.30
+# ...and a cap on how finely ANY body is cut. Twenty-four thin hulls on a 1.5 kg chair is a stack of
+# simultaneous contacts for the solver to satisfy at once, and it resolves them by launching it:
+# Kitchen's Chair0 travelled 175 m. Decomposition buys the ability to put a chair UNDER a table —
+# a handful of parts delivers that; two dozen buys nothing and costs stability. The budget scales
+# with mass, because a heavy body absorbs contact noise that throws a light one across the room.
+def _part_budget(mesh, density: float) -> int:
+    try:
+        mass = max(float(mesh.volume) * density, 0.05)
+    except Exception:                                   # noqa: BLE001
+        mass = 1.0
+    if mass < 3.0:
+        return 4
+    if mass < 15.0:
+        return 8
+    return DECOMP_MAX_PARTS
+# RoomPlan measures a wall as a surface, not a solid, and this capture records every one of them as
+# 0.1 mm thick. That is a plane, and it fails twice over: from any raised angle the room renders as
+# an open box with no walls at all, and a light object under a hard impulse can cross 0.1 mm in one
+# 2 ms step and tunnel straight through it. Real partition walls are 75-100 mm, so a wall thinner
+# than this is a measurement artefact rather than a thin wall, and it is given a believable body.
+MIN_WALL_THICKNESS = 0.09
+
+
+def _coacd_worker(vertices, faces, mode, queue, budget=DECOMP_MAX_PARTS):
+    """Run CoACD in a throwaway process, so a hang can be killed rather than waited out."""
+    try:
+        import coacd
+
+        parts = coacd.run_coacd(coacd.Mesh(vertices, faces),
+                                max_convex_hull=budget, preprocess_mode=mode)
+        queue.put([(np.asarray(v).tolist(), np.asarray(f).tolist()) for v, f in parts])
+    except Exception:                                   # noqa: BLE001 — report nothing, not a crash
+        queue.put([])
+
+
+def _decompose(mesh, timeout: float = DECOMP_TIMEOUT, budget: int = DECOMP_MAX_PARTS):
+    """Convex parts for one mesh, or []. Never hangs.
+
+    CoACD does not merely fail on awkward input, it SPINS. `Pinboard0` — a watertight 60-face flat
+    board — ran its search for two hours and twenty minutes with preprocessing off before anyone
+    noticed the export had stopped moving. A near-planar mesh offers no good split and the tree
+    search keeps hunting for one, so there is no exception to catch: only a clock helps. Each body
+    therefore gets its own process and a deadline, and one that misses it falls back to voxelised
+    decomposition and then to its own convex hull. A slightly coarse collider on one board is a
+    fair price for an export that always finishes.
+    """
+    import multiprocessing as mp
+
+    for mode in ("off", "auto"):
+        ctx = mp.get_context("spawn")
+        queue = ctx.Queue()
+        proc = ctx.Process(target=_coacd_worker,
+                           args=(np.asarray(mesh.vertices), np.asarray(mesh.faces), mode,
+                                 queue, budget))
+        proc.start()
+        try:
+            parts = queue.get(timeout=timeout)
+        except Exception:                               # noqa: BLE001 — Empty means it hung
+            parts = []
+        proc.terminate()
+        proc.join(5)
+        if parts:
+            return parts
+    return []
+
+
+def _kelvin_rgb(kelvin: float) -> tuple[float, float, float]:
+    """Colour temperature -> a normalised RGB. 2700 K is orange, 6500 K is white.
+
+    The authoring pass records the temperature it measured from the photographs, and throwing that
+    away makes every room the same neutral white — which is exactly the thing that reads as CG.
+    """
+    t = max(1000.0, min(12000.0, float(kelvin))) / 100.0
+    if t <= 66:
+        r, g = 255.0, 99.4708025861 * math.log(t) - 161.1195681661
+    else:
+        r = 329.698727446 * (t - 60) ** -0.1332047592
+        g = 288.1221695283 * (t - 60) ** -0.0755148492
+    b = 255.0 if t >= 66 else (0.0 if t <= 19 else
+                               138.5177312231 * math.log(t - 10) - 305.0447927307)
+    return tuple(max(0.0, min(1.0, v / 255.0)) for v in (r, g, b))
+
+
+def _in_category(category: str, table) -> bool:
+    """Does this category — a merged run's compound name included — belong to `table`?
+
+    Deliberately a local copy of `scene_init.layout.graph.in_category` rather than an import.
+    `room_ops` is the inner layer: the pipeline may call it, it may not call back, and the
+    architecture test enforces that. Six lines of set membership is a smaller cost than a layer
+    violation, and the two callers want the same thing for the same reason — a box merge names a
+    fused unit after its members (`oven_storage_stove`), so exact-string category tests miss it.
+    """
+    table = set(table)
+    return category in table or bool(
+        {token for token in (category or "").split("_") if token} & table)
+
+
+def _supported_from_below(rec: dict, records: dict, tol: float = 0.06) -> bool:
+    """Is there something directly under this object that could be holding it up?
+
+    Footprints must overlap and the supporter's top must meet this object's underside. Anything
+    else — a shelf two metres away, a table beside it — is not support, and an object with no
+    support and no floor under it is hanging from the structure whether or not anyone said so.
+    """
+    lo = np.asarray(rec["bbox_min"], dtype=float)
+    hi = np.asarray(rec["bbox_max"], dtype=float)
+    for other in records.values():
+        if other is rec:
+            continue
+        # A ceiling is not underneath anything. Its slab's top surface sits a few centimetres above
+        # a downlight's underside, which passed the height test and made the ceiling "support" every
+        # light screwed into it — so the lights stayed free and fell 2.65 m. Walls likewise.
+        if other.get("category") in {"wall", "ceiling"}:
+            continue
+        o_lo = np.asarray(other["bbox_min"], dtype=float)
+        o_hi = np.asarray(other["bbox_max"], dtype=float)
+        if o_hi[2] > float(rec["center"][2]):
+            continue                                     # a supporter is below what it holds up
+        if o_hi[2] < lo[2] - tol or o_hi[2] > lo[2] + tol:
+            continue                                     # its top is not at our underside
+        if o_hi[0] <= lo[0] or o_lo[0] >= hi[0] or o_hi[1] <= lo[1] or o_lo[1] >= hi[1]:
+            continue                                     # footprints do not overlap
+        return True
+    return False
+
+
+def _material_spec(mesh) -> tuple:
+    """A hashable description of one mesh's appearance: ('tex', name) or ('rgba', r, g, b, a).
+
+    glTF's `baseColorFactor` arrives here on 0-255 while MuJoCo wants 0-1, and a factor is present
+    even on meshes that also carry an image — the texture wins when there is one.
+    """
+    visual = getattr(mesh, "visual", None)
+    material = getattr(visual, "material", None)
+    if material is None:
+        return ("rgba", 0.7, 0.7, 0.7, 1.0, "")
+    image = getattr(material, "baseColorTexture", None) or getattr(material, "image", None)
+    uv = getattr(visual, "uv", None)
+    name = getattr(material, "name", None) or ""
+    if image is not None and uv is not None and len(uv):
+        return ("tex", name or f"tex{id(image):x}", image)
+    factor = getattr(material, "baseColorFactor", None)
+    if factor is None:
+        return ("rgba", 0.7, 0.7, 0.7, 1.0, name)
+    values = [float(v) for v in np.asarray(factor, dtype=float).ravel()[:4]]
+    while len(values) < 4:
+        values.append(255.0)
+    scale = 255.0 if max(values) > 1.001 else 1.0
+    return ("rgba", *[round(v / scale, 4) for v in values], name)
+
+
+def _material_groups(meshes_in, prefix: str, out_dir: Path, reuse: bool):
+    """Split a body's parts by appearance and write one OBJ per group.
+
+    Returns [(mesh name, group, spec)]. Grouping by material rather than by source node keeps the
+    geom count down: a chair with 40 parts in two materials becomes two visual geoms, not forty.
+    """
+    from collections import defaultdict
+
+    import trimesh
+
+    # Key on the WHOLE spec, not its first two fields. `spec[:2]` for a colour is ("rgba", red),
+    # so a beige wall and a red book with the same red channel were being merged into one geom and
+    # painted with whichever won — a quiet way for materials to come out wrong with nothing to see
+    # in the logs.
+    buckets: dict[tuple, list] = defaultdict(list)
+    for mesh in meshes_in:
+        spec = _material_spec(mesh)
+        buckets[spec if spec[0] == "rgba" else spec[:2]].append((spec, mesh))
+
+    out = []
+    for index, (_key, items) in enumerate(sorted(buckets.items(), key=lambda kv: str(kv[0]))):
+        spec = items[0][0]
+        group = trimesh.util.concatenate([m for _s, m in items])
+        name = f"{prefix}_v{index}"
+        path = out_dir / f"{name}.obj"
+        if not (reuse and path.is_file()):
+            try:
+                group.export(path, include_texture=(spec[0] == "tex"))
+            except Exception:                           # noqa: BLE001 — UV export is best-effort
+                group.export(path)
+        out.append((name, group, spec))
+    return out
+
+
+def _fill_unobserved(image, threshold: int = 26):
+    """Replace a stitched texture's unseen regions with the colour of the parts that WERE seen.
+
+    A wall texture is a stitch of the capture, and a hand-held scan never sees the top of a wall:
+    `tex_Wall0_Paint.png` is 96% near-black across its upper quarter. Blender hides that because
+    the authored material only samples the observed part, but MuJoCo maps the image straight onto
+    the box and the missing data renders as a black band across every wall — which looks exactly
+    like the walls being cut off half way up, and was diagnosed twice as a lighting fault before
+    anyone looked at the texture. Painting the void the median observed colour is what the room
+    would have been had the scan reached it.
+    """
+    import numpy as np
+    from PIL import Image
+
+    rgb = image.convert("RGB")
+    a = np.asarray(rgb).astype(np.int16)
+    void = a.max(axis=2) < threshold
+    if not void.any() or void.all():
+        return rgb
+    seen = a[~void]
+    if not len(seen):
+        return rgb
+    a[void] = np.median(seen, axis=0).astype(np.int16)
+    return Image.fromarray(a.astype("uint8"), "RGB")
+
+
+def _material_name(asset, spec: tuple, fallback: str, out_dir: Path, reuse: bool,
+                   structural: bool = False, node: str = "") -> str:
+    """Declare (once) the MJCF material for a spec and return its name."""
+    registry = _material_name.__dict__.setdefault("seen", {})
+    # GLAZING IS NAMED BY THE PART, NOT ALWAYS BY THE MATERIAL. Deciding transparency from the
+    # material name alone works only when the author named it: these rooms carry materials called
+    # `Material_0_007` or `tex7f8677eaecb0`, and a window's opening leaves came through as flat
+    # opaque grey panes because nothing in "tex7f8677eaecb0" says glass. The NODE knows —
+    # `Window0_sash_right` is a glazed leaf whatever its material is called. The flag joins the
+    # cache key so the same grey used elsewhere as a solid stays solid.
+    glass_by_node = bool(GLASSY_RE.search(node))
+    key = (id(asset), spec if spec[0] == "rgba" else spec[:2], glass_by_node)
+    if key in registry:
+        return registry[key]
+    if spec[0] == "tex":
+        image = spec[2]
+        safe = "".join(c if c.isalnum() else "_" for c in str(spec[1]))[:40] or "tex"
+        png = out_dir / f"tex_{safe}.png"
+        # A STRUCTURAL texture is always rewritten. Its void-filling is a function of code that has
+        # changed under it: the floors kept 41-61% black caches from before the fill existed, and
+        # `--reuse-meshes` faithfully preserved them. Reuse is only safe for bytes that are a pure
+        # function of the source asset, which a repaired texture is not.
+        if not (reuse and png.is_file() and not structural):
+            try:
+                # Only for walls/floor/ceiling: on an OBJECT a black region is usually a black
+                # object — a monitor screen, a television — and repainting it would be a lie.
+                (_fill_unobserved(image) if structural else image.convert("RGB")).save(png)
+            except Exception:                           # noqa: BLE001 — unreadable image
+                registry[key] = fallback
+                return fallback
+        glassy = glass_by_node or bool(GLASSY_RE.search(str(spec[1])))
+        if glassy and glass_by_node:
+            safe = f"{safe}_glass"[:46]
+        if f"m_{safe}" in {m.get("name") for m in asset.findall("material")}:
+            registry[key] = f"m_{safe}"
+            return registry[key]
+        ET.SubElement(asset, "texture", name=f"t_{safe}", type="2d", file=png.name)
+        ET.SubElement(asset, "material", name=f"m_{safe}", texture=f"t_{safe}",
+                      texuniform="false",
+                      specular="0.6" if glassy else "0.2",
+                      shininess="0.85" if glassy else "0.3",
+                      reflectance="0.25" if glassy else "0",
+                      rgba=f"1 1 1 {GLASS_ALPHA}" if glassy else "1 1 1 1")
+        registry[key] = f"m_{safe}"
+        return registry[key]
+    values = list(spec[1:5])
+    if glass_by_node or bool(GLASSY_RE.search(str(spec[5] if len(spec) > 5 else ""))):
+        values[3] = GLASS_ALPHA
+    rgba = " ".join(f"{v:.4f}" for v in values)
+    safe = "c" + "_".join(f"{int(round(v * 255))}" for v in values)
+    if safe not in {m.get("name") for m in asset.findall("material")}:
+        ET.SubElement(asset, "material", name=safe, rgba=rgba, specular="0.15", shininess="0.25")
+    registry[key] = safe
+    return safe
+
+
+def _load_shell(room: Path) -> dict:
+    src = (room / "Room.py").read_text(encoding="utf-8")
+    i = src.rindex("SHELL = ") + len("SHELL = ")
+    return json.JSONDecoder().raw_decode(src[i:])[0]
+
+
+def _glb_to_shell(mesh):
+    """glTF is Y-up, the SHELL and MuJoCo are Z-up: (x, y, z)_glb -> (x, -z, y)."""
+    m = mesh.copy()
+    t = np.array([[1, 0, 0, 0], [0, 0, -1, 0], [0, 1, 0, 0], [0, 0, 0, 1]], dtype=float)
+    m.apply_transform(t)
+    return m
+
+
+# glTF is Y-up, the SHELL and MuJoCo are Z-up. `A` maps a vector from one to the other and `A_INV`
+# back again; both are needed because an articulation axis is recorded in the object's OWN frame.
+_A = np.array([[1.0, 0.0, 0.0], [0.0, 0.0, -1.0], [0.0, 1.0, 0.0]])
+_A_INV = _A.T
+_A4 = np.eye(4)
+_A4[:3, :3] = _A
+
+
+def _axis_to_world(axis, transform) -> list[float]:
+    """An articulation axis from the object's local frame into the world the scene is built in.
+
+    The recipe records the axis where the object was MODELLED — a drawer slides along its own
+    -Y, a door hinges about its own Z — and the room then places that object with a rotation.
+    Using the recorded axis verbatim as a world axis is only correct for objects that happen to sit
+    square to the world, which in a scanned room is almost none of them: every drawer in a unit
+    against an angled wall slid sideways out of its own carcass, and doors swung about the wrong
+    line. `room_layout.json` does not record yaw, so the object's true orientation has to come from
+    the node's own transform in the room glb.
+
+        world = A . R . A_inv . local        (A: glTF -> SHELL, R: the node's world rotation)
+    """
+    rotation = np.asarray(transform, dtype=float)[:3, :3]
+    world = _A @ rotation @ _A_INV @ np.asarray(axis, dtype=float)
+    norm = float(np.linalg.norm(world))
+    if norm < 1e-9:
+        return [0.0, 0.0, 1.0]
+    return [round(float(v), 6) for v in world / norm]
+
+
+def _bodies_from_glb(glb: Path, handles: set[str]) -> tuple[dict[str, Any], Any]:
+    """Every named handle in the room glb -> its world mesh, in the SHELL frame.
+
+    The loaded SCENE comes back too. It is what `sim_assets.placement_transform` needs to work out
+    where the room put each object, and re-loading a 200 MB glb a second time to get it is minutes
+    of the export spent reading a file that is already open.
+    """
+    from collections import defaultdict
+
+    import networkx as nx
+    import trimesh
+
+    scene = trimesh.load(str(glb))
+    graph = scene.graph.to_networkx()
+    preds = nx.predecessor(graph, scene.graph.base_frame)
+
+    def owner(node: str) -> str | None:
+        cur, seen = node, 0
+        while cur is not None and seen < 64:
+            if cur in handles:
+                return cur
+            parent = preds.get(cur) or []
+            cur = parent[0] if parent else None
+            seen += 1
+        return None
+
+    parts: dict[str, list] = defaultdict(list)
+    for node in scene.graph.nodes_geometry:
+        h = owner(node)
+        if h is None:
+            continue
+        transform, name = scene.graph[node]
+        m = scene.geometry[name].copy()
+        m.apply_transform(transform)
+        # The world mesh is what gets exported; the TRANSFORM is what says which way the object is
+        # actually facing, and an articulation axis is meaningless without it.
+        parts[h].append((node, m, np.asarray(transform, dtype=float)))
+    return parts, scene
+
+
+def _articulation(object_glb: Path) -> dict[str, dict]:
+    """part name -> {type, axis, limit_min, limit_max}, read from the object's glTF extras.
+
+    The per-object exporter runs with `export_extras=True`, so the joint the build recipe declared
+    survives in the file. The ROOM exporter does not, which is why this is read from the object's
+    own glb rather than from `Room.glb` — the room keeps the node NAMES but drops what they mean.
+    """
+    import struct
+
+    if not object_glb.is_file():
+        return {}
+    raw = object_glb.read_bytes()
+    length, _ = struct.unpack_from("<II", raw, 12)
+    gltf = json.loads(raw[20:20 + length].decode("utf-8"))
+    out = {}
+    for node in gltf.get("nodes", []):
+        extras = node.get("extras") or {}
+        if extras.get("articulation_type"):
+            out[node.get("name", "")] = {
+                "type": extras["articulation_type"],
+                "axis": [float(v) for v in extras.get("articulation_axis", (0, 0, 1))],
+                "min": float(extras.get("limit_min", 0.0)),
+                "max": float(extras.get("limit_max", 0.0)),
+            }
+    return out
+
+
+def _convex_parts(mesh, name: str, out_dir: Path, decompose: bool,
+                  reuse: bool = False, density: float = 300.0) -> list[Path]:
+    """Colliders for one body. A convex mesh is its own collider; a concave one is decomposed.
+
+    This is the difference between a table you can put a chair under and a table that is a solid
+    block of wood from floor to top — MuJoCo collides a mesh geom as its convex hull, always.
+    """
+    if reuse:
+        have = sorted(out_dir.glob(f"{name}_col*.obj"))
+        if have:
+            return have
+    written: list[Path] = []
+    try:
+        hull = mesh.convex_hull
+        convex = hull.volume <= 0 or abs(hull.volume - mesh.volume) / max(hull.volume, 1e-9) < CONVEX_TOL
+    except Exception:                                   # noqa: BLE001 — degenerate mesh
+        convex = True
+    try:
+        diagonal = float(np.linalg.norm(mesh.extents))
+    except Exception:                                   # noqa: BLE001
+        diagonal = 1.0
+    if convex or not decompose or diagonal < MIN_DECOMP_DIAGONAL:
+        path = out_dir / f"{name}_col0.obj"
+        mesh.convex_hull.export(path)
+        return [path]
+    # `preprocess_mode="off"` is not an optimisation, it is the difference between a collider and
+    # a slightly larger object. CoACD's default voxel preprocessing remeshes at resolution 50 and
+    # inflates the result by ~32% in volume, lifting a table's top surface 7.4 mm above where the
+    # mesh actually ends. Every object authored to sit EXACTLY on that surface then starts 7 mm
+    # inside it, and MuJoCo resolves the penetration by ejecting it: measured, that threw a chair
+    # 66 cm and knocked a photo frame off a shelf onto the floor. With preprocessing off the
+    # inflation is 1.7% and the top surface is exact — and it runs 3.5x faster. Voxelising is only
+    # needed for meshes CoACD cannot handle directly, so it stays as the fallback.
+    parts = _decompose(mesh, budget=_part_budget(mesh, density))
+    if not parts:
+        path = out_dir / f"{name}_col0.obj"
+        mesh.convex_hull.export(path)
+        return [path]
+    import trimesh
+    for i, (verts, faces) in enumerate(parts):
+        piece = trimesh.Trimesh(np.asarray(verts), np.asarray(faces))
+        if piece.volume <= 1e-9:
+            continue
+        path = out_dir / f"{name}_col{i}.obj"
+        piece.export(path)
+        written.append(path)
+    return written or [out_dir / f"{name}_col0.obj"]
+
+
+def _object_physics(room: Path, rec: dict, room_scene, node_names, placed_mesh, yaw, report: dict):
+    """The physics the OBJECT states about itself, placed where the room put it — or None.
+
+    This is the difference between a room that is sim-ready and one that merely renders. Without
+    it the exporter has to invent every physical number at the last moment from a category table
+    and a bounding box: one friction for the whole building, a mass shared out by nothing, a
+    hinge pivot guessed from the shape of the leaf. The generated object already knows all three,
+    was gated by a solver before it was placed, and carries the answer in a sidecar beside it.
+
+    Returns None — and says why in `report` — whenever the sidecar is missing, unreadable, or
+    cannot be matched to the placed geometry. Each of those is a real condition and none of them
+    should stop the export: the caller falls back to deriving physics from the placed mesh, which
+    is what every room built before this existed already did.
+    """
+    import trimesh
+
+    source = rec.get("source_glb")
+    if not source:
+        return None                     # authored in `Room.py` — it has no object package at all
+    name = Path(source).stem
+    sim_dir = sim_assets.sidecar_dir(room, name)
+    if sim_dir is None:
+        report.setdefault("no_sidecar", []).append(name)
+        return None
+    try:
+        model = sim_assets.load(sim_dir / f"{name}.physics.json")
+    except Exception as exc:                            # noqa: BLE001 — a bad sidecar is not fatal
+        report.setdefault("unreadable_sidecar", []).append(f"{name}: {exc}")
+        return None
+
+    object_glb = room.parent / "room_preview" / "Object" / f"{name}.glb"
+    if not object_glb.is_file():
+        report.setdefault("no_object_glb", []).append(name)
+        return None
+    try:
+        transform = sim_assets.placement_transform(trimesh.load(str(object_glb)), room_scene,
+                                                   node_names)
+    except Exception as exc:                            # noqa: BLE001
+        report.setdefault("unplaceable", []).append(f"{name}: {exc}")
+        return None
+    if transform is None:
+        # NO NODE NAME SURVIVED. An object placed more than once — four chairs from one cluster —
+        # has every node renamed for every instance after the first, and a cluster whose own parts
+        # already repeat has nothing unique inside its own file either. The placement still has a
+        # known shape, so it is recovered from the geometry and the SHELL's yaw instead. Rejecting
+        # here would have left exactly the objects a room has several of collided by guesswork.
+        transform = sim_assets.placement_from_bbox(model, placed_mesh, yaw)
+        if transform is None:
+            report.setdefault("unplaceable", []).append(f"{name}: no node matched the room glb")
+            return None
+        report.setdefault("placed_by_geometry", []).append(name)
+
+    placed = sim_assets.place(model, transform)
+    if not placed.links:
+        report.setdefault("no_colliders", []).append(name)
+        return None
+    # PROVE THE PLACEMENT before trusting it. The transform is derived from ONE node (or from two
+    # bounding boxes), so a room that had moved the object's parts relative to each other would be
+    # silently mis-collided. The colliders are a decomposition of the same geometry the room is
+    # holding, so their union has to land on THE PLACED MESH — not on `room_layout.json`'s bbox for
+    # the handle, which covers everything grouped under it and is 20 cm larger on a table the
+    # author hung nothing on. Comparing against the wrong box rejected a correct placement.
+    world = trimesh.util.concatenate([piece for link in placed.links.values()
+                                      for piece in link.colliders])
+    reference = np.asarray(placed_mesh.bounds, dtype=float)
+    span = float(np.max(reference[1] - reference[0])) or 1.0
+    error = float(np.abs(np.asarray(world.bounds, dtype=float) - reference).max())
+    if error > max(0.05, 0.08 * span):
+        report.setdefault("placement_rejected", []).append(
+            f"{name}: colliders land {error:.3f} m from the placed mesh")
+        return None
+    report.setdefault("from_sidecar", []).append(name)
+    return placed
+
+
+def _wall_segments(wall: dict, openings: list[dict], floor_z: float,
+                   room_centre: np.ndarray | None = None,
+                   room_height: float | None = None) -> list[tuple]:
+    """One wall minus its openings -> the boxes that are left.
+
+    A wall carrying a door is not a box: it is two jambs and a lintel. Emitting it whole gives the
+    room a door-shaped hole in the render and a solid wall in the physics, so the door cannot open
+    and nobody can walk through — the single most obvious way for a "simulation-ready" room to be
+    nothing of the kind.
+    """
+    start = np.asarray(wall["start"], dtype=float)
+    end = np.asarray(wall["end"], dtype=float)
+    delta = end - start
+    length = float(np.linalg.norm(delta))
+    if length < 1e-6:
+        return []
+    along = delta / length
+    yaw = math.atan2(along[1], along[0])
+    measured = float(wall.get("thickness", 0.1))
+    thickness = max(measured, MIN_WALL_THICKNESS)
+    # Thicken AWAY from the room. Growing a 0.1 mm plane symmetrically pushes 4.5 cm of new wall
+    # into the room, swallowing every skirting board, socket and shelf that was flush against it —
+    # measured, that threw the settle drift from 0.9 mm to 2.9 m. The inner face is where the scan
+    # put it and must not move; only the outside is invented.
+    # 2 mm of setback, always. The authored room mounts its wall panels, dados and splashbacks
+    # FLUSH against the wall plane, and a box whose face is exactly on that plane is coplanar with
+    # them — two surfaces at the same depth, which the renderer resolves per-pixel and draws as a
+    # dithered band across the wall. It reads as dirty plaster and survives any amount of shadow
+    # map or anti-aliasing, because it is not a shadow or an edge. Retreating the wall by less than
+    # its own render precision puts every panel unambiguously in front of it.
+    setback = 0.002
+    outward = np.zeros(2)
+    if room_centre is not None:
+        normal = np.array([along[1], -along[0]])
+        mid_wall = (np.asarray(wall["start"], float) + np.asarray(wall["end"], float)) / 2.0
+        sign = 1.0 if float(np.dot(normal, mid_wall - room_centre[:2])) > 0 else -1.0
+        grow = (thickness - measured) / 2.0 if thickness > measured else 0.0
+        outward = normal * sign * (grow + setback)
+    # This capture records no wall height at all, and the old fallback of a flat 2.5 m left every
+    # wall 20 cm short of a 2.707 m ceiling — a room with a gap running round the top of it, which
+    # reads from above as a doll's house with low walls. The room's own floor-to-ceiling distance
+    # is the right default: it is measured, and it is what a wall in that room actually is.
+    height = float(wall.get("height") or 0.0) or float(room_height or 2.5)
+
+    spans = []
+    for o in openings:
+        half = o["width"] / 2.0
+        t0, t1 = o["offset"] - half, o["offset"] + half
+        sill = float(o.get("sill", 0.0))
+        spans.append((max(0.0, t0), min(length, t1), sill, sill + float(o["height"])))
+    spans.sort()
+
+    boxes = []
+
+    def box(t0, t1, z0, z1):
+        if t1 - t0 < 0.02 or z1 - z0 < 0.02:
+            return
+        mid = start + along * ((t0 + t1) / 2.0) + outward
+        boxes.append(((float(mid[0]), float(mid[1]), floor_z + (z0 + z1) / 2.0),
+                      ((t1 - t0) / 2.0, thickness / 2.0, (z1 - z0) / 2.0), yaw))
+
+    cursor = 0.0
+    for t0, t1, z0, z1 in spans:
+        box(cursor, t0, 0.0, height)          # full-height pier before the opening
+        box(t0, t1, 0.0, z0)                  # under the sill (a window's spandrel)
+        box(t0, t1, z1, height)               # the lintel above it
+        cursor = max(cursor, t1)
+    box(cursor, length, 0.0, height)
+    return boxes
+
+
+def _quat_z(yaw: float) -> str:
+    return f"{math.cos(yaw / 2):.6f} 0 0 {math.sin(yaw / 2):.6f}"
+
+
+def export(room: Path, out: Path | None = None, *, decompose: bool = True,
+           reuse_meshes: bool = False) -> Path:
+    """Write `<out>/scene.xml` + `meshes/` from an authored room. Returns the xml path."""
+    import trimesh
+
+    room = Path(room).resolve()
+    preview = room.parent / "room_preview"
+    layout_path = preview / "room_layout.json"
+    glb = preview / "Room.glb"
+    for p in (room / "Room.py", layout_path, glb):
+        if not p.is_file():
+            raise SystemExit(f"missing {p} — build the room first (compile_room)")
+
+    out = Path(out) if out else (room.parent / "mujoco")
+    meshes = out / "meshes"
+    # Decomposing 130 bodies costs ~25 minutes, and every XML-level fix would otherwise pay it
+    # again. The meshes depend only on the room's geometry, so they are reusable across any number
+    # of iterations on the scene structure.
+    if out.exists() and not reuse_meshes:
+        shutil.rmtree(out)
+    meshes.mkdir(parents=True, exist_ok=True)
+
+    _material_name.__dict__.pop("seen", None)   # a fresh registry per export
+    shell = _load_shell(room)
+    floor_z = float(shell.get("floor_z", 0.0))
+    ceiling_z = float(shell.get("ceiling_z", floor_z + 2.5))
+    layout = json.loads(layout_path.read_text(encoding="utf-8"))
+    _bounds = layout.get("bounds") or {}
+    lo = np.asarray(_bounds.get("min") or [-3, -3, floor_z], dtype=float)
+    hi = np.asarray(_bounds.get("max") or [3, 3, ceiling_z], dtype=float)
+    mid = (lo + hi) / 2.0
+    records = {o["handle"]: o for o in layout["objects"]}
+    parts, room_scene = _bodies_from_glb(glb, set(records))
+
+    mujoco = ET.Element("mujoco", model=layout.get("scene", "room"))
+    # `texturedir` as well as `meshdir`: MuJoCo resolves texture files against their OWN search
+    # path, which defaults to the model's directory, so meshes and their textures living together
+    # in one folder is not enough to make them both resolve.
+    ET.SubElement(mujoco, "compiler", angle="radian", meshdir="meshes", texturedir="meshes",
+                  autolimits="true")
+    ET.SubElement(mujoco, "option", timestep="0.002", integrator="implicitfast")
+    # MuJoCo's offscreen framebuffer defaults to 640x480, and a Renderer larger than it raises
+    # rather than downscaling. A room is worth looking at at more than VGA.
+    visual = ET.SubElement(mujoco, "visual")
+    ET.SubElement(visual, "global", offwidth="1280", offheight="960")
+    # MuJoCo has no bounced light, and a cutaway removes the walls that would have bounced it. The
+    # authored lamps then light only what they point at and everything else is black. The headlight
+    # is the stand-in for the light a real room gets from its own surfaces; it is deliberately
+    # strong on ambient and weak on specular so it fills without flattening the authored lamps.
+    # Dimmer than the first attempt: 0.45 ambient washed every authored colour towards white, so
+    # the beige walls and the blue carpet both drifted grey. It is a fill for the light MuJoCo
+    # cannot bounce, not a substitute for the lamps.
+    # Lower than before so the lamps and daylight above actually shape the room. A high ambient
+    # flattens everything to the same brightness, which is the other way a render says "synthetic".
+    ET.SubElement(visual, "headlight", ambient="0.25 0.25 0.263", diffuse="0.18 0.18 0.18",
+                  specular="0.03 0.03 0.03")
+    ET.SubElement(visual, "map", shadowclip="6", shadowscale="0.6")
+    # QUALITY. MuJoCo defaults to a 1024 px shadow map and 4x multisampling, and at 1024 the shadow
+    # map cannot resolve a room: the depth comparison lands between texels and scatters dark
+    # speckles over every wall — the "dirty" mottling on the plaster in every frame so far was
+    # shadow acne, not a texture. 4096 gives roughly 4 cm of shadow resolution across a 5 m room,
+    # and 8x samples clean up the geometry edges that make a render look like a render.
+    ET.SubElement(visual, "quality", shadowsize="4096", offsamples="8",
+                  numslices="28", numstacks="16")
+    default = ET.SubElement(mujoco, "default")
+    # `solref` time constant of 0.004 s is exactly 2x the 0.002 s timestep — the hard floor of what
+    # MuJoCo can integrate, and at that stiffness contacts buzz. The buzz pumps energy in, and
+    # furniture that should not move at all creeps: a chest of drawers slid 62 cm under a 3 m/s^2
+    # shake when breaking its friction needs nearly 9. Five timesteps of compliance costs a
+    # millimetre of penetration and stops the scene inventing motion that no force produced.
+    # 0.9 is a rubber-on-concrete coefficient. Furniture on carpet or vinyl is nearer 0.5, and the
+    # difference decides the whole character of a shake: at 0.9 a 5 kg chair needs 8.8 m/s^2 before
+    # it will move at all, so any shake gentle enough to leave the room standing left every chair
+    # welded to the floor. At 0.55 it starts to slide around 5.4 — a strong tremor, which is what a
+    # shake that visibly moves furniture should be.
+    ET.SubElement(default, "geom", condim="4", friction="0.55 0.03 0.005",
+                  solref="0.01 1", solimp="0.9 0.95 0.001")
+    ET.SubElement(ET.SubElement(default, "default", {"class": "visual"}),
+                  "geom", group="2", contype="0", conaffinity="0", density="0")
+    ET.SubElement(ET.SubElement(default, "default", {"class": "collision"}), "geom", group="3")
+
+    asset = ET.SubElement(mujoco, "asset")
+    world = ET.SubElement(mujoco, "worldbody")
+    # THE ROOM ITSELF IS A BODY. Oscillating gravity shakes the contents while the walls stand
+    # perfectly still, which is not an earthquake — it is a room where physics changed direction.
+    # A mocap body is MuJoCo's kinematically-driven rigid body: infinitely heavy, contacts resolved
+    # normally, position set from outside each step. Driving it moves the walls, the floor and
+    # everything bolted to them together, and the free objects then slide because the FLOOR moved
+    # under them — which is also what finally makes a hung door swing, since its frame is what is
+    # being shaken.
+    # NOT a mocap body. A mocap body is teleported each step, so its children are dragged along
+    # kinematically and never feel the acceleration: the free objects still slide (the floor pushes
+    # them through contact) but a hung door simply travels with its frame and never swings, because
+    # no torque ever reaches the hinge. Three slide joints driven by stiff position servos put the
+    # room's motion INSIDE the dynamics instead, so the frame really accelerates and the leaf
+    # really swings. The mass is set far above the room's contents so nothing inside can shove it.
+    # `gravcomp="1"`: the room is held by position servos, and a servo sags by mg/kp under load —
+    # 50 t on kp=2e7 is 2.45 cm, and the whole room with everything in it sank by exactly that,
+    # reporting a 2.3 cm "settle drift" for every object in the building. Compensating gravity on
+    # the room alone leaves its contents falling normally.
+    room_body = ET.SubElement(world, "body", name="room", pos="0 0 0", gravcomp="1")
+    ET.SubElement(room_body, "inertial", pos="0 0 0", mass="50000", diaginertia="50000 50000 50000")
+    for axis, name in (("1 0 0", "room_x"), ("0 1 0", "room_y"), ("0 0 1", "room_z")):
+        ET.SubElement(room_body, "joint", name=name, type="slide", axis=axis,
+                      limited="false", damping="200")
+    # AND A TWIST. Three sliding axes move every object in the room by the same vector at the same
+    # instant, so the whole contents translate together and only differences in friction separate
+    # them. A real building also rotates about its vertical, and that is what makes the far corner
+    # of a room move further than the middle — the motion objects actually feel is different
+    # depending on where they stand.
+    ET.SubElement(room_body, "joint", name="room_yaw", type="hinge", axis="0 0 1",
+                  limited="false", damping="400")
+
+    synthesised_lights = 0
+    lights = layout.get("lights") or []
+    if not lights:
+        # NO AUTHORED LIGHTING. Only a room whose authoring pass was asked for it records its
+        # luminaires; every earlier room has none, and a single fill lamp lights a patch of floor
+        # and leaves the walls in hard-edged darkness — which reads as holes in the walls rather
+        # than as an unlit room. A plain grid of neutral downlights is not the room's real lighting
+        # and does not pretend to be; it is enough to SEE the room, which is the point of a viewer.
+        span_x, span_y = float(hi[0] - lo[0]), float(hi[1] - lo[1])
+        for ix in (0.3, 0.7):
+            for iy in (0.3, 0.7):
+                lights.append({
+                    "name": f"auto_{ix}_{iy}".replace(".", ""),
+                    "position": [lo[0] + ix * span_x, lo[1] + iy * span_y, ceiling_z - 0.12],
+                    "power_watts": 26.0, "color_temperature_kelvin": 4000})
+        synthesised_lights = len(lights)
+
+    for lamp in lights:
+        pos = lamp.get("position") or [0, 0, 0]
+        rgb = _kelvin_rgb(lamp.get("color_temperature_kelvin") or 4000)
+        # MuJoCo has no photometry: watts only order the lamps by strength. 60 W is taken as full.
+        gain = max(0.25, min(1.0, float(lamp.get("power_watts") or 30.0) / 60.0))
+        # AIM THE CONE SO IT LANDS ON THE FLOOR AND NOT ON A WALL. MuJoCo fits ONE shadow map across
+        # a spot's whole cone, and where that cone meets a surface at a shallow angle the map's depth
+        # comparison starts failing against the very surface it measured — a dithered band up the
+        # wall. It is not fixed by a bigger shadow map (4096, 8192 and 16384 measure identically),
+        # nor by cleaner textures, nor by more anti-aliasing, because none of them touch the cause.
+        # Widening the cone only feeds it: at the 160 degrees this once used, every light grazed
+        # every wall in the room.
+        #
+        # A cone whose footprint stops short of the walls cannot graze one. Its floor radius is
+        # h*tan(theta/2), so asking for a radius equal to the light's own distance from the nearest
+        # wall gives theta = 2*atan(d/h) — which is self-tuning: a lamp in the middle of a small room
+        # opens up, and one close to a wall in a big room closes down, both landing on the floor. The
+        # clamp keeps it a plausible fitting either way, and what the narrower cone stops reaching is
+        # picked up by the directional fills below, which write no shadow map and so cannot band.
+        height = max(0.5, float(pos[2]) - floor_z)
+        to_wall = min(abs(float(pos[0]) - lo[0]), abs(hi[0] - float(pos[0])),
+                      abs(float(pos[1]) - lo[1]), abs(hi[1] - float(pos[1])))
+        # 0.8, not 1.0: a footprint that reaches exactly to the wall still grazes its foot, which is
+        # where the shadow map fails. Stopping the cone short of the skirting is what actually keeps
+        # the wall out of it.
+        cutoff_deg = max(45.0, min(75.0,
+                                   2.0 * math.degrees(math.atan2(0.8 * max(to_wall, 0.2), height))))
+        ET.SubElement(world, "light", name=lamp.get("name", "lamp").replace(" ", "_"),
+                      pos=" ".join(f"{v:.4f}" for v in pos), dir="0 0 -1",
+                      diffuse=" ".join(f"{c * gain:.3f}" for c in rgb),
+                      specular="0.15 0.15 0.15", directional="false",
+                      castshadow="true",
+                      # A MuJoCo light is a SPOT with a 45 degree cone by default, so a ceiling
+                      # panel aimed down lit the floor and left every wall black — the room read as
+                      # furniture floating in a void. A real luminaire in a real room throws light
+                      # at the walls too, and the walls are most of what you look at.
+                      # exponent 0: `exponent=1` tapers towards the cone edge and drew a hard
+                      # diagonal line across every wall. A room lamp does not have an edge, and
+                      # quadratic falloff over 4 m of room only darkens the far wall.
+                      cutoff=f"{cutoff_deg:.1f}", exponent="0", attenuation="1 0 0")
+    # A dim fill INSIDE the room, not above its roof: the first export put a single lamp at z = 3
+    # on a room whose ceiling is at z = 1.1, so the only thing lighting the interior was MuJoCo's
+    # default headlight. It is a fill, not the lighting — the authored lamps above are that.
+    # DIRECTIONAL fill, because a spot cannot light a wall. MuJoCo clamps a spotlight's cutoff to
+    # 90 degrees, so a ceiling lamp aimed down covers a downward hemisphere and every wall top sits
+    # exactly at the cone edge — which rendered as a hard black band across the upper half of every
+    # wall and read as holes in the room. A directional light has no cone and no position: it lights
+    # whatever faces it, walls included. Two of them, from opposite quarters, so no wall is missed.
+    # FOUR fills, one per quarter of the compass. Two left the walls facing away from both in a
+    # black band: a directional light illuminates only surfaces turned towards it, and a room has
+    # walls pointing every way. Four at 90 degrees apart means every wall faces one of them, and
+    # each can then be dim enough not to wash the room flat.
+    for i in range(4):
+        azimuth = math.radians(45 + 90 * i)
+        ET.SubElement(world, "light", name=f"fill_{i}", directional="true",
+                      dir=f"{math.cos(azimuth):.4f} {math.sin(azimuth):.4f} -0.55",
+                      diffuse="0.40 0.40 0.412", specular="0.01 0.01 0.01", castshadow="false")
+    # UPWARD fill. Every other light in the room points down, and a ceiling faces down — so nothing
+    # lit it and it rendered black in every frame. In a real room the ceiling is lit almost entirely
+    # by light bounced up off the floor, which MuJoCo cannot do, so it is supplied directly.
+    ET.SubElement(world, "light", name="bounce", directional="true", dir="0.1 0.1 0.99",
+                  diffuse="0.20 0.20 0.19", specular="0 0 0", castshadow="false")
+
+    # DAYLIGHT, aimed the way the room's own windows face. In every scanned room the windows are
+    # the dominant source and the reason one side of it is bright — a uniform interior fill makes
+    # any room look like a showroom. The direction comes from the wall each window is cut into,
+    # pointing INTO the room, so the light arrives through the glass rather than from nowhere.
+    inward = np.zeros(2)
+    for opening in (shell.get("openings") or {}).values():
+        if opening.get("type") != "window":
+            continue
+        wall = (shell.get("walls") or {}).get(opening.get("wall") or "")
+        if not wall:
+            continue
+        start = np.asarray(wall["start"], dtype=float)
+        end = np.asarray(wall["end"], dtype=float)
+        along = end - start
+        norm = float(np.linalg.norm(along))
+        if norm < 1e-6:
+            continue
+        along /= norm
+        normal = np.array([along[1], -along[0]])
+        centre_wall = (start + end) / 2.0
+        if float(np.dot(normal, mid[:2] - centre_wall)) < 0:
+            normal = -normal                    # always the side the room is on
+        inward += normal
+    if np.linalg.norm(inward) > 1e-6:
+        inward /= np.linalg.norm(inward)
+        ET.SubElement(world, "light", name="daylight", directional="true",
+                      dir=f"{inward[0]:.4f} {inward[1]:.4f} -0.45",
+                      diffuse=" ".join(f"{c:.3f}" for c in
+                                       (v * 0.55 for v in _kelvin_rgb(6500))),
+                      # NO SHADOW from this one. It is a directional light standing in for the sun,
+                      # which means it arrives from outside and above — and the ceiling slab is in
+                      # the way, so it cast a hard horizontal shadow across the top of every wall
+                      # that looked exactly like the walls being cut off half way up. Real daylight
+                      # comes through the window, under the ceiling; a shadowless fill from the
+                      # window's direction is the honest approximation. The lamps below the ceiling
+                      # still cast, so objects keep their shadows.
+                      specular="0.06 0.06 0.06", castshadow="false")
+
+    # Colour by KIND, not by appearance. The exported meshes carry no materials, so an untinted
+    # scene renders as one grey mass in which nothing can be seen to move. Tinting the bodies that
+    # can move against the structure that cannot turns the shake from a grey blur into a readable
+    # result: if anything grey moves, the export is wrong.
+    ET.SubElement(asset, "material", name="mat_free", rgba="0.85 0.55 0.25 1")
+    ET.SubElement(asset, "material", name="mat_fixed", rgba="0.55 0.60 0.68 1")
+    ET.SubElement(asset, "material", name="mat_moving", rgba="0.30 0.65 0.45 1")
+
+    stats = {"structure": 0, "free": 0, "attached": 0, "articulated": 0, "colliders": 0,
+             "skipped": [], "synthesised_lights": synthesised_lights}
+    # A moving part overlaps the thing it moves within — that is what "fits" means, not a defect.
+    excludes: list[tuple[str, str]] = []
+    placed: list[tuple[str, "np.ndarray", "np.ndarray", bool]] = []
+    hangings: list[tuple[str, float]] = []
+
+    # ── structure: exact boxes from the SHELL, with the openings taken out ────
+    by_wall: dict[str, list] = {}
+    for oid, o in (shell.get("openings") or {}).items():
+        by_wall.setdefault(o.get("wall", ""), []).append(o)
+    def structural_material(handle: str, fallback: str) -> str:
+        """The material the room was AUTHORED with, not one invented here.
+
+        Walls and the floor are rebuilt as boxes from the SHELL, and the first version painted them
+        a hardcoded grey and blue. They are the two largest surfaces in any frame, so that one
+        shortcut threw away more of the room's appearance than every prop put together — including
+        the floor's fetched 1024x1024 carpet PBR.
+        """
+        meshes_for = [m for _n, m, _t in (parts.get(handle) or [])]
+        if not meshes_for:
+            return fallback
+        return _material_name(asset, _material_spec(meshes_for[0]), fallback, meshes,
+                              reuse_meshes, structural=True)
+
+    wall_points = [p for w in (shell.get("walls") or {}).values() for p in (w["start"], w["end"])]
+    room_centre = (np.asarray(wall_points, dtype=float).mean(axis=0) if wall_points
+                   else np.zeros(2))
+    for wid, wall in (shell.get("walls") or {}).items():
+        wall_mat = structural_material(wid, "mat_fixed")
+        for i, (pos, size, yaw) in enumerate(_wall_segments(wall, by_wall.get(wid, []), floor_z,
+                                                            room_centre,
+                                                            ceiling_z - floor_z)):
+            ET.SubElement(room_body, "geom", name=f"{wid}_{i}", type="box",
+                          pos=" ".join(f"{v:.4f}" for v in pos),
+                          size=" ".join(f"{v:.4f}" for v in size),
+                          quat=_quat_z(yaw), material=wall_mat, group="1")
+            stats["structure"] += 1
+
+    verts = np.asarray((shell.get("floor") or {}).get("verts") or [], dtype=float)
+    if len(verts):
+        lo, hi = verts[:, :2].min(axis=0), verts[:, :2].max(axis=0)
+        centre = (lo + hi) / 2.0
+        half = np.maximum((hi - lo) / 2.0, 0.05)
+        # The slab sits BELOW `floor_z`, not straddling it. Objects were authored with their
+        # undersides exactly on that plane, so a slab centred on it puts every one of them 5 cm
+        # inside the floor — and MuJoCo resolves that penetration by launching them. The first
+        # export did exactly that: Bag0 travelled 2.09 m before the shake even started.
+        for name, handle, z in (("floor", "Floor0", floor_z - 0.05),
+                                ("ceiling", "Ceiling0", ceiling_z + 0.05)):
+            # Walls in group 1 and the ceiling in group 0, so a renderer can drop either and look
+            # into the room. They stay in the model and keep colliding — a cutaway is a VIEW, and a
+            # room whose walls stop existing when you look at it is not the room being simulated.
+            # NOT group 5: MuJoCo's default `geomgroup` is [1,1,1,1,1,0], so group 5 is invisible
+            # unless a viewer turns it on. Every render came back with the walls missing and no
+            # error to explain it — they were being hidden by a default, not by any flag.
+            # COLLISION ONLY. The floor is a 54-vertex polygon and the room is rotated, so the
+            # axis-aligned box that contains it spills well outside the walls — the carpet ran out
+            # past the building. A box is still the right CONTACT surface (flat, exact, cheap), so
+            # it stays as an invisible collider and the visible floor is the real polygon below.
+            ET.SubElement(room_body, "geom", name=name, type="box",
+                          pos=f"{centre[0]:.4f} {centre[1]:.4f} {z:.4f}",
+                          size=f"{half[0]:.4f} {half[1]:.4f} 0.05",
+                          group="3", rgba="0.5 0.5 0.5 0")
+            # FACE THE ROOM. A ceiling slab exported from Blender keeps the normals it was built
+            # with, which point up and out of the building; seen from inside, every face is a back
+            # face and shades black no matter what light is in the room. The floor has the same
+            # problem upside down. Flipping any surface whose average normal points away from the
+            # room makes it a surface the room can see.
+            surface = []
+            for _n, mesh, _t in (parts.get(handle) or []):
+                converted = _glb_to_shell(mesh)
+                want_up = name == "floor"
+                try:
+                    mean_z = float(np.asarray(converted.face_normals)[:, 2].mean())
+                    if (mean_z < 0) if want_up else (mean_z > 0):
+                        converted.invert()
+                except Exception:                       # noqa: BLE001 — no normals to judge by
+                    pass
+                surface.append(converted)
+            for suffix, _grp, spec in _material_groups(
+                    surface, f"{name}_surface", meshes, reuse_meshes):
+                ET.SubElement(asset, "mesh", name=suffix, file=f"{suffix}.obj", inertia="shell")
+                ET.SubElement(room_body, "geom", {
+                    "class": "visual", "type": "mesh", "mesh": suffix,
+                    # `structural=True`: the floor and ceiling SURFACES come through here, not
+                    # through `structural_material` which the walls use, so they were the one part
+                    # of the shell never getting their unobserved regions filled. A scan sees very
+                    # little of a floor it is standing on — 41% of Airbnb's and 61% of fallside's
+                    # carpet textures were empty — and that void renders as black flooring.
+                    "material": _material_name(asset, spec, "mat_fixed", meshes, reuse_meshes,
+                                               structural=True),
+                    # Group 0, NOT 4. MuJoCo's default geomgroup is [1,1,1,0,0,0]: groups 3, 4 and
+                    # 5 are all off unless a viewer turns them on. The walls were invisible in group
+                    # 5 for the same reason and were moved to 1; the ceiling was left in 4 and went
+                    # on rendering as a black void above the walls through three separate attempts
+                    # to fix it as a lighting and then a normals problem. Only 0, 1 and 2 are drawn.
+                    "group": "0" if name == "ceiling" else "2"})
+            stats["structure"] += 1
+
+    # ── objects ──────────────────────────────────────────────────────────────
+    obj_dir = preview / "Object"
+    # The yaw `build_room` fitted each asset with. `room_layout.json` records a pose but not this,
+    # and without it an object whose node names did not survive the room build cannot be placed.
+    shell_objects = shell.get("objects") or {}
+    for handle, rec in sorted(records.items()):
+        category = rec.get("category", "")
+        if category in STRUCTURE:
+            continue                                    # already emitted as exact boxes
+        pieces = parts.get(handle) or []
+        if not pieces:
+            stats["skipped"].append(handle)
+            continue
+
+        source = rec.get("source_glb")
+        placed_mesh = trimesh.util.concatenate([_glb_to_shell(m) for _n, m, _t in pieces])
+        physics = _object_physics(room, rec, room_scene, [n for n, _m, _t in pieces], placed_mesh,
+                                  math.radians(float(shell_objects.get(handle, {}).get("yaw", 0.0))),
+                                  stats)
+        joints = {}
+        if physics is None and source:
+            # No sidecar to read, so fall back to the raw articulation extras: the four numbers a
+            # build recipe wrote onto the node. They say which parts move and about what axis, and
+            # nothing about mass, friction or where the pivot is.
+            joints = _articulation(obj_dir / Path(source).name)
+
+        centre = np.asarray(rec["center"], dtype=float)
+        # Match a node to its articulated part by PREFIX, not equality. The room builder appends a
+        # hex suffix to any node name it has seen before — the door leaf arrives as
+        # `door_leaf_20cf2a` and `door_leaf_f03ab9`, the window's sashes likewise. Only `Lift_Top`
+        # happened to be unique, so exact matching articulated the desk and silently left the door
+        # and both window sashes welded shut: the joints existed in the source and reached nothing.
+        # One part can also own SEVERAL nodes, so they are grouped rather than overwriting.
+        moving: dict[str, list] = {}
+        fixed = []
+        if physics is not None:
+            by_node = {n: (m, t) for n, m, t in pieces}
+            for link, owned in sim_assets.assign_nodes(list(by_node), physics.model).items():
+                # A link the placement could not give colliders to is welded into the carcass
+                # rather than emitted as a body that would fall through everything it touches.
+                if link == physics.model.root or link not in physics.links:
+                    fixed.extend((n, by_node[n][0]) for n in owned)
+                else:
+                    moving[link] = [by_node[n] for n in owned]
+        else:
+            for node_name, mesh, node_t in pieces:
+                key = None
+                for candidate in joints:
+                    if node_name == candidate or node_name.startswith(candidate + "_"):
+                        if key is None or len(candidate) > len(key):
+                            key = candidate
+                if key is not None:
+                    moving.setdefault(key, []).append((mesh, node_t))
+                else:
+                    fixed.append((node_name, mesh))
+
+        # INFER what the authoring pass did not declare. `attached_to` only exists in rooms
+        # authored to declare it; a room that was not has none, and without it a
+        # wall-mounted television is a free rigid body that falls off the wall on the first step —
+        # measured, MIL-Meeting's `Television0` dropped 95 cm before the shake even started. The
+        # test is the one `scene_init/layout` already uses for the same question: a category that
+        # CAN hang, a bottom clearly off the floor, and a wall actually within reach. All three,
+        # so a cabinet standing in the middle of a room is still a cabinet standing on the floor.
+        hung = None
+        if not rec.get("attached_to") and not rec.get("rests_on"):
+            # NOTHING UNDER IT MEANS SOMETHING HOLDS IT. Enumerating mountable categories was a
+            # losing game — after downlights came alarms, fire blankets and exit signs, and the
+            # next room would bring something else. The general fact is simpler: an object whose
+            # underside is well clear of the floor and has nothing beneath it is not standing, it
+            # is FIXED, whatever it happens to be called. Anything with a surface under it is left
+            # free to stand, fall or be knocked over as normal.
+            bottom = float(rec["center"][2]) - float(rec["size"][2]) / 2.0
+            if _in_category(category, FABRIC):
+                hung = "fabric"                          # part of the building, not an object in it
+            elif bottom - floor_z > 0.30 and not _supported_from_below(rec, records):
+                top = float(rec["center"][2]) + float(rec["size"][2]) / 2.0
+                hung = "ceiling" if ceiling_z - top < CEILING_GAP else "wall"
+            if hung:
+                stats.setdefault("inferred_attached", []).append(f"{handle}->{hung}")
+
+        # A hanging is NOT static: it is a free body held by a weld that the shake can break.
+        hanging = (category in HANGING and (rec.get("attached_to") or hung)
+                   and not moving and category not in OPENING)
+        static = (not hanging and (bool(rec.get("attached_to")) or bool(hung)
+                                   or category in OPENING or bool(moving)))
+        body_attrs = {"name": handle, "pos": " ".join(f"{v:.4f}" for v in centre)}
+        # A free object hangs off the world; anything fixed to the structure hangs off the ROOM, so
+        # it travels with the walls when they move instead of being left behind in mid-air.
+        body = ET.SubElement(world if not static else room_body, "body", **body_attrs)
+        if not static:
+            ET.SubElement(body, "freejoint", name=f"{handle}_free")
+            stats["free"] += 1
+            placed.append((handle, np.asarray(rec["center"], float),
+                           np.asarray(rec["size"], float), bool(hanging)))
+            if hanging:
+                # THE NAIL, not the whole back of the frame. The body origin is the object's own
+                # centre, so its top edge is half its height above that; pulled 10 mm down so the
+                # anchor sits in the frame rather than on its rim. `rec["size"]` is the object's
+                # own extent — NOT the `lo`/`hi` in this scope, which are the room's 2D bounds.
+                nail = np.array([0.0, 0.0, max(float(rec["size"][2]) / 2.0 - 0.01, 0.0)])
+                hangings.append((handle, DENSITY.get(category, DENSITY["default"]), nail))
+        else:
+            placed.append((handle, np.asarray(rec["center"], float),
+                           np.asarray(rec["size"], float), False))
+            if rec.get("attached_to") or hung:
+                stats["attached"] += 1
+
+        tint = "mat_fixed" if static else "mat_free"
+
+        def emit(target, meshes_in, name_prefix, density, material=None, link=None,
+                 origin=None):
+            origin = centre if origin is None else origin
+            shifted = [_glb_to_shell(m) for m in meshes_in]
+            for m in shifted:
+                m.apply_translation(-origin)
+
+            # VISUAL: one geom per MATERIAL, not one per body. MuJoCo binds a single material to a
+            # geom, so merging a chair's fabric and its chrome legs into one mesh forces one colour
+            # onto both — which is why the first export rendered the whole room in flat grey while
+            # `Room.glb` carried a distinct material on all 1206 of its geometries. Splitting costs
+            # extra visual geoms and nothing in physics: they are contype=0.
+            for suffix, group, spec in _material_groups(shifted, name_prefix, meshes, reuse_meshes):
+                mat_name = material or _material_name(asset, spec, tint, meshes, reuse_meshes, node=suffix)
+                # `inertia="shell"` because a VISUAL mesh may legitimately be flat — a monitor's
+                # screen, a poster, a sheet of paper. MuJoCo computes an inertia for every mesh at
+                # compile time, even one that can never collide, and refuses a zero-volume solid.
+                ET.SubElement(asset, "mesh", name=suffix, file=f"{suffix}.obj", inertia="shell")
+                ET.SubElement(target, "geom", {"class": "visual", "type": "mesh",
+                                               "mesh": suffix, "material": mat_name})
+
+            # COLLISION. The object's OWN colliders when it has any: already convex, already
+            # decomposed, already run past a solver on their own before this room existed, and
+            # carrying the friction of the material the recipe chose rather than one number for the
+            # whole building. Appearance splits the visual geoms above; physics does not follow it.
+            if link is not None:
+                for i, piece in enumerate(link.colliders):
+                    body_local = piece.copy()
+                    body_local.apply_translation(-origin)
+                    path = meshes / f"{name_prefix}_c{i}.obj"
+                    if not (reuse_meshes and path.is_file()):
+                        body_local.export(path)
+                    ET.SubElement(asset, "mesh", name=f"{name_prefix}_c{i}", file=path.name)
+                    ET.SubElement(target, "geom", {
+                        "class": "collision", "type": "mesh", "mesh": f"{name_prefix}_c{i}",
+                        # No `density`: the mass is stated on the body from the sidecar, and a
+                        # density here would have MuJoCo compute a second, different one.
+                        "friction": f"{link.friction:.4g} 0.03 0.005"})
+                    stats["colliders"] += 1
+                stats["sidecar_colliders"] = stats.get("sidecar_colliders", 0) + len(link.colliders)
+                return
+
+            combined = trimesh.util.concatenate(shifted)
+            for i, col in enumerate(_convex_parts(combined, name_prefix, meshes, decompose,
+                                                  reuse_meshes, density)):
+                ET.SubElement(asset, "mesh", name=f"{name_prefix}_c{i}", file=col.name)
+                ET.SubElement(target, "geom", {"class": "collision", "type": "mesh",
+                                               "mesh": f"{name_prefix}_c{i}",
+                                               "density": f"{density:.1f}"})
+                stats["colliders"] += 1
+
+        # MASS STATED EXPLICITLY. The object's own figure when it has one — occupancy density over
+        # its bounding box, or a mass the recipe read off a label, split across its links by volume
+        # and re-scaled by however much the room stretched it into its RoomPlan box. Otherwise the
+        # category table, which is what every room built before the sidecars existed still uses.
+        # Leaving MuJoCo to integrate it from the mesh is what produced 1.5 kg chairs and 0.3 kg
+        # signs, and a solver resolves a contact on a body that light by throwing it.
+        root_link = physics.links.get(physics.model.root) if physics is not None else None
+        # STATED WHETHER OR NOT THE BODY CAN MOVE. The mass used to be written only for free
+        # bodies, because everything else got it from a `density` on its collision geoms — and the
+        # sidecar path deliberately writes no density, since the mass is already known. Left
+        # unstated, MuJoCo falls back to its own 1000 kg/m^3 default and a uPVC window frame
+        # compiles at 305 kg. Nothing in the scene is dynamically wrong (a fixed body is welded to
+        # a 50 t room) but every mass anyone reads out of the model is a fiction.
+        if root_link is not None:
+            ET.SubElement(body, "inertial",
+                          pos=" ".join(f"{v:.6f}" for v in (root_link.com - centre)),
+                          mass=f"{max(root_link.mass, MIN_BODY_MASS):.4f}",
+                          fullinertia=" ".join(f"{v:.8g}" for v in root_link.inertia))
+        elif not static:
+            box = np.asarray(rec["size"], dtype=float)
+            mass = max(float(np.prod(box)) * DENSITY.get(category, DENSITY["default"]),
+                       MIN_BODY_MASS)
+            extents = np.maximum(box, 0.02)
+            inertia = mass / 12.0 * np.array([extents[1] ** 2 + extents[2] ** 2,
+                                              extents[0] ** 2 + extents[2] ** 2,
+                                              extents[0] ** 2 + extents[1] ** 2])
+            ET.SubElement(body, "inertial", pos="0 0 0", mass=f"{mass:.4f}",
+                          diaginertia=" ".join(f"{v:.6f}" for v in inertia))
+
+        density = DENSITY.get(category, DENSITY["default"])
+        if fixed:
+            emit(body, [m for _, m in fixed], handle, density, link=root_link)
+
+        # each articulated part becomes its own body, hinged where it meets what holds it
+        for part_name, part_meshes in moving.items():
+            leaf = trimesh.util.concatenate([_glb_to_shell(m) for m, _t in part_meshes])
+            part_link = physics.links.get(part_name) if physics is not None else None
+            joint = physics.joint_for(part_name) if physics is not None else None
+            if joint is not None:
+                # THE PIVOT IS AUTHORED. `object.py` placed this hinge and wrote down where it put
+                # it; the alternative below has to infer it from the shape of the leaf, which is
+                # right for a door with one obvious free edge and wrong for a sash, a lid, a
+                # drawer, or any leaf whose hinged edge is not its nearest one. Reading it is the
+                # single biggest reason to prefer the sidecar over the extras.
+                pivot = physics.pivots[part_name]
+                spec = {"axis": physics.axes[part_name], "type": joint.type,
+                        "min": joint.limit_lower, "max": joint.limit_upper,
+                        "damping": joint.damping, "friction": joint.friction}
+            else:
+                raw = joints[part_name]
+                local_axis = list(raw["axis"])
+                spec = dict(raw, axis=_axis_to_world(local_axis, part_meshes[0][1]),
+                            damping=0.05, friction=0.02)
+                pivot = _hinge_point(leaf, [_glb_to_shell(m) for _, m in fixed], spec,
+                                     local_axis, part_meshes[0][1])
+            child = ET.SubElement(body, "body", name=f"{handle}_{part_name}",
+                                  pos=" ".join(f"{v:.4f}" for v in (pivot - centre)))
+            kind = "slide" if str(spec["type"]).startswith("pris") else "hinge"
+            ET.SubElement(child, "joint", name=f"{handle}_{part_name}", type=kind,
+                          axis=" ".join(f"{v:.4f}" for v in spec["axis"]),
+                          range=f"{spec['min']:.4f} {spec['max']:.4f}",
+                          damping=f"{spec['damping']:.4g}",
+                          frictionloss=f"{spec['friction']:.4g}", armature="0.002")
+            if part_link is not None:
+                ET.SubElement(child, "inertial",
+                              pos=" ".join(f"{v:.6f}" for v in (part_link.com - pivot)),
+                              mass=f"{max(part_link.mass, MIN_BODY_MASS):.4f}",
+                              fullinertia=" ".join(f"{v:.8g}" for v in part_link.inertia))
+            # The cached mesh was written relative to whatever pivot was computed AT THE TIME.
+            # Change how the pivot is derived and `--reuse-meshes` keeps the old geometry while the
+            # body origin moves to the new one — the two no longer cancel and the part is drawn
+            # metres from where it belongs. Kitchen doors were 1.95 m out and it looked like a
+            # physics fault. An articulated part's mesh is a function of its pivot, so it is never
+            # reused: the cost is one small export, the alternative is silent misplacement.
+            leaf.apply_translation(-pivot)
+            for suffix, _grp, vspec in _material_groups([leaf], f"{handle}_{part_name}",
+                                                        meshes, reuse=False):
+                ET.SubElement(asset, "mesh", name=suffix, file=f"{suffix}.obj",
+                              inertia="shell")
+                ET.SubElement(child, "geom", {
+                    "class": "visual", "type": "mesh", "mesh": suffix,
+                    "material": _material_name(asset, vspec, "mat_moving", meshes, reuse_meshes,
+                                               node=suffix)})
+            if part_link is not None:
+                for i, piece in enumerate(part_link.colliders):
+                    local = piece.copy()
+                    local.apply_translation(-pivot)
+                    local.export(meshes / f"{handle}_{part_name}_c{i}.obj")
+                    ET.SubElement(asset, "mesh", name=f"{handle}_{part_name}_c{i}",
+                                  file=f"{handle}_{part_name}_c{i}.obj")
+                    ET.SubElement(child, "geom", {
+                        "class": "collision", "type": "mesh",
+                        "mesh": f"{handle}_{part_name}_c{i}",
+                        "friction": f"{part_link.friction:.4g} 0.03 0.005"})
+                    stats["colliders"] += 1
+                stats["sidecar_colliders"] = (stats.get("sidecar_colliders", 0)
+                                              + len(part_link.colliders))
+            else:
+                for i, col in enumerate(_convex_parts(leaf, f"{handle}_{part_name}", meshes,
+                                                      decompose, False, density)):
+                    ET.SubElement(asset, "mesh", name=f"{handle}_{part_name}_c{i}", file=col.name)
+                    ET.SubElement(child, "geom", {"class": "collision", "type": "mesh",
+                                                  "mesh": f"{handle}_{part_name}_c{i}",
+                                                  "density": f"{density:.1f}"})
+                    stats["colliders"] += 1
+            excludes.append((handle, f"{handle}_{part_name}"))
+            stats["articulated"] += 1
+
+    if hangings:
+        equality = ET.SubElement(mujoco, "equality")
+        for handle, _density, nail in hangings:
+            # A NAIL IS A POINT, NOT A CLAMP. This was a `weld`, which fixes all six degrees of
+            # freedom: the picture could not tilt, could not swing, and simply rode the wall as if
+            # glued to it until the hold broke and it dropped. That is not how anything hangs. A
+            # `connect` constrains POSITION at one point and leaves rotation free, which is exactly
+            # a nail through the frame's top rail — the picture swings and tilts against the wall it
+            # rests on, and the wall contact is what keeps it flat rather than the constraint.
+            # `solimp`'s low upper bound keeps the hold soft, so it rattles on its nail before it
+            # goes rather than being rigid right up to the instant it is not.
+            ET.SubElement(equality, "connect", name=f"hang_{handle}", body1=handle, body2="room",
+                          anchor=" ".join(f"{v:.4f}" for v in nail),
+                          solref="0.02 1", solimp="0.85 0.92 0.001")
+        stats["hangings"] = [h for h, _d, _n in hangings]
+
+    actuator = ET.SubElement(mujoco, "actuator")
+    for name in ("room_x", "room_y", "room_z"):
+        # CRITICALLY DAMPED, AND STIFF ENOUGH TO STAY OUT OF THE WAY. The room is a 50 t body on a
+        # position servo, which is a mass-spring: kp=2e7 put its natural frequency at 3.18 Hz and
+        # kv=2e5 left it at a damping ratio of 0.10. The vertical drive runs at 1.93x the base
+        # frequency — 3.09 Hz — a ratio of 0.97 to that resonance, so the room bounced about five
+        # times harder than commanded. Everything in it was repeatedly unweighted until friction
+        # could not hold, then slammed down: chests slid 62 cm and chairs toppled under a shake far
+        # too gentle to do either. kp=5e7 moves the resonance to 5.0 Hz — clear of the 3.09 Hz
+        # drive without being so stiff that the integrator cannot follow it, which at 2e8 threw a
+        # kitchen 172 m. kv = 2*sqrt(kp*m) damps it critically so it tracks without ringing.
+        ET.SubElement(actuator, "position", name=f"drive_{name}", joint=name,
+                      kp="5e7", kv="3.16e6")
+
+    # A PICTURE DOES NOT FIGHT THE RAIL IT HANGS BESIDE. These frames are attached to WALLS, but
+    # they are authored overlapping separate `PictureRail` fixtures at the same height — Picture1
+    # starts 23.6 mm inside PictureRail4. The rail shoves it out, the nail holds it back, and the
+    # hook carries 69x the frame's own weight before the room has moved at all, which tears it off a
+    # wall that is standing still. The overlap cannot be simulated away, and nudging the frame clear
+    # only violates the `connect` anchor — which is fixed at compile time — so MuJoCo drags it back.
+    # The pair simply does not collide. Contact with the ROOM is deliberately kept: the wall is what
+    # a picture rests flat against, and losing that would let it swing through the plaster.
+    for _handle, _centre, _size, _is_hanging in placed:
+        if not _is_hanging:
+            continue
+        lo_h, hi_h = _centre - _size / 2.0, _centre + _size / 2.0
+        for _other, _c2, _s2, _other_hanging in placed:
+            if _other == _handle or _other_hanging:
+                continue
+            lo_o, hi_o = _c2 - _s2 / 2.0, _c2 + _s2 / 2.0
+            if bool(np.all(hi_h >= lo_o - 0.005)) and bool(np.all(hi_o >= lo_h - 0.005)):
+                excludes.append((_handle, _other))
+
+    if excludes:
+        contact = ET.SubElement(mujoco, "contact")
+        for a, b in excludes:
+            ET.SubElement(contact, "exclude", body1=a, body2=b)
+
+    # The capture cameras, as MuJoCo cameras. Rendering the simulation from the SAME viewpoint the
+    # room was photographed from is what makes a physics result comparable to the scan rather than
+    # merely pretty — and MuJoCo's default free camera, aimed at the origin of a room whose floor
+    # sits at z = -1.6, renders black.
+    # STRAIGHT DOWN, from just under the ceiling. Above the ceiling would be simpler and would
+    # see nothing but the ceiling slab, which is solid geometry like any other. The vertical field
+    # of view is computed from the room rather than guessed: at 2.7 m the default 45 degrees covers
+    # 2.2 m of a 4.9 m room, so a fixed value either crops the room or is wrong for the next one.
+    span = float(max(hi[0] - lo[0], hi[1] - lo[1]))
+    height = max(float(ceiling_z - floor_z) - 0.15, 0.5)
+    fovy = min(150.0, 2.0 * math.degrees(math.atan((span / 2.0) / height)) + 8.0)
+    ET.SubElement(world, "camera", name="topdown",
+                  pos=f"{mid[0]:.4f} {mid[1]:.4f} {ceiling_z - 0.15:.4f}",
+                  xyaxes="1 0 0 0 1 0", fovy=f"{fovy:.1f}")
+
+    # DOLLHOUSE: outside the room and well above it, looking down into it at roughly 50 degrees.
+    # Useless on its own — it sees the backs of the walls — and the intended view once groups 4 and
+    # 5 are hidden. Top-down gives the best coverage of the FLOOR; this gives the best coverage of
+    # the room, because objects have height and a plan view foreshortens all of it away.
+    diag = float(np.linalg.norm(hi[:2] - lo[:2]))
+    eye = np.array([mid[0] + 0.55 * diag, mid[1] - 0.55 * diag, ceiling_z + 0.85 * diag])
+    fwd = np.array([mid[0], mid[1], floor_z + 0.35 * (ceiling_z - floor_z)]) - eye
+    fwd /= max(float(np.linalg.norm(fwd)), 1e-9)
+    right = np.cross(fwd, np.array([0.0, 0.0, 1.0]))
+    right /= max(float(np.linalg.norm(right)), 1e-9)
+    ET.SubElement(world, "camera", name="dollhouse",
+                  pos=" ".join(f"{v:.4f}" for v in eye),
+                  xyaxes=" ".join(f"{v:.4f}" for v in list(right) + list(np.cross(right, fwd))),
+                  fovy=f"{min(120.0, 2.0 * math.degrees(math.atan((diag * 0.52) / float(np.linalg.norm(eye - mid)))) ):.1f}")
+
+    # EYE LEVEL, standing in a corner. A room photographed from 1.6 m reads as a room: the walls
+    # rise past the frame, the floor recedes, and nothing has to be hidden to see in. The raised
+    # views above are for watching everything at once; this is for judging whether it looks right.
+    # Placed from the FLOOR POLYGON, not the bounding box. A bbox corner is only inside the room
+    # when the room is a rectangle; on MIL-Meeting's angled plan the corner of the box sits inside a
+    # wall, and the camera rendered a solid grey slab. Standing back from the centroid towards the
+    # most distant floor vertex keeps the viewpoint on the floor that actually exists.
+    plate = np.asarray((shell.get("floor") or {}).get("verts") or [], dtype=float)
+    if len(plate) >= 3:
+        centroid = plate[:, :2].mean(axis=0)
+        # AND STANDING SOMEWHERE EMPTY. Retreating to the furthest floor corner put the camera
+        # 3.8 cm from the bed in Airbnb-Cam — effectively standing on it — and the view filled with
+        # a duvet seen from within, which reads as a bed flying through the air. The simulation was
+        # correct the whole time: nothing in that room ever rose more than 70 cm. So every candidate
+        # is scored against the furniture it would be standing in, and the clearest wins.
+        standing = [(np.asarray(o["bbox_min"], float)[:2], np.asarray(o["bbox_max"], float)[:2])
+                    for o in records.values()
+                    if o.get("category") not in STRUCTURE
+                    and float(o["bbox_max"][2]) - floor_z > 0.35]
+        segments = [(np.asarray(w["start"], float), np.asarray(w["end"], float))
+                    for w in (shell.get("walls") or {}).values()]
+
+        def _room_clearance(point):
+            """Distance to the nearest thing the camera could be standing in — WALLS INCLUDED.
+
+            Scoring against furniture alone put the camera 5 cm from a wall in the kitchen, with a
+            cabinet slab filling the frame: it was 0.63 m from the nearest object and inside the
+            wall behind it. A viewpoint has to be clear of the room as well as of its contents.
+            """
+            gaps = [float(np.linalg.norm(point - np.clip(point, f_lo, f_hi)))
+                    for f_lo, f_hi in standing]
+            for a, b in segments:
+                span = b - a
+                length2 = float(span @ span)
+                t = 0.0 if length2 < 1e-9 else float(np.clip((point - a) @ span / length2, 0.0, 1.0))
+                gaps.append(float(np.linalg.norm(point - (a + t * span))))
+            return min(gaps) if gaps else 9.9
+
+        def _view_depth(point):
+            """How far the camera can SEE towards the middle before something blocks it.
+
+            Clearance alone asks only how much room the camera has to stand in, and answers the
+            wrong question: a spot with a metre of space in every direction still scores well with a
+            2.5 m wall exactly a metre in front of it, and the render is then a grey slab with a
+            room somewhere behind it. What matters is the distance along the direction the camera
+            actually looks.
+            """
+            ray = centroid - point
+            reach = float(np.linalg.norm(ray))
+            if reach < 1e-6:
+                return 0.0
+            ray = ray / reach
+            nearest = reach
+            for f_lo, f_hi in standing:
+                # slab test against the footprint, in the plane
+                t0, t1 = 0.0, nearest
+                for axis in (0, 1):
+                    if abs(ray[axis]) < 1e-9:
+                        if not (f_lo[axis] <= point[axis] <= f_hi[axis]):
+                            t0 = nearest + 1.0
+                        continue
+                    ta = (f_lo[axis] - point[axis]) / ray[axis]
+                    tb = (f_hi[axis] - point[axis]) / ray[axis]
+                    t0, t1 = max(t0, min(ta, tb)), min(t1, max(ta, tb))
+                if t0 <= t1 and t0 > 0.05:
+                    nearest = min(nearest, t0)
+            return nearest
+
+        scored = []
+        for vertex in plate[:, :2]:
+            for pull in (0.30, 0.45, 0.60, 0.72, 0.84):
+                candidate = centroid + pull * (vertex - centroid)
+                gap = _room_clearance(candidate)
+                # Prefer standing back towards the edge, but never at the cost of clearance: a
+                # metre of space is worth more than another half metre of setback — and never at
+                # the cost of being able to see, which the view depth below is what enforces.
+                scored.append((min(gap, 1.2) + 0.15 * pull + 0.45 * min(_view_depth(candidate), 3.0),
+                               candidate))
+        scored.sort(key=lambda sc: -sc[0])
+        eye_xy = scored[0][1] if scored else centroid
+    else:
+        centroid = mid[:2]
+        eye_xy = np.array([lo[0] + 0.12 * (hi[0] - lo[0]), lo[1] + 0.12 * (hi[1] - lo[1])])
+    stand = np.array([eye_xy[0], eye_xy[1], floor_z + 1.68])
+    look = np.array([centroid[0], centroid[1], floor_z + 1.05])
+    fwd = look - stand
+    fwd /= max(float(np.linalg.norm(fwd)), 1e-9)
+    right = np.cross(fwd, np.array([0.0, 0.0, 1.0]))
+    right /= max(float(np.linalg.norm(right)), 1e-9)
+    ET.SubElement(world, "camera", name="eye",
+                  pos=" ".join(f"{v:.4f}" for v in stand),
+                  xyaxes=" ".join(f"{v:.4f}" for v in list(right) + list(np.cross(right, fwd))),
+                  fovy="72")
+
+    def _look_from(name, eye_pt, look_at, fovy):
+        forward = look_at - eye_pt
+        forward /= max(float(np.linalg.norm(forward)), 1e-9)
+        side = np.cross(forward, np.array([0.0, 0.0, 1.0]))
+        side /= max(float(np.linalg.norm(side)), 1e-9)
+        ET.SubElement(world, "camera", name=name,
+                      pos=" ".join(f"{v:.4f}" for v in eye_pt),
+                      xyaxes=" ".join(f"{v:.4f}" for v in list(side) + list(np.cross(side, forward))),
+                      fovy=f"{fovy}")
+
+    # A SECOND CORNER, FAR FROM THE FIRST. One viewpoint answers "does this look right"; it cannot
+    # answer "is that chair inside the table", because whatever the first corner happens to hide
+    # stays hidden however long the video runs. The next-best scoring candidate is usually a hand's
+    # width from the best one and shows the same half of the room, so this takes the best candidate
+    # that stands at least a third of the room's diagonal away — a different corner by construction,
+    # still chosen for clearance rather than picked by hand.
+    diag_xy = float(np.linalg.norm(hi[:2] - lo[:2]))
+    alt_xy = None
+    for _, candidate in (scored if len(plate) >= 3 else []):
+        if float(np.linalg.norm(candidate - eye_xy)) >= 0.34 * diag_xy:
+            alt_xy = candidate
+            break
+    if alt_xy is not None:
+        alt_stand = np.array([alt_xy[0], alt_xy[1], floor_z + 1.68])
+        _look_from("eye_alt", alt_stand, np.array([centroid[0], centroid[1], floor_z + 1.05]), 72)
+
+    # OVERVIEW, from the same clearance-scored spot but just under the ceiling. It used to be placed
+    # at a fraction of the BOUNDING BOX, which is only inside the room when the room is a rectangle:
+    # on MIL-Meeting's angled plan that corner sits inside a wall and the camera rendered a flat grey
+    # slab. The floor polygon is the only description of where the room actually is.
+    high_xy = alt_xy if alt_xy is not None else eye_xy
+    _look_from("overview", np.array([high_xy[0], high_xy[1], ceiling_z - 0.25]),
+               np.array([centroid[0], centroid[1], floor_z + 0.7]), 75)
+
+    for cam in (layout.get("cameras") or []):
+        pos = cam.get("position") or [0, 0, 0]
+        fwd = np.asarray(cam.get("forward") or [0, 1, 0], dtype=float)
+        up = np.asarray(cam.get("up") or [0, 0, 1], dtype=float)
+        # MuJoCo's xyaxes wants the camera's own +X (right) and +Y (up); it looks down -Z.
+        right = np.cross(fwd, up)
+        if np.linalg.norm(right) < 1e-6:
+            continue
+        right /= np.linalg.norm(right)
+        true_up = np.cross(right, fwd)
+        ET.SubElement(world, "camera", name=cam.get("name", "cam"),
+                      pos=" ".join(f"{v:.4f}" for v in pos),
+                      xyaxes=" ".join(f"{v:.4f}" for v in list(right) + list(true_up)))
+
+    xml = out / "scene.xml"
+    ET.indent(mujoco, space="  ")
+    xml.write_text(ET.tostring(mujoco, encoding="unicode"), encoding="utf-8")
+    (out / "export_report.json").write_text(json.dumps(stats, indent=2), encoding="utf-8")
+    return xml
+
+
+def _hinge_point(leaf, frame_meshes, spec, local_axis=None, transform=None) -> np.ndarray:
+    """Where the joint sits. For a hinge, the leaf edge CLOSEST to what it hangs from.
+
+    The extras record the axis and the limits but not the pivot, and the pivot is what decides
+    whether a door swings on its hinges or pirouettes about its middle. Rather than trusting a
+    naming convention ("hinges are on +X"), which holds for the door this was written against and
+    for nothing else, it is measured: of the two candidate edges perpendicular to the axis, the
+    hinge is the one nearer the frame the leaf is hung in.
+    """
+    if spec["type"].startswith("pris"):
+        return (leaf.bounds[0] + leaf.bounds[1]) / 2.0
+
+    # IN THE LEAF'S OWN FRAME. A world axis-aligned bounding box has its corners on the box, not on
+    # the door: for a door in a wall running at 40 degrees, the AABB corner sits well off the leaf
+    # and the hinge line with it, so the door swept through the wall instead of along it. The leaf
+    # was modelled square, so its own frame is where its hinge edge actually is.
+    if local_axis is not None and transform is not None:
+        composite = _A4 @ np.asarray(transform, dtype=float)
+        try:
+            local = leaf.copy()
+            inverse = np.linalg.inv(composite)
+            local.apply_transform(inverse)
+            # IN THE SAME FRAME AS THE BOUNDS. `local_axis` is written in the shell's Z-up
+            # convention, but `local` above is the leaf in its own glTF Y-up frame, and comparing
+            # one against the other silently mixes up which dimension is which. The axis then
+            # matched the door's 39 mm THICKNESS instead of its height, `across` fell through to
+            # the height, and the pivot landed halfway along the door's width — a cupboard door
+            # that pirouettes about its own middle instead of swinging on a stile. It only showed
+            # on doors TALLER than they are wide: a squat door's width still won the comparison, so
+            # two units in the same kitchen were right and two were wrong. Rotating the world axis
+            # back through the same inverse keeps axis and bounds in one frame.
+            world_ref = np.asarray(spec["axis"], dtype=float)
+            axis = inverse[:3, :3] @ world_ref
+            if float(np.linalg.norm(axis)) < 1e-9:
+                axis = np.asarray(local_axis, dtype=float)
+            axis = axis / max(float(np.linalg.norm(axis)), 1e-9)
+            lo, hi = local.bounds
+            centre = (lo + hi) / 2.0
+            extent = hi - lo
+            across = int(np.argmax(np.where(np.abs(axis) > 0.5, -1.0, extent)))
+            along = int(np.argmax(np.abs(axis)))
+            picks = []
+            for edge in (lo[across], hi[across]):
+                point = centre.copy()
+                point[across] = edge
+                point[along] = lo[along]
+                picks.append((composite @ np.append(point, 1.0))[:3])
+            # A HORIZONTAL hinge axis means a drop-down door — a dishwasher, an oven, a washing
+            # machine — and those are hinged along their BOTTOM edge. Choosing by proximity to the
+            # frame picked the top edge for the dishwasher, so opening it swung the door up into
+            # the worktop instead of down into the room. With a vertical axis both candidates are
+            # at the same height and the frame test is still the right discriminator.
+            world_axis = (composite[:3, :3] @ axis)
+            if abs(world_axis[2]) < 0.5 and len(picks) == 2:
+                return picks[int(np.argmin([p[2] for p in picks]))]
+            if not frame_meshes:
+                return picks[1]
+            import trimesh as _tm
+            frame = _tm.util.concatenate(frame_meshes)
+            gaps = [float(np.min(np.linalg.norm(frame.vertices - p, axis=1))) for p in picks]
+            return picks[int(np.argmin(gaps))]
+        except Exception:                               # noqa: BLE001 — fall back to the AABB
+            pass
+
+    axis = np.asarray(spec["axis"], dtype=float)
+    axis = axis / max(float(np.linalg.norm(axis)), 1e-9)
+    lo, hi = leaf.bounds
+    centre = (lo + hi) / 2.0
+
+    # the in-plane direction of greatest extent is the leaf's width; its two ends are the candidates
+    extent = hi - lo
+    horizontal = np.argmax(np.where(np.abs(axis) > 0.5, -1.0, extent))
+    candidates = []
+    for edge in (lo[horizontal], hi[horizontal]):
+        p = centre.copy()
+        p[horizontal] = edge
+        p[int(np.argmax(np.abs(axis)))] = lo[int(np.argmax(np.abs(axis)))]
+        candidates.append(p)
+    if not frame_meshes:
+        return candidates[1]
+    import trimesh
+    frame = trimesh.util.concatenate(frame_meshes)
+    dists = [float(np.min(np.linalg.norm(frame.vertices - c, axis=1))) for c in candidates]
+    return candidates[int(np.argmin(dists))]
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--room", required=True, type=Path, help="room dir holding Room.py")
+    ap.add_argument("--out", type=Path, default=None, help="output dir (default: <room>/../mujoco)")
+    ap.add_argument("--reuse-meshes", action="store_true",
+                    help="keep the meshes already in <out>/meshes and only rebuild scene.xml")
+    ap.add_argument("--no-decompose", action="store_true",
+                    help="skip convex decomposition (faster, but concave bodies collide as hulls)")
+    a = ap.parse_args(argv)
+    xml = export(a.room, a.out, decompose=not a.no_decompose, reuse_meshes=a.reuse_meshes)
+    print(f"MJCF -> {xml}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/litereality_agent/room_ops/export/mujoco_scene.py
+++ b/src/litereality_agent/room_ops/export/mujoco_scene.py
@@ -85,6 +85,29 @@ CEILING_GAP = 0.30       # m below the ceiling and still counted as mounted on i
 FABRIC = {"skirting", "trunking", "conduit", "rail", "cornice", "coving", "dado", "architrave",
           "socket", "switch", "data_socket", "power_socket", "radiator", "pipe", "boxing",
           "shelf_standard", "curtain_rail", "picture_rail", "beam"}
+# FURNITURE THAT STANDS ON THE FLOOR AND STAYS THERE. A room's tables, worktops, counters and
+# cabinets are scenery: nobody pushes a desk across an office, and a simulator that lets them is
+# not more realistic, it is less. Left free they are also the multiplier on every other error in
+# the room — a cabinet ejected by a 5 mm authored overlap takes everything standing on it with it.
+#
+# The trigger is a real gap rather than a preference. `rests_on` is written by `group_fixture`, so
+# only the fixtures and props the AUTHOR added ever carry it; the furniture that came from the scan
+# is placed from the manifest and has neither `rests_on` nor `attached_to`. Office-Elliott's Table0
+# is 27.8 kg on a free joint for exactly that reason, while Table1 — the same kind of desk — is
+# static only by accident, because it happens to have a lift top and anything with a moving part
+# was already being pinned.
+#
+# CHAIRS AND STOOLS ARE DELIBERATELY NOT HERE. A chair is the one piece of furniture a room really
+# does move, it is what a robot has to get around, and freezing them would take the most useful
+# obstacle in the scene out of the physics.
+SCENERY = {"table", "desk", "worktop", "countertop", "counter", "bench", "storage", "cabinet",
+           "cupboard", "wardrobe", "sideboard", "dresser", "shelving", "bookcase", "sink",
+           "oven", "stove", "hob", "dishwasher", "refrigerator", "freezer", "washer", "dryer",
+           "bed", "sofa", "settee", "couch", "piano", "reception_desk"}
+# ...and only when it is actually standing on the floor. A "table" whose underside is a metre up is
+# a wall-mounted shelf that happens to be named one, and that is a different thing.
+SCENERY_FLOOR_GAP = 0.08
+
 # Materials whose NAME says they are see-through. glTF carries the pane as an ordinary opaque
 # texture — Blender's transmission does not survive the export — so a window arrives as a solid
 # painted panel and the room has no daylight in it. The name is the only surviving evidence that
@@ -131,6 +154,9 @@ DECOMP_TIMEOUT = 45.0    # seconds per body — see `_decompose`
 # across the room — and worse at LOW shake amplitudes than high ones, which is the signature of a
 # numerical artefact rather than a push.
 MIN_DECOMP_DIAGONAL = 0.30
+# How many parts a body may be collided piece-by-piece before it goes back to one decomposition of
+# the whole carcass. See the note where it is used.
+MAX_PARTWISE_COLLIDERS = 16
 # ...and a cap on how finely ANY body is cut. Twenty-four thin hulls on a 1.5 kg chair is a stack of
 # simultaneous contacts for the solver to satisfy at once, and it resolves them by launching it:
 # Kitchen's Chair0 travelled 175 m. Decomposition buys the ability to put a chair UNDER a table —
@@ -138,7 +164,14 @@ MIN_DECOMP_DIAGONAL = 0.30
 # with mass, because a heavy body absorbs contact noise that throws a light one across the room.
 def _part_budget(mesh, density: float) -> int:
     try:
-        mass = max(float(mesh.volume) * density, 0.05)
+        # OCCUPANCY VOLUME, NOT MESH VOLUME. `DENSITY` is kg per cubic metre of the BOUNDING BOX —
+        # it says so at its definition — and multiplying it by the mesh volume instead makes every
+        # hollow thing weightless. A 2.5 m shelving unit is a few thin boards, so it came out under
+        # 3 kg and was given four convex hulls for the whole carcass; one of them spanned 2.4 m and
+        # swallowed the shelves, and every prop standing on one started 200 mm inside it and was
+        # ejected three metres on the first step.
+        extents = np.asarray(mesh.extents, dtype=float)
+        mass = max(float(np.prod(np.maximum(extents, 0.02))) * density, 0.05)
     except Exception:                                   # noqa: BLE001
         mass = 1.0
     if mass < 3.0:
@@ -1129,8 +1162,15 @@ def export(room: Path, out: Path | None = None, *, decompose: bool = True,
         # A hanging is NOT static: it is a free body held by a weld that the shake can break.
         hanging = (category in HANGING and (rec.get("attached_to") or hung)
                    and not moving and category not in OPENING)
+        # Scenery: floor-standing furniture, pinned because that is what it is, not because it
+        # happened to be given a door. See `SCENERY`.
+        scenery = (not hanging and _in_category(category, SCENERY)
+                   and float(rec["center"][2]) - float(rec["size"][2]) / 2.0 - floor_z
+                   < SCENERY_FLOOR_GAP)
+        if scenery:
+            stats.setdefault("scenery", []).append(handle)
         static = (not hanging and (bool(rec.get("attached_to")) or bool(hung)
-                                   or category in OPENING or bool(moving)))
+                                   or category in OPENING or bool(moving) or scenery))
         body_attrs = {"name": handle, "pos": " ".join(f"{v:.4f}" for v in centre)}
         # A free object hangs off the world; anything fixed to the structure hangs off the ROOM, so
         # it travels with the walls when they move instead of being left behind in mid-air.
@@ -1197,14 +1237,28 @@ def export(room: Path, out: Path | None = None, *, decompose: bool = True,
                 stats["sidecar_colliders"] = stats.get("sidecar_colliders", 0) + len(link.colliders)
                 return
 
-            combined = trimesh.util.concatenate(shifted)
-            for i, col in enumerate(_convex_parts(combined, name_prefix, meshes, decompose,
-                                                  reuse_meshes, density)):
-                ET.SubElement(asset, "mesh", name=f"{name_prefix}_c{i}", file=col.name)
-                ET.SubElement(target, "geom", {"class": "collision", "type": "mesh",
-                                               "mesh": f"{name_prefix}_c{i}",
-                                               "density": f"{density:.1f}"})
-                stats["colliders"] += 1
+            # COLLIDE THE PARTS, NOT THEIR UNION. An authored fixture is built out of the shapes it
+            # is actually made of — a shelving unit is five boards, a desk is a top and four legs —
+            # and each of those is already convex or nearly so. Concatenating them first throws that
+            # away and hands CoACD a single carcass to guess at, which it fills: Office-Elliott's
+            # Shelving1 came back as one hull 2.4 m tall with the shelves solid inside it. Colliding
+            # each part on its own gives exact shelves for no decomposition at all.
+            #
+            # Only up to a point. A generated chair arrives as forty small parts, and forty geoms on
+            # one body is a stack of simultaneous contacts for the solver rather than a better
+            # shape, so a body with more parts than this keeps the single-carcass decomposition.
+            pieces = shifted if len(shifted) <= MAX_PARTWISE_COLLIDERS else [
+                trimesh.util.concatenate(shifted)]
+            index = 0
+            for part_no, piece in enumerate(pieces):
+                stem = name_prefix if len(pieces) == 1 else f"{name_prefix}_p{part_no}"
+                for col in _convex_parts(piece, stem, meshes, decompose, reuse_meshes, density):
+                    ET.SubElement(asset, "mesh", name=f"{name_prefix}_c{index}", file=col.name)
+                    ET.SubElement(target, "geom", {"class": "collision", "type": "mesh",
+                                                   "mesh": f"{name_prefix}_c{index}",
+                                                   "density": f"{density:.1f}"})
+                    index += 1
+                    stats["colliders"] += 1
 
         # MASS STATED EXPLICITLY. The object's own figure when it has one — occupancy density over
         # its bounding box, or a mass the recipe read off a label, split across its links by volume

--- a/src/litereality_agent/room_ops/export/mujoco_shake.py
+++ b/src/litereality_agent/room_ops/export/mujoco_shake.py
@@ -1,0 +1,545 @@
+#!/usr/bin/env python3
+"""mujoco_shake.py — shake the exported room and see what actually moves.
+
+    python -m litereality_agent.room_ops.export.mujoco_shake --scene <mujoco/scene.xml> [--video out.mp4]
+
+A room that LOADS in MuJoCo has proved almost nothing. The interesting failures all pass loading:
+every prop welded into the walls, a table whose convex hull swallows its own chairs, a mug authored
+two centimetres inside the desk it "rests on", a hundred bodies that never had a joint and so can
+never move. Each of those is a still image of a room that looks perfect and a simulation that is
+inert or explodes.
+
+So the check is a shake. Gravity is swung horizontally for a few seconds — the whole room feels a
+lateral acceleration, exactly as if the building were moving — and then released. Three numbers
+come out of that, and they are the ones worth having:
+
+* **settle** — how far things drift with NO shaking. A scene that is already at rest reports
+  millimetres. Centimetres mean objects were authored floating and are falling; a big number means
+  something is interpenetrating and being pushed apart on the first step.
+* **shake** — how much the shaking actually moved things. Near zero means the bodies are not free
+  at all, whatever the XML says.
+* **what stayed put** — the walls, the sockets, the skirting. If those move, something that should
+  be static was emitted with a joint.
+
+The video is the other half. Numbers say the scene is dynamic; watching a desk's clutter slide and
+topple says it is dynamic in the way a room is.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import numpy as np
+
+
+def _free_bodies(model) -> list[tuple[int, str, int]]:
+    """(body id, name, qpos address) for every body with a free joint."""
+    import mujoco
+
+    out = []
+    for b in range(model.nbody):
+        if model.body_jntnum[b] != 1:
+            continue
+        j = model.body_jntadr[b]
+        if model.jnt_type[j] != mujoco.mjtJoint.mjJNT_FREE:
+            continue
+        name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, b) or f"body{b}"
+        out.append((b, name, model.jnt_qposadr[j]))
+    return out
+
+
+def _pick_camera(model) -> int:
+    """A camera that can actually see the room. -1 (the free camera) usually cannot.
+
+    The exported scene carries every capture camera, and the useful one is whichever sees the most
+    of the room — approximated by the camera furthest from the walls it is looking at, which in a
+    hand-held scan is a corner shot rather than a close-up of a desk.
+    """
+
+    best, best_score = -1, -1.0
+    for c in range(model.ncam):
+        pos = model.cam_pos[c]
+        score = float(np.linalg.norm(pos - model.stat.center))
+        if score > best_score:
+            best, best_score = c, score
+    return best
+
+
+def _lift_out_of_walls(model, data, *, limit: float = 0.15) -> dict:
+    """Move any free body that STRADDLES a wall back to the side it mostly lies on.
+
+    The relax pass below can separate objects that merely touch, but it is helpless against a body
+    that passes clean THROUGH a wall: an interior partition is 80 mm thick and a floor cabinet is
+    700 mm deep, so contacts on the two faces push in exactly opposite directions and cancel. The
+    cabinet then sits in a stable equilibrium with half its geometry inside the plaster, and no
+    amount of relaxation time or damping changes it — measured at 1.2 s and 4 s, at every damping
+    from 0.55 to 0.99, the result was identical to the millimetre.
+
+    So this is geometric, not physical. Each wall is a box, and its thinnest axis is the one through
+    the plaster; a body's vertices projected onto that axis say which side it belongs to, and it is
+    translated along that axis until the last vertex clears the face. The shift is capped, because a
+    body needing more than `limit` is not slightly misplaced — it is somewhere else entirely, and
+    quietly teleporting it would hide an authoring fault rather than report one.
+    """
+    import mujoco
+
+    walls = []
+    for g in range(model.ngeom):
+        name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_GEOM, g) or ""
+        if name.lower().startswith("wall") and model.geom_type[g] == mujoco.mjtGeom.mjGEOM_BOX:
+            walls.append(g)
+    free_adr = {}
+    for b in range(model.nbody):
+        for j in range(int(model.body_jntadr[b]), int(model.body_jntadr[b]) + int(model.body_jntnum[b])):
+            if int(model.jnt_type[j]) == int(mujoco.mjtJoint.mjJNT_FREE):
+                free_adr[b] = int(model.jnt_qposadr[j])
+    if not walls or not free_adr:
+        return {}
+
+    def collision_verts(b):
+        pts = []
+        for g in range(int(model.body_geomadr[b]), int(model.body_geomadr[b]) + int(model.body_geomnum[b])):
+            if model.geom_group[g] != 3 or model.geom_type[g] != mujoco.mjtGeom.mjGEOM_MESH:
+                continue
+            mid = int(model.geom_dataid[g])
+            a, n = int(model.mesh_vertadr[mid]), int(model.mesh_vertnum[mid])
+            v = model.mesh_vert[a:a + n].reshape(-1, 3)
+            pts.append(v @ data.geom_xmat[g].reshape(3, 3).T + data.geom_xpos[g])
+        return np.vstack(pts) if pts else None
+
+    lifted: dict[str, float] = {}
+
+    def _stand_on_fixtures():
+        """Raise a free body that starts INSIDE a fixture until it sits on top of it.
+
+        A shelf unit's convex decomposition fills its own shelves: the hulls that approximate an
+        open carcass close it up, so a mug authored ON a shelf is geometrically INSIDE the collider.
+        MuJoCo then ejects it and it falls the height of the desk — fallside-office drifted 72 cm
+        with nobody shaking it, and half its free bodies never came to rest at all.
+
+        The direction is UP, not the contact normal. These objects are meant to be supported, and
+        the shortest way out of a hull is usually sideways, which slides a keyboard off the desk it
+        belongs on. Lifting it clear and letting gravity bring it back down puts it where the author
+        meant it to be, on top of whatever it was standing in.
+        """
+        raised = 0
+        for _ in range(12):
+            mujoco.mj_forward(model, data)
+            worst = {}
+            for c in range(data.ncon):
+                con = data.contact[c]
+                if con.dist >= -0.004:
+                    continue
+                b1, b2 = int(model.geom_bodyid[con.geom1]), int(model.geom_bodyid[con.geom2])
+                for body, other in ((b1, b2), (b2, b1)):
+                    if body in free_adr and other not in free_adr:
+                        name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, other) or ""
+                        if name in ("room", "world"):
+                            continue        # walls are handled above, with a proper thin axis
+                        if body not in worst or con.dist < worst[body]:
+                            worst[body] = con.dist
+            if not worst:
+                break
+            for body, dist in worst.items():
+                name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, body) or str(body)
+                if lifted.get(name, 0.0) >= limit:
+                    continue
+                adr = free_adr[body]
+                data.qpos[adr + 2] += -dist + 0.002
+                lifted[name] = round(lifted.get(name, 0.0) + float(-dist), 4)
+                raised += 1
+        return raised
+
+    for _ in range(4):
+        mujoco.mj_forward(model, data)
+        worst = None
+        for b in sorted(free_adr):
+            verts = collision_verts(b)
+            if verts is None:
+                continue
+            for w in walls:
+                rot = data.geom_xmat[w].reshape(3, 3)
+                local = (verts - data.geom_xpos[w]) @ rot
+                size = model.geom_size[w]
+                if int(np.all(np.abs(local) <= size, axis=1).sum()) < 3:
+                    continue
+                thin = int(np.argmin(size))
+                along = local[:, thin]
+                side = 1.0 if float(along.mean()) > 0 else -1.0
+                clear = (size[thin] + 0.004) - (float(along.min()) if side > 0 else -float(along.max()))
+                if clear <= 0:
+                    continue
+                if worst is None or clear > worst[0]:
+                    worst = (clear, b, rot[:, thin] * side)
+        if worst is None:
+            break
+        clear, b, direction = worst
+        name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, b) or str(b)
+        if clear > limit:
+            lifted[name] = -round(float(clear), 4)   # negative: reported, deliberately NOT moved
+            break
+        adr = free_adr[b]
+        data.qpos[adr:adr + 3] += direction * clear
+        lifted[name] = round(lifted.get(name, 0.0) + float(clear), 4)
+    _stand_on_fixtures()
+    mujoco.mj_forward(model, data)
+    return lifted
+
+
+def run(scene: Path, *, video: Path | None = None, camera: int | str | None = None,
+        settle_s: float = 1.0,
+        shake_s: float = 3.0, calm_s: float = 2.0, amplitude: float = 6.0,
+        # 1280x960 is what the model's offscreen framebuffer is sized for; rendering 960x720 into
+        # it threw away a third of the resolution that was already being paid for.
+        frequency: float = 2.2, fps: int = 30, width: int = 1280, height: int = 960,
+        hide_groups: tuple[int, ...] = (), ajar: float = 0.0,
+        # A PICTURE HOOK IS NOT A BOLT. Measured against the real constraint force: at 1.6x the
+        # frame's own weight nothing came down at any amplitude, at 0.2 they fell in a tremor you
+        # could sleep through. 0.4 leaves a still room untouched, survives a gentle shake, and drops
+        # every frame in a real one — which is what a nail through a plasterboard wall does.
+        hold_ratio: float = 0.4,
+        relax_s: float = 1.2) -> dict:
+    """Settle, shake, let it calm. Returns a report; writes a video if asked."""
+    import mujoco
+
+    model = mujoco.MjModel.from_xml_path(str(scene))
+    data = mujoco.MjData(model)
+    free = _free_bodies(model)
+    dt = model.opt.timestep
+    g = float(abs(model.opt.gravity[2])) or 9.81
+
+    room_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "room")
+    drives = [mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, f"drive_room_{a}")
+              for a in "xyz"]
+    drives = [d for d in drives if d >= 0]
+    yaw_drive = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "drive_room_yaw")
+    mujoco.mj_forward(model, data)
+    # WHAT THE ROOM WAS HANDED IN. A settle drift only says objects moved; this says whether they
+    # were overlapping before anything ran. A room whose author declared what holds each object up reports
+    # zero here because that brief required `check_collisions`; MIL-Meeting, authored before it
+    # existed, starts with 28 overlaps — chairs 2.8 cm inside a projection screen — and MuJoCo
+    # resolves those by pushing things apart, which reads as the simulation misbehaving when it is
+    # in fact the room being unphysical to begin with.
+    def _penetrations():
+        out = []
+        for i in range(data.ncon):
+            c = data.contact[i]
+            if c.dist < -0.001:
+                out.append((float(c.dist),
+                            mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY,
+                                              model.geom_bodyid[c.geom1]) or "?",
+                            mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY,
+                                              model.geom_bodyid[c.geom2]) or "?"))
+        return sorted(out)
+
+    if ajar:
+        for j in range(model.njnt):
+            if int(model.jnt_type[j]) == int(mujoco.mjtJoint.mjJNT_HINGE):
+                lo, hi = model.jnt_range[j]
+                data.qpos[model.jnt_qposadr[j]] = lo + ajar * (hi - lo)
+        mujoco.mj_forward(model, data)
+        start = data.xpos.copy()
+
+    # `int(...)`: `jnt_type` is a numpy int32 and `mjtJoint` is a pybind enum, so `x in (ENUM_A,
+    # ENUM_B)` is quietly False for every joint. It raises nothing — the list simply comes back
+    # empty and every articulated joint in the room reports a swing of zero.
+    moving_kinds = {int(mujoco.mjtJoint.mjJNT_HINGE), int(mujoco.mjtJoint.mjJNT_SLIDE)}
+
+    # AFTER opening the joints, not before. `--ajar` snaps a drawer 30% out in a single step, and a
+    # drawer with a table in front of it lands 3 cm inside that table — an overlap this code
+    # created and then did not count, because the census ran first. Opening the room and then
+    # measuring it means the relaxation below pushes those drawers back to where they actually fit.
+    initial_overlaps = _penetrations()
+
+    # HANGINGS FAIL UNDER LOAD. Each picture is welded to the room, and the weld is switched off
+    # the moment the inertial pull on it exceeds what a picture hook holds: F = m * |a|, with the
+    # acceleration the one the room is actually being driven at. That is a real criterion rather
+    # than a timer — a heavy mirror comes down before a small photo, and in a gentle tremor nothing
+    # does. Once broken it stays broken: a nail does not re-seat itself.
+    # WELD **OR** CONNECT. A hanging used to be welded to the room; it is now held by a `connect`,
+    # a point constraint that lets the picture swing on its nail instead of being clamped flat.
+    # Matching on the weld type alone silently found none of them, and every picture in the room
+    # became unbreakable — the failure looked like a physics result rather than a filter that had
+    # stopped matching. The name is what identifies a hanging; the constraint type is an
+    # implementation detail of how it is held.
+    holds = (int(mujoco.mjtEq.mjEQ_WELD), int(mujoco.mjtEq.mjEQ_CONNECT))
+    welds = [e for e in range(model.neq)
+             if int(model.eq_type[e]) in holds
+             and (mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_EQUALITY, e) or "").startswith("hang_")]
+    # A HOOK HOLDS A FEW TIMES WHAT HANGS ON IT — not a fixed number of newtons. The threshold used
+    # to be a flat 22 N for everything, which is a wall bolt, not a picture hook: a 0.31 kg mirror
+    # pulls 1.9 N at this shake and a 1.22 kg picture 7.3 N, so NOTHING could ever come down however
+    # hard the room was driven, and the stillness read as a physics result. Scaling the hold to each
+    # frame's own weight is what a hook actually does, and it scales with the object: a heavy mirror
+    # needs more force to shift but also weighs more, so both are equally precarious.
+    weld_limit = {}
+    for e in welds:
+        name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_EQUALITY, e) or ""
+        body = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, name[len("hang_"):])
+        mass = float(model.body_mass[body]) if body >= 0 else 1.0
+        weld_limit[e] = max(hold_ratio * mass * g, 0.5)
+    pull_ema: dict[int, float] = {}
+    pull_base: dict[int, float] = {}
+    ema_alpha = dt / (dt + 0.02)
+    fallen: list[str] = []
+    # a = A(2*pi*f)^2 -> the displacement that delivers the requested lateral acceleration
+    amp_m = amplitude / (2.0 * math.pi * frequency) ** 2
+    start = data.xpos.copy()
+
+    cam_id = camera if isinstance(camera, int) else (
+        mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_CAMERA, camera) if camera else _pick_camera(model))
+    renderer = None
+    frames_dir = None
+    # A cutaway is a rendering choice, never a model change: the walls stay in the physics and keep
+    # colliding, they are simply not drawn. Hiding them by deleting geoms would be simulating a
+    # different room from the one being watched.
+    scene_option = mujoco.MjvOption()
+    for g in hide_groups:
+        if 0 <= g < len(scene_option.geomgroup):
+            scene_option.geomgroup[g] = 0
+    if video:
+        renderer = mujoco.Renderer(model, height=height, width=width)
+        frames_dir = Path(tempfile.mkdtemp())
+    every = max(1, int(round(1.0 / (fps * dt))))
+
+    def phase(name, seconds, shaking):
+        nonlocal frame_no
+        for step in range(int(seconds / dt)):
+            if shaking:
+                t = step * dt
+                if drives:
+                    # MOVE THE BUILDING. Displacement, not gravity: a = A(2*pi*f)^2, so the
+                    # requested acceleration is converted to the amplitude that produces it. The
+                    # contents then slide because the floor moved under them, which is what an
+                    # earthquake is; tilting gravity instead leaves the walls standing still and
+                    # looks like the room's contents deciding to migrate.
+                    #
+                    # THE VERTICAL TERM IS NOT A GARNISH. A chair does not slide because the floor is
+                    # dragged sideways under it; it slides when the floor drops away and unloads its
+                    # feet. Friction 0.55 breaks traction at mu*g = 5.4 m/s^2 and this drive peaks at
+                    # 3.0, so a level shake never breaks it — every chair rides with the floor and
+                    # reads as glued to it. A vertical term of comparable size modulates the normal
+                    # force instead of fighting it, and the feet let go at the top of each cycle. It
+                    # is how furniture actually walks across a room in a quake, it costs no extra
+                    # violence in the horizontal, and it needs no fudging of the friction.
+                    targets = (amp_m * math.sin(2 * math.pi * frequency * t),
+                               amp_m * math.sin(2 * math.pi * frequency * 1.41 * t + 1.1),
+                               0.9 * amp_m * math.sin(2 * math.pi * frequency * 1.93 * t + 2.3))
+                    for act, value in zip(drives, targets):
+                        data.ctrl[act] = value
+                    if yaw_drive >= 0:
+                        # A twist about the vertical, at a fourth incommensurate frequency. Its
+                        # amplitude is set so a point 2 m from the centre sees roughly the same
+                        # acceleration as the sliding axes deliver — enough to make where an object
+                        # STANDS matter, which pure translation never does.
+                        data.ctrl[yaw_drive] = (amp_m / 2.0) * math.sin(
+                            2 * math.pi * frequency * 0.77 * t + 0.6)
+                # Three INCOMMENSURATE frequencies, one per axis. A single frequency in x and y
+                # traces a smooth ellipse: every object gets the same push at the same moment and
+                # the room sways as one piece, which looks like a camera move rather than a shake.
+                # Ratios that never repeat make the direction wander, so objects load against each
+                # other and topple instead of sliding in convoy. The vertical term is deliberately
+                # weaker than gravity — it should unstick things, not throw them at the ceiling.
+            elif drives:
+                for act in drives:
+                    data.ctrl[act] = 0.0
+                if yaw_drive >= 0:
+                    data.ctrl[yaw_drive] = 0.0
+            if welds and name != "settle":
+                # THE FORCE THE NAIL IS ACTUALLY CARRYING, not a guess from the drive signal.
+                # `m * |a_commanded|` describes how hard the ROOM is being pushed and says nothing
+                # about the picture: a frame that has begun to swing loads its hook far harder than
+                # its own mass times the room's acceleration, and one hanging in a sheltered corner
+                # far less. MuJoCo already solves for the constraint force every step — a `connect`
+                # contributes three rows, and their norm IS the pull on the nail. Checking it also
+                # lets a picture come off during the calm, while it is still swinging, which is when
+                # a real one usually goes.
+                for e in list(welds):
+                    if not data.eq_active[e]:
+                        continue
+                    rows = [i for i in range(data.nefc)
+                            if int(data.efc_type[i]) == int(mujoco.mjtConstraint.mjCNSTR_EQUALITY)
+                            and int(data.efc_id[i]) == e]
+                    if not rows:
+                        continue
+                    # SMOOTHED, NOT INSTANTANEOUS. A constraint solver produces single-step spikes
+                    # when it first catches a body — Picture0 peaked at 2718 N, 226x its own weight,
+                    # while the room was standing perfectly still — and breaking on the raw value
+                    # dropped two pictures off a wall that was never shaken. A hook fails under load
+                    # it is actually carrying, so the pull is low-passed over ~20 ms: a real overload
+                    # lasts, a solver artefact does not survive the filter.
+                    pull = float(np.linalg.norm(data.efc_force[rows]))
+                    smooth = pull_ema.get(e)
+                    smooth = pull if smooth is None else smooth + ema_alpha * (pull - smooth)
+                    pull_ema[e] = smooth
+                    # AGAINST WHAT IT WAS ALREADY CARRYING. Some pictures are authored INSIDE the
+                    # rail they hang on — Picture1 starts 23.6 mm into PictureRail4 — so the rail
+                    # shoves and the nail holds it back at 69x the frame's own weight before anything
+                    # has moved. Judged on the absolute pull those two dropped off a wall that was
+                    # standing still, which says nothing about the hook and everything about the
+                    # authoring. A hook fails on the load ADDED to whatever preload it already sits
+                    # under, so the baseline is taken the moment the shaking starts.
+                    if e not in pull_base:
+                        pull_base[e] = smooth
+                    if smooth - pull_base[e] > weld_limit[e]:
+                        data.eq_active[e] = 0
+                        name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_EQUALITY, e) or ""
+                        fallen.append(name[len("hang_"):])
+                        welds.remove(e)
+            mujoco.mj_step(model, data)
+            if hinges:
+                hinge_track.append([float(data.qpos[model.jnt_qposadr[j]]) for j in hinges])
+            if renderer is not None and step % every == 0:
+                renderer.update_scene(data, camera=cam_id, scene_option=scene_option)
+                import PIL.Image
+                PIL.Image.fromarray(renderer.render()).save(frames_dir / f"f_{frame_no:05d}.png")
+                frame_no += 1
+
+    hinge_track: list[float] = []
+    # A CLOSED door cannot respond to anything: it starts hard against its own limit stop, wedged
+    # in the frame, and a shake can only rattle it. Reporting that as "not responsive" would be
+    # measuring a latch, not the joint. Setting each articulated joint part-open gives the shake
+    # something to act on — which is also the more useful demonstration, since the question is
+    # whether the ARTICULATION works, not whether shut doors stay shut.
+    # HINGES ONLY. A prismatic joint in a room is usually something that CARRIES things — a desk's
+    # lift top, a drawer — and opening it a third of the way lifts a laptop, a keyboard and a mug
+    # 8.8 cm into the air before the clock starts. That measured as 88 cm of "settle drift" and was
+    # entirely self-inflicted. A door ajar disturbs nothing; a desk raised does.
+    hinges = [j for j in range(model.njnt) if int(model.jnt_type[j]) in moving_kinds]
+    # RELAX FIRST. Rooms authored without support declarations ship with objects already inside
+    # each other — Airbnb-Cam starts with 87 overlapping contacts, a chair 2.6 cm inside a table —
+    # and MuJoCo's first instinct is to resolve that penetration by firing them apart. Stepping
+    # briefly with NO gravity and bleeding off velocity each step lets the same overlaps separate
+    # gently instead: the contact still pushes, nothing accelerates far, and by the time gravity is
+    # switched on the room is merely untidy rather than exploding. It cannot fix a room that was
+    # authored wrong; it stops that wrongness becoming a launch.
+    frame_no = 0
+    lifted = _lift_out_of_walls(model, data)
+    if initial_overlaps:
+        saved_gravity = model.opt.gravity.copy()
+        model.opt.gravity[:] = 0.0
+        for _ in range(int(relax_s / dt)):
+            mujoco.mj_step(model, data)
+            data.qvel[:] *= 0.55
+        model.opt.gravity[:] = saved_gravity
+        data.qvel[:] = 0.0
+        mujoco.mj_forward(model, data)
+        start = data.xpos.copy()          # the room as the simulation actually begins
+        relaxed_overlaps = len(_penetrations())
+    else:
+        relaxed_overlaps = 0
+
+    phase("settle", settle_s, False)
+    settled = data.xpos.copy()
+    phase("shake", shake_s, True)
+    phase("calm", calm_s, False)
+    final = data.xpos.copy()
+    # PER JOINT. Collapsing every joint into one number each step measures whichever joint happens
+    # to sit furthest from zero, not how far anything actually travelled: a door swinging 110 deg
+    # while a desk's lift top holds still reported a swing of zero.
+    # np.ptp(...), not arr.ptp(...): the method was removed from ndarray in NumPy 2.
+    swings = (np.ptp(np.asarray(hinge_track), axis=0) if hinge_track else np.array([]))
+
+    def moved(a, b, ids):
+        return {n: float(np.linalg.norm(b[i] - a[i])) for i, n, _ in ids}
+
+    drift = moved(start, settled, free)
+    shook = moved(settled, final, free)
+    # The room is DRIVEN, so it is not a witness to whether static things stayed put — its
+    # children are. Excluding it keeps `static_moved` meaningful.
+    static_ids = [(b, mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, b) or f"body{b}", 0)
+                  for b in range(model.nbody)
+                  if model.body_jntnum[b] == 0 and b != room_id]
+    static_move = moved(start, final, static_ids)
+
+    report = {
+        "bodies": int(model.nbody),
+        "free_bodies": len(free),
+        "static_bodies": len(static_ids),
+        "geoms": int(model.ngeom),
+        "settle_drift_max_cm": round(max(drift.values(), default=0.0) * 100, 2),
+        "settle_drift_mean_cm": round(float(np.mean(list(drift.values()))) * 100, 2) if drift else 0.0,
+        "settled_within_1cm": sum(1 for v in drift.values() if v < 0.01),
+        "shake_moved_max_cm": round(max(shook.values(), default=0.0) * 100, 2),
+        "shake_moved_over_1cm": sum(1 for v in shook.values() if v > 0.01),
+        "static_moved_max_cm": round(max(static_move.values(), default=0.0) * 100, 2),
+        "room_shake_amplitude_cm": round(amp_m * 100, 2),
+        "initial_overlaps": len(initial_overlaps),
+        "overlaps_after_relax": relaxed_overlaps,
+        "lifted_out_of_walls": lifted,
+        "hangings": len(weld_limit),
+        "hangings_fell": fallen,
+        "worst_initial_overlaps": [(round(d * 100, 1), a, b) for d, a, b in initial_overlaps[:5]],
+        "hinge_swing_deg": {
+            (mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, j) or f"joint{j}"):
+                (round(float(np.degrees(swings[i])), 1)
+                 if int(model.jnt_type[j]) == int(mujoco.mjtJoint.mjJNT_HINGE)
+                 else round(float(swings[i]) * 100, 1))     # a slide travels in cm, not degrees
+            for i, j in enumerate(hinges)
+            if not (mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, j) or "").startswith("room_")
+        } if len(swings) else {},
+        "worst_settlers": sorted(((round(v * 100, 1), n) for n, v in drift.items()), reverse=True)[:8],
+        "most_shaken": sorted(((round(v * 100, 1), n) for n, v in shook.items()), reverse=True)[:8],
+    }
+
+    if renderer is not None and frames_dir is not None:
+        video = Path(video)
+        video.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(["ffmpeg", "-v", "error", "-y", "-framerate", str(fps),
+                        "-i", str(frames_dir / "f_%05d.png"), "-c:v", "libx264",
+                        "-preset", "slow", "-pix_fmt", "yuv420p", "-crf", "17",
+                        str(video)], check=True)
+        report["video"] = str(video)
+        report["frames"] = frame_no
+        # DELETE THE FRAMES. `mkdtemp` does not clean up after itself, and a render of this room is
+        # ~130 MB of PNGs. Left behind, forty-seven renders filled the root filesystem to 4 KB free
+        # and the next export died with "No space left on device" — a failure with no connection to
+        # anything it was doing. The mp4 is the artefact; the frames are scaffolding.
+        shutil.rmtree(frames_dir, ignore_errors=True)
+    return report
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--scene", required=True, type=Path)
+    ap.add_argument("--video", type=Path, default=None)
+    ap.add_argument("--camera", default=None, help="camera name (default: the widest capture view)")
+    # 12 m/s^2 was a demolition setting: it emptied the shelves and threw a chair across the room.
+    # A tremor you can watch without the room being destroyed is around 1-2.
+    ap.add_argument("--amplitude", type=float, default=1.5,
+                    help="lateral m/s^2 during the shake (~1 a tremor, ~5 furniture moves, 12+ destructive)")
+    ap.add_argument("--cutaway", action="store_true",
+                    help="hide the walls (group 1) and ceiling (group 0) for a cutaway view")
+    ap.add_argument("--hide", default="", help="extra geom groups to hide, comma separated")
+    ap.add_argument("--ajar", type=float, default=0.0,
+                    help="start every articulated joint this fraction open (0.3 = a door ajar)")
+    ap.add_argument("--frequency", type=float, default=1.5, help="Hz")
+    ap.add_argument("--shake", type=float, default=3.0, help="seconds of shaking")
+    # THE SHAKE SHOULD BE MOST OF THE VIDEO. Every second of settle and calm is a still room, and a
+    # clip that spends 1 s arriving and 2 s subsiding around 2 s of movement reads as a static scene
+    # with a wobble in the middle — the objects are moving correctly and nobody can tell. These are
+    # exposed because they set what fraction of the result is worth watching.
+    ap.add_argument("--settle", type=float, default=1.0,
+                    help="seconds of stillness before the shake (proves the room starts at rest)")
+    ap.add_argument("--calm", type=float, default=2.0,
+                    help="seconds of stillness after the shake (shows where everything ended up)")
+    a = ap.parse_args(argv)
+    hide = {int(g) for g in a.hide.split(",") if g.strip().isdigit()}
+    if a.cutaway:
+        hide |= {0, 1}
+    report = run(a.scene, video=a.video, camera=a.camera, shake_s=a.shake,
+                 settle_s=a.settle, calm_s=a.calm,
+                 amplitude=a.amplitude, frequency=a.frequency, hide_groups=tuple(sorted(hide)),
+                 ajar=a.ajar)
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/litereality_agent/room_ops/export/sim_assets.py
+++ b/src/litereality_agent/room_ops/export/sim_assets.py
@@ -1,0 +1,414 @@
+"""sim_assets.py — the physics a generated object carries, read back and placed in a room.
+
+Every object the reconstruct stage builds now leaves a sidecar beside its GLB: a
+`<name>.physics.json` holding the links, joints, masses, inertias, frictions and CONVEX COLLIDERS
+that `object_generation.sim` compiled from the mesh, plus the OBJ files those colliders live in.
+It is the asset's own statement of what it is physically, gated by a solver before it was ever put
+in a room.
+
+This module is how the room-level MuJoCo export reads that statement instead of re-inventing it.
+The difference is not cosmetic:
+
+  * the PIVOT of a hinge is authored — `object.py` placed the hinge and recorded where. The room
+    exporter's alternative is to guess it from the leaf's geometry, which is right for a door with
+    an obvious free edge and wrong for a sash, a lid, or a drawer.
+  * the MASS is split across the links by volume, so a door leaf weighs what a door leaf weighs
+    rather than a share of the whole object's bounding box.
+  * FRICTION comes from the material the recipe deliberately chose. Glass grips at 0.30, carpet at
+    0.85, and a room where everything is 0.55 slides wrong in a way no amount of tuning fixes.
+  * the COLLIDERS are already decomposed, so a 25-minute CoACD pass over the whole room turns into
+    reading a few dozen OBJ files.
+
+`room_ops` may not import the pipeline or the models layer (the architecture test enforces it), so
+nothing here imports the compiler. The sidecar is a FILE FORMAT, and this reads it as one — the
+dataclasses below mirror `object_generation.sim.properties` and are checked against
+`schema_version`.
+
+FRAMES. The sidecar is Z-up metres in the object's own build frame, with each link's geometry
+expressed relative to that link's own frame origin (which sits on its joint). A room places the
+object with a rotation and a NON-UNIFORM scale — RoomPlan measured a box and the asset was fitted
+into it — so everything has to travel through one affine on the way in. `placement_transform`
+recovers that affine exactly from the two glTF files, and `place` applies it.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+SCHEMA_VERSION = 1
+
+# glTF is Y-up, the SHELL and MuJoCo are Z-up. Kept local rather than imported from mujoco_scene so
+# this module can be read (and tested) on its own.
+_A = np.array([[1.0, 0.0, 0.0], [0.0, 0.0, -1.0], [0.0, 1.0, 0.0]])
+_A4 = np.eye(4)
+_A4[:3, :3] = _A
+_A4_INV = np.linalg.inv(_A4)
+
+# trimesh appends `_<6 hex>` to a node name it has already seen, and it picks a DIFFERENT suffix
+# each time a file is loaded. So `DoorLeaf_5a8bb9` in the object's own glb and `DoorLeaf_22e63d` in
+# the room glb are the same node, and no amount of string equality will say so. Only names that are
+# unique within their own file can be matched across the two — which is enough, because one matched
+# node determines the whole placement.
+_DEDUP_SUFFIX = re.compile(r"_[0-9a-f]{6}$")
+
+MIN_LINK_MASS = 0.15
+
+
+def base_name(node: str) -> str:
+    """The node name with trimesh's de-duplication suffix removed."""
+    return _DEDUP_SUFFIX.sub("", node)
+
+
+@dataclass
+class Collider:
+    file: str
+    volume: float
+
+
+@dataclass
+class Link:
+    name: str
+    mass: float
+    com: list
+    inertia: list
+    friction: float
+    restitution: float
+    material: str = ""
+    visual: str = ""
+    colliders: list = field(default_factory=list)
+    mass_source: str = "derived"
+    inertia_source: str = "geometry"
+
+
+@dataclass
+class Joint:
+    name: str
+    type: str
+    parent: str
+    child: str
+    origin: list
+    axis: list
+    limit_lower: float
+    limit_upper: float
+    damping: float = 0.05
+    friction: float = 0.02
+    effort: float = 20.0
+    velocity: float = 3.0
+    origin_source: str = "node_transform"
+
+
+@dataclass
+class SimModel:
+    name: str
+    category: str
+    root: str
+    links: list = field(default_factory=list)
+    joints: list = field(default_factory=list)
+    bbox: list = field(default_factory=list)
+    total_mass: float = 0.0
+    notes: list = field(default_factory=list)
+    directory: Path = field(default=Path("."))
+
+    def link(self, name: str) -> Link | None:
+        return next((link for link in self.links if link.name == name), None)
+
+    def frames(self) -> dict[str, np.ndarray]:
+        """Each link's frame origin in the OBJECT's own Z-up frame.
+
+        A joint records its pivot in the PARENT's frame, so the absolute origin is the chain of
+        them accumulated from the root. Written iteratively rather than recursively because a
+        malformed sidecar could otherwise describe a cycle and blow the stack.
+        """
+        origins = {self.root: np.zeros(3)}
+        pending = list(self.joints)
+        for _ in range(len(pending) + 1):
+            if not pending:
+                break
+            rest = []
+            for joint in pending:
+                if joint.parent in origins:
+                    origins[joint.child] = origins[joint.parent] + np.asarray(joint.origin, float)
+                else:
+                    rest.append(joint)
+            if len(rest) == len(pending):
+                break                      # an orphan or a cycle: leave the rest at the root
+            pending = rest
+        for link in self.links:
+            origins.setdefault(link.name, np.zeros(3))
+        return origins
+
+
+def sidecar_dir(room: Path, object_name: str) -> Path | None:
+    """The `sim/` directory an object's physics was compiled into, inside the Room package.
+
+    `export_room` carries it in beside the object's own source, so a Room directory is a complete
+    statement of the room INCLUDING its physics. Both object kinds are searched because a
+    generative mesh (a TRELLIS chair) is as much a rigid body as a recipe-built one.
+    """
+    for kind in ("Procedural", "Static"):
+        candidate = Path(room) / "Objects" / kind / object_name / "sim"
+        if (candidate / f"{object_name}.physics.json").is_file():
+            return candidate
+    return None
+
+
+def load(path: Path) -> SimModel:
+    """One `<name>.physics.json` -> the model. Raises on a schema this code does not know."""
+    path = Path(path)
+    raw: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+    version = raw.pop("schema_version", 0)
+    if version != SCHEMA_VERSION:
+        raise ValueError(
+            f"{path} is physics schema v{version}, this reads v{SCHEMA_VERSION}. Reading it "
+            f"anyway would put a wrong mass or a wrong hinge into a scene and report success."
+        )
+    links = [Link(**{**row, "colliders": [Collider(**c) for c in row.get("colliders", [])]})
+             for row in raw.get("links", [])]
+    joints = [Joint(**row) for row in raw.get("joints", [])]
+    return SimModel(name=raw["name"], category=raw.get("category", ""),
+                    root=raw.get("root", "base_link"), links=links, joints=joints,
+                    bbox=raw.get("bbox") or [], total_mass=float(raw.get("total_mass") or 0.0),
+                    notes=list(raw.get("notes") or []), directory=path.parent)
+
+
+# ------------------------------------------------------------------ placement
+
+
+def placement_transform(object_scene, room_scene, room_nodes) -> np.ndarray | None:
+    """The affine that carries the object's own glb frame onto where the room put it (Y-up).
+
+    `build_room` fits an asset into the RoomPlan box it belongs to, which is a rotation about the
+    vertical and a per-axis SCALE — the box was measured by the scan and the asset was built to its
+    own proportions, so the two rarely agree. Any single node present in both files pins the whole
+    thing down:
+
+        T = T_room(node) . T_object(node)^-1
+
+    and every other node then maps through it exactly. Returns None when no node can be matched,
+    which is the caller's signal to fall back to deriving physics from the placed mesh instead of
+    quietly using an unplaced one.
+    """
+    from collections import Counter
+
+    def unique(nodes) -> dict[str, str]:
+        counts = Counter(base_name(n) for n in nodes)
+        return {base_name(n): n for n in nodes if counts[base_name(n)] == 1}
+
+    in_object = unique(list(object_scene.graph.nodes_geometry))
+    in_room = unique(list(room_nodes))
+    shared = sorted(set(in_object) & set(in_room))
+    if not shared:
+        return None
+    # Prefer the node with the most geometry: a big part pins the transform with the least relative
+    # error if the two files ever disagree, and it is the one most likely to be the carcass rather
+    # than a fitting that a later edit moved.
+    def area(name: str) -> float:
+        try:
+            return float(object_scene.geometry[object_scene.graph[in_object[name]][1]].area)
+        except Exception:                                    # noqa: BLE001 — degenerate geometry
+            return 0.0
+
+    best = max(shared, key=area)
+    to_object = np.asarray(object_scene.graph[in_object[best]][0], dtype=float)
+    to_room = np.asarray(room_scene.graph[in_room[best]][0], dtype=float)
+    try:
+        return to_room @ np.linalg.inv(to_object)
+    except np.linalg.LinAlgError:
+        return None
+
+
+def placement_from_bbox(model: SimModel, placed_mesh, yaw: float) -> np.ndarray | None:
+    """The same affine, recovered from GEOMETRY when no node name survived the room build.
+
+    An object placed more than once — four chairs from one cluster, a repeated cabinet — has every
+    node renamed for every instance after the first, and a cluster whose own parts already repeat
+    has nothing unique inside its own file either. Name matching then reports nothing for objects
+    that are perfectly well placed.
+
+    But the placement has a known SHAPE. `build_room` fits an asset into its box as
+
+        world = T(centre) . Rz(yaw) . diag(s) . (p - asset centre)
+
+    with `yaw` stated in the SHELL, so rotating the placed mesh back by that yaw makes the fit
+    axis-aligned and the two bounding boxes give `s` and `centre` directly. It is exact for exactly
+    the transform the room applies, which is why the caller still checks the result.
+
+    Returns the Y-up matrix, so it feeds `place` identically to `placement_transform`.
+    """
+    if not model.bbox or len(model.bbox) != 2:
+        return None
+    lo = np.asarray(model.bbox[0], dtype=float)
+    hi = np.asarray(model.bbox[1], dtype=float)
+    asset_size = hi - lo
+    if np.any(asset_size < 1e-6):
+        return None
+
+    c, s_ = math.cos(yaw), math.sin(yaw)
+    rotation = np.array([[c, -s_, 0.0], [s_, c, 0.0], [0.0, 0.0, 1.0]])
+    aligned = np.asarray(placed_mesh.vertices, dtype=float) @ rotation     # == Rz(-yaw) . v
+    placed_lo, placed_hi = aligned.min(axis=0), aligned.max(axis=0)
+    scale = (placed_hi - placed_lo) / asset_size
+    if np.any(~np.isfinite(scale)) or np.any(np.abs(scale) < 1e-9):
+        return None
+
+    linear = rotation @ np.diag(scale)
+    centre = rotation @ ((placed_lo + placed_hi) / 2.0)
+    transform = np.eye(4)
+    transform[:3, :3] = linear
+    transform[:3, 3] = centre - linear @ ((lo + hi) / 2.0)
+    return _A4_INV @ transform @ _A4
+
+
+@dataclass
+class PlacedLink:
+    name: str
+    mass: float
+    friction: float
+    restitution: float
+    inertia: np.ndarray              # [ixx, iyy, izz, ixy, ixz, iyz] about the com
+    com: np.ndarray                  # world Z-up, metres
+    colliders: list                  # trimesh meshes, world Z-up
+    mass_source: str
+    inertia_source: str
+
+
+@dataclass
+class Placed:
+    """A SimModel expressed in the room's world frame, ready to be written as MJCF bodies."""
+    model: SimModel
+    transform: np.ndarray            # 4x4, world Z-up <- object Z-up
+    volume_ratio: float
+    links: dict                      # name -> PlacedLink
+    pivots: dict                     # link name -> world Z-up pivot
+    axes: dict                       # link name -> world Z-up unit axis
+    total_mass: float
+
+    def joint_for(self, link: str) -> Joint | None:
+        return next((j for j in self.model.joints if j.child == link), None)
+
+
+def _transform_points(points: np.ndarray, transform: np.ndarray) -> np.ndarray:
+    return points @ transform[:3, :3].T + transform[:3, 3]
+
+
+def _inertia_about_com(mesh, mass: float):
+    """Inertia about the centre of mass, from the placed geometry, at the sidecar's mass.
+
+    The sidecar's own tensor describes the object at the size it was BUILT, and the room scales it
+    — a door stretched 10% taller has a different tensor, not a scaled mass with the old one. It is
+    cheaper and more honest to recompute from the geometry that is actually going into the scene.
+    The ladder mesh -> convex hull -> bounding box is the one `object_generation.sim` uses, and it
+    exists because a flat visual part (a pane, a poster) has no volume for trimesh to integrate and
+    MuJoCo refuses a non-positive-definite inertia at compile time.
+    """
+    for candidate, source in ((mesh, "geometry"), (mesh.convex_hull, "hull")):
+        try:
+            if candidate.volume > 1e-9:
+                scaled = candidate.copy()
+                scaled.density = mass / float(candidate.volume)
+                tensor = np.asarray(scaled.moment_inertia, dtype=float)
+                if np.all(np.linalg.eigvalsh(tensor) > 0):
+                    return tensor, np.asarray(scaled.center_mass, dtype=float), source
+        except Exception:                                    # noqa: BLE001 — degenerate mesh
+            continue
+    extents = np.maximum(np.asarray(mesh.extents, dtype=float), 0.01)
+    diagonal = mass / 12.0 * np.array([extents[1] ** 2 + extents[2] ** 2,
+                                       extents[0] ** 2 + extents[2] ** 2,
+                                       extents[0] ** 2 + extents[1] ** 2])
+    return np.diag(diagonal), np.asarray(mesh.bounds, dtype=float).mean(axis=0), "bounding_box"
+
+
+def place(model: SimModel, transform_yup: np.ndarray) -> Placed:
+    """Carry a model's colliders, masses, pivots and axes into the room's world frame.
+
+    `transform_yup` comes from `placement_transform`; it is converted here so that every number
+    this returns is Z-up and nothing downstream has to think about frames again.
+    """
+    import trimesh
+
+    transform = _A4 @ np.asarray(transform_yup, dtype=float) @ _A4_INV
+    linear = transform[:3, :3]
+    # How much bigger the room made this object. A mass the sidecar DERIVED came from occupancy
+    # density over the object's own bounding box, so at a different size it is a different mass;
+    # a mass the recipe AUTHORED is a fact about the real object and survives the fit unchanged.
+    volume_ratio = abs(float(np.linalg.det(linear))) or 1.0
+    frames = model.frames()
+
+    links: dict[str, PlacedLink] = {}
+    pivots: dict[str, np.ndarray] = {}
+    axes: dict[str, np.ndarray] = {}
+    for link in model.links:
+        frame = frames.get(link.name, np.zeros(3))
+        pivots[link.name] = _transform_points(frame.reshape(1, 3), transform)[0]
+
+        pieces = []
+        for collider in link.colliders:
+            path = model.directory / collider.file
+            if not path.is_file():
+                continue
+            try:
+                piece = trimesh.load(str(path), process=False, force="mesh")
+            except Exception:                                # noqa: BLE001 — unreadable collider
+                continue
+            # The collider was written relative to the link's own frame; put it back in the
+            # object's frame before placing it, or every moving part lands on the carcass.
+            piece.vertices = _transform_points(np.asarray(piece.vertices, float) + frame, transform)
+            if piece.volume > 1e-9 or len(piece.vertices) >= 4:
+                pieces.append(piece)
+        if not pieces:
+            continue
+
+        mass = float(link.mass)
+        if link.mass_source != "authored":
+            mass *= volume_ratio
+        mass = max(mass, MIN_LINK_MASS)
+        merged = trimesh.util.concatenate(pieces)
+        inertia, com, source = _inertia_about_com(merged, mass)
+        links[link.name] = PlacedLink(
+            name=link.name, mass=mass, friction=float(link.friction),
+            restitution=float(link.restitution),
+            inertia=np.array([inertia[0, 0], inertia[1, 1], inertia[2, 2],
+                              inertia[0, 1], inertia[0, 2], inertia[1, 2]], dtype=float),
+            com=np.asarray(com, dtype=float), colliders=pieces,
+            mass_source=link.mass_source, inertia_source=source)
+
+    for joint in model.joints:
+        # A joint AXIS is a direction in the object's frame and travels through the linear part —
+        # the same map `mujoco_scene._axis_to_world` applies, and for the rotation-plus-diagonal
+        # scale a room fit produces it is the correct one. It is renormalised because the scale is
+        # not uniform and an unnormalised MuJoCo axis silently changes a slide joint's units.
+        world = linear @ np.asarray(joint.axis, dtype=float)
+        norm = float(np.linalg.norm(world))
+        axes[joint.child] = world / norm if norm > 1e-9 else np.array([0.0, 0.0, 1.0])
+
+    return Placed(model=model, transform=transform, volume_ratio=volume_ratio, links=links,
+                  pivots=pivots, axes=axes,
+                  total_mass=sum(link.mass for link in links.values()))
+
+
+def assign_nodes(node_names, model: SimModel) -> dict[str, list[str]]:
+    """Room-glb node names -> the link each belongs to.
+
+    A link owns the node it was named for and everything welded under it, and the room appends a
+    de-duplication suffix to any name it has seen before. Longest match wins so that `door_leaf`
+    does not swallow a `door_leaf_handle` that has its own joint. Anything unclaimed belongs to the
+    root, which is what "welded into the carcass" means.
+    """
+    names = [link.name for link in model.links if link.name != model.root]
+    out: dict[str, list[str]] = {}
+    for node in node_names:
+        stem = base_name(node)
+        owner = None
+        for candidate in names:
+            if stem == candidate or stem.startswith(candidate + "_"):
+                if owner is None or len(candidate) > len(owner):
+                    owner = candidate
+        out.setdefault(owner or model.root, []).append(node)
+    return out

--- a/tests/test_sim_assets.py
+++ b/tests/test_sim_assets.py
@@ -1,0 +1,295 @@
+"""The room export reading a generated object's OWN physics, rather than inventing it.
+
+Every assertion here is about a number surviving the trip from the asset into the scene: the mass
+the object was compiled with, the friction of the material its recipe chose, the pivot its build
+put the hinge on, and the convex pieces a solver already accepted. Getting any of them wrong is
+silent — the scene still loads, still renders, and behaves like a different room.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from litereality_agent.room_ops.export import sim_assets
+
+trimesh = pytest.importorskip("trimesh")
+
+
+def _model_json(name="Widget0", *, mass_source="derived", joints=True):
+    doc = {
+        "schema_version": 1,
+        "name": name,
+        "category": "cabinet",
+        "root": "base_link",
+        "bbox": [[-0.3, -0.2, 0.0], [0.3, 0.2, 0.9]],
+        "total_mass": 12.0,
+        "notes": [],
+        "links": [
+            {"name": "base_link", "mass": 8.0, "com": [0, 0, 0.45],
+             "inertia": [1.0, 1.0, 0.5, 0, 0, 0], "friction": 0.55, "restitution": 0.15,
+             "material": "Oak", "visual": f"{name}_base_link_vis.obj",
+             "colliders": [{"file": f"{name}_base_link_col0.obj", "volume": 0.05}],
+             "mass_source": mass_source, "inertia_source": "geometry"},
+            {"name": "door_leaf", "mass": 4.0, "com": [0, 0, 0.45],
+             "inertia": [0.4, 0.4, 0.1, 0, 0, 0], "friction": 0.30, "restitution": 0.30,
+             "material": "Glazing", "visual": f"{name}_door_leaf_vis.obj",
+             "colliders": [{"file": f"{name}_door_leaf_col0.obj", "volume": 0.01}],
+             "mass_source": mass_source, "inertia_source": "geometry"},
+        ],
+        "joints": [
+            {"name": "door_leaf_joint", "type": "revolute", "parent": "base_link",
+             "child": "door_leaf", "origin": [0.3, -0.2, 0.05], "axis": [0.0, 0.0, 1.0],
+             "limit_lower": 0.0, "limit_upper": 1.5708, "damping": 0.05, "friction": 0.02,
+             "effort": 20.0, "velocity": 3.0, "origin_source": "authored"},
+        ] if joints else [],
+    }
+    return doc
+
+
+def _write_sidecar(directory: Path, doc: dict) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    for link in doc["links"]:
+        for collider in link["colliders"]:
+            box = trimesh.creation.box(extents=(0.2, 0.1, 0.3))
+            box.export(directory / collider["file"])
+    path = directory / f"{doc['name']}.physics.json"
+    path.write_text(json.dumps(doc, indent=2))
+    return path
+
+
+def test_a_sidecar_from_a_schema_this_does_not_know_is_refused(tmp_path):
+    """Reading it anyway would put a wrong mass or a wrong hinge in and report success."""
+    doc = _model_json()
+    doc["schema_version"] = 99
+    path = _write_sidecar(tmp_path, doc)
+    with pytest.raises(ValueError, match="schema"):
+        sim_assets.load(path)
+
+
+def test_link_frames_accumulate_down_the_joint_chain(tmp_path):
+    """A joint's origin is stated in its PARENT's frame, so a link two joints down is the sum."""
+    doc = _model_json()
+    doc["links"].append({"name": "handle", "mass": 0.3, "com": [0, 0, 0],
+                         "inertia": [0.01, 0.01, 0.01, 0, 0, 0], "friction": 0.4,
+                         "restitution": 0.2, "material": "", "visual": "",
+                         "colliders": [], "mass_source": "derived",
+                         "inertia_source": "geometry"})
+    doc["joints"].append({"name": "handle_joint", "type": "prismatic", "parent": "door_leaf",
+                          "child": "handle", "origin": [0.0, 0.1, 0.4], "axis": [0, 1, 0],
+                          "limit_lower": 0.0, "limit_upper": 0.05, "damping": 0.05,
+                          "friction": 0.02, "effort": 20.0, "velocity": 1.0,
+                          "origin_source": "authored"})
+    model = sim_assets.load(_write_sidecar(tmp_path, doc))
+    frames = model.frames()
+    assert np.allclose(frames["base_link"], [0, 0, 0])
+    assert np.allclose(frames["door_leaf"], [0.3, -0.2, 0.05])
+    assert np.allclose(frames["handle"], [0.3, -0.1, 0.45])
+
+
+def test_a_cycle_in_the_joints_does_not_hang_or_raise(tmp_path):
+    """A malformed sidecar is a bad file, not a reason for an export to never finish."""
+    doc = _model_json()
+    doc["joints"].append({"name": "loop", "type": "revolute", "parent": "door_leaf",
+                          "child": "base_link", "origin": [1, 1, 1], "axis": [0, 0, 1],
+                          "limit_lower": 0.0, "limit_upper": 1.0, "damping": 0.05,
+                          "friction": 0.02, "effort": 20.0, "velocity": 3.0,
+                          "origin_source": "authored"})
+    model = sim_assets.load(_write_sidecar(tmp_path, doc))
+    frames = model.frames()
+    assert set(frames) >= {"base_link", "door_leaf"}
+
+
+# ------------------------------------------------------------------ placement
+
+
+def _scene(nodes):
+    """A trimesh Scene with one box per (name, transform)."""
+    scene = trimesh.Scene()
+    for name, transform in nodes:
+        scene.add_geometry(trimesh.creation.box(extents=(0.2, 0.2, 0.2)),
+                           node_name=name, geom_name=f"g_{name}", transform=transform)
+    return scene
+
+
+def _yaw_scale(yaw, scale, translation):
+    m = np.eye(4)
+    c, s = math.cos(yaw), math.sin(yaw)
+    m[:3, :3] = np.array([[c, -s, 0], [s, c, 0], [0, 0, 1]]) @ np.diag(scale)
+    m[:3, 3] = translation
+    return m
+
+
+def test_the_placement_transform_is_recovered_exactly_from_one_shared_node():
+    """`build_room` fits an asset into a measured box — a yaw and a per-axis scale. One node
+    present in both files pins the whole affine down, and every other node then maps through it."""
+    expected = _yaw_scale(0.7, (1.3, 0.8, 1.1), (2.0, -1.0, 0.4))
+    object_scene = _scene([("Carcass", np.eye(4)),
+                           ("Leaf", trimesh.transformations.translation_matrix([0.5, 0, 0]))])
+    room_scene = _scene([("Carcass", expected),
+                         ("Leaf", expected @ trimesh.transformations.translation_matrix(
+                             [0.5, 0, 0]))])
+    got = sim_assets.placement_transform(object_scene, room_scene, ["Carcass", "Leaf"])
+    assert got is not None
+    assert np.allclose(got, expected, atol=1e-9)
+
+
+def test_no_matchable_node_returns_none_rather_than_guessing():
+    """trimesh renames a duplicated node with a random suffix per load, so an object whose every
+    node was duplicated somewhere in the room has nothing to match on. Placing it anyway would put
+    its colliders where the object is not."""
+    object_scene = _scene([("Leaf_aaaaaa", np.eye(4)), ("Leaf_bbbbbb", np.eye(4))])
+    room_scene = _scene([("Leaf_cccccc", np.eye(4)), ("Leaf_dddddd", np.eye(4))])
+    assert sim_assets.placement_transform(object_scene, room_scene,
+                                          ["Leaf_cccccc", "Leaf_dddddd"]) is None
+
+
+def test_place_carries_colliders_pivots_and_axes_into_the_room(tmp_path):
+    model = sim_assets.load(_write_sidecar(tmp_path, _model_json()))
+    # A quarter turn, no scale, moved across the room: the pivot must arrive rotated, not raw.
+    transform_zup = _yaw_scale(math.pi / 2, (1.0, 1.0, 1.0), (5.0, 1.0, 0.0))
+    transform_yup = np.linalg.inv(sim_assets._A4) @ transform_zup @ sim_assets._A4
+    placed = sim_assets.place(model, transform_yup)
+
+    assert set(placed.links) == {"base_link", "door_leaf"}
+    # origin [0.3, -0.2, 0.05] rotated +90 deg about Z is [0.2, 0.3, 0.05], then translated.
+    assert np.allclose(placed.pivots["door_leaf"], [5.2, 1.3, 0.05], atol=1e-6)
+    # A vertical hinge stays vertical.
+    assert np.allclose(placed.axes["door_leaf"], [0, 0, 1], atol=1e-6)
+    # The friction is the one the recipe's material implies, per link — not one for the room.
+    assert placed.links["base_link"].friction == pytest.approx(0.55)
+    assert placed.links["door_leaf"].friction == pytest.approx(0.30)
+    assert placed.links["door_leaf"].colliders
+
+
+def test_a_derived_mass_scales_with_the_box_but_an_authored_one_does_not(tmp_path):
+    """Occupancy density over a bounding box is a rule, so at a different size it is a different
+    mass. A mass the recipe read off the real object is a fact, and the fit does not change it."""
+    scale = (2.0, 1.0, 1.0)                                   # the room stretched it 2x in X
+    transform_zup = _yaw_scale(0.0, scale, (0, 0, 0))
+    transform_yup = np.linalg.inv(sim_assets._A4) @ transform_zup @ sim_assets._A4
+
+    derived = sim_assets.place(sim_assets.load(
+        _write_sidecar(tmp_path / "d", _model_json())), transform_yup)
+    authored = sim_assets.place(sim_assets.load(
+        _write_sidecar(tmp_path / "a", _model_json(mass_source="authored"))), transform_yup)
+
+    assert derived.links["base_link"].mass == pytest.approx(16.0)
+    assert authored.links["base_link"].mass == pytest.approx(8.0)
+
+
+def test_a_missing_collider_file_drops_the_link_rather_than_emitting_a_ghost(tmp_path):
+    """A body with no collider falls through everything it touches, silently. Dropping the link
+    welds its geometry into the carcass instead, which is wrong in a way you can see."""
+    doc = _model_json()
+    path = _write_sidecar(tmp_path, doc)
+    (tmp_path / "Widget0_door_leaf_col0.obj").unlink()
+    placed = sim_assets.place(sim_assets.load(path), np.eye(4))
+    assert "door_leaf" not in placed.links
+    assert "base_link" in placed.links
+
+
+def test_nodes_are_assigned_to_links_past_the_room_glbs_rename(tmp_path):
+    """The room appends `_<6 hex>` to any node name it has seen before, and longest match wins so
+    a part with its own joint is not swallowed by the link it hangs on."""
+    doc = _model_json()
+    doc["links"].append({"name": "door_leaf_handle", "mass": 0.2, "com": [0, 0, 0],
+                         "inertia": [0.01, 0.01, 0.01, 0, 0, 0], "friction": 0.4,
+                         "restitution": 0.2, "material": "", "visual": "", "colliders": [],
+                         "mass_source": "derived", "inertia_source": "geometry"})
+    model = sim_assets.load(_write_sidecar(tmp_path, doc))
+    owned = sim_assets.assign_nodes(
+        ["Carcass", "door_leaf_a1b2c3", "door_leaf_panel", "door_leaf_handle_ff0011"], model)
+    assert owned["base_link"] == ["Carcass"]
+    assert sorted(owned["door_leaf"]) == ["door_leaf_a1b2c3", "door_leaf_panel"]
+    assert owned["door_leaf_handle"] == ["door_leaf_handle_ff0011"]
+
+
+# ------------------------------------------------------- into the Room package
+
+
+def test_only_this_objects_files_are_carried_into_the_room_package(tmp_path):
+    """A generative object is a bare glb at the top of `reconstruct/`, so every chair in the room
+    shares one `sim/`. Copying the DIRECTORY would put all of them into each object's package."""
+    from litereality_agent.room_ops.export.export_room import copy_sim_sidecar
+
+    shared = tmp_path / "sim"
+    _write_sidecar(shared, _model_json("ChairCluster0"))
+    _write_sidecar(shared, _model_json("ChairCluster1"))
+    (shared / "ChairCluster0.urdf").write_text("<robot/>")
+
+    dest = tmp_path / "package" / "sim"
+    copied = copy_sim_sidecar(shared, dest, "ChairCluster0")
+
+    names = sorted(p.name for p in dest.iterdir())
+    assert copied == len(names)
+    assert "ChairCluster0.physics.json" in names
+    assert "ChairCluster0.urdf" in names
+    assert not any("ChairCluster1" in n for n in names)
+
+
+def test_an_object_with_no_compiled_physics_copies_nothing_and_does_not_raise(tmp_path):
+    """Physics is new; every room exported before it exists without one, and an export that
+    refused those would be an export nobody could run."""
+    from litereality_agent.room_ops.export.export_room import copy_sim_sidecar
+
+    assert copy_sim_sidecar(tmp_path / "absent", tmp_path / "dest", "Table0") == 0
+
+
+def test_sidecar_files_are_named_for_the_object_so_two_cannot_overwrite_each_other(tmp_path):
+    """Both objects have a `base_link`. When they share an output directory — which every
+    generative object does — link-named files meant the second one's geometry replaced the first
+    one's while both physics.json files went on claiming their own volumes, and both objects
+    passed their own gate."""
+    from litereality_agent.models.object_generation.sim import properties
+
+    first = {c["file"] for c in _model_json("ChairCluster0")["links"][0]["colliders"]}
+    second = {c["file"] for c in _model_json("ChairCluster1")["links"][0]["colliders"]}
+    assert not (first & second), "the fixture must exercise distinct names"
+    # And the compiler is what produces them: the stem it builds colliders under carries the
+    # object's name, not just the link's.
+    source = Path(properties.__file__).read_text(encoding="utf-8")
+    assert 'stem = f"{name}_{link}"' in source
+    assert "_colliders(local, stem," in source
+
+
+def test_an_instanced_object_is_placed_from_geometry_when_no_name_survives(tmp_path):
+    """Four chairs from one cluster: every node is renamed for every instance after the first, and
+    a cluster whose own parts repeat has nothing unique inside its own file either. The placement
+    still has a known shape — a yaw and a per-axis scale — so it comes out of the two bounding
+    boxes instead. Rejecting here would have left exactly the objects a room has several of
+    collided by guesswork."""
+    doc = _model_json()
+    doc["bbox"] = [[-0.3, -0.2, 0.0], [0.3, 0.2, 0.9]]
+    model = sim_assets.load(_write_sidecar(tmp_path, doc))
+
+    yaw, scale, translation = 0.6, (1.5, 0.9, 1.2), (3.0, -2.0, 0.1)
+    truth = _yaw_scale(yaw, scale, translation)
+    lo, hi = np.asarray(doc["bbox"][0]), np.asarray(doc["bbox"][1])
+    centre = (lo + hi) / 2.0
+    # The object's own bounding box, carried into the room the way `build_room` carries it.
+    corners = np.array([[x, y, z] for x in (lo[0], hi[0]) for y in (lo[1], hi[1])
+                        for z in (lo[2], hi[2])])
+    world = (corners - centre) @ truth[:3, :3].T + truth[:3, 3]
+    placed_mesh = trimesh.PointCloud(world).convex_hull
+
+    recovered = sim_assets.placement_from_bbox(model, placed_mesh, yaw)
+    assert recovered is not None
+    as_zup = sim_assets._A4 @ recovered @ sim_assets._A4_INV
+    assert np.allclose(as_zup[:3, :3], truth[:3, :3], atol=1e-6)
+    # `truth` maps the asset's CENTRED box, so its translation is the room position of that centre.
+    assert np.allclose(as_zup[:3, :3] @ centre + as_zup[:3, 3], translation, atol=1e-6)
+
+
+def test_a_model_with_no_recorded_bbox_cannot_be_placed_from_geometry(tmp_path):
+    """Without the object's own extent there is no second box to compare against, and inventing
+    one would scale the colliders by whatever the room happened to measure."""
+    doc = _model_json()
+    doc["bbox"] = []
+    model = sim_assets.load(_write_sidecar(tmp_path, doc))
+    box = trimesh.creation.box(extents=(1, 1, 1))
+    assert sim_assets.placement_from_bbox(model, box, 0.0) is None

--- a/tests/test_simulate_stage.py
+++ b/tests/test_simulate_stage.py
@@ -97,3 +97,44 @@ def test_the_shake_is_opt_in_because_it_is_a_measurement_and_costs_minutes(conte
     calls.clear()
     simulate.run(context, {"shake": True})
     assert calls[-1] == "litereality_agent.room_ops.export.mujoco_shake"
+
+
+def _seeded(context: RunContext) -> None:
+    """A scan that has been through `seed` but never authored."""
+    context.seed_room.mkdir(parents=True, exist_ok=True)
+    (context.seed_room / "Room.py").write_text("SHELL = {}\n")
+    preview = context.seed_room.parent / "room_preview"
+    preview.mkdir(parents=True, exist_ok=True)
+    (preview / "Room.glb").write_bytes(b"glTF")
+
+
+def test_from_seed_exports_the_unauthored_room(context, monkeypatch):
+    """Authoring adds materials, wall fixtures and clutter — appearance. The physical scene is
+    complete without it: the shell with its openings cut out, and every reconstructed object in its
+    measured box carrying the physics its own build compiled."""
+    _seeded(context)
+    seen: list[list] = []
+
+    def record(_context, module, args=(), *, log_name=None):
+        seen.append([str(a) for a in args])
+        out = simulate.scene_dir(context, seed=True)
+        out.mkdir(parents=True, exist_ok=True)
+        (out / "scene.xml").write_text("<mujoco/>")
+        (out / "export_report.json").write_text('{"from_sidecar": ["Table0"]}')
+        return 0, out / "log"
+
+    monkeypatch.setattr(simulate, "run_module", record)
+    result = simulate.run(context, {"from_seed": True})
+
+    assert result.status is StageStatus.COMPLETED
+    assert result.details["source"] == "seed"
+    assert str(context.seed_room) in seen[0]
+    # ...and it goes somewhere of its own, so an authored export is not overwritten by one that
+    # deliberately has no authoring in it.
+    assert result.details["scene"].endswith("mujoco_seed/scene.xml")
+
+
+def test_from_seed_asks_for_seed_rather_than_author_when_the_room_is_missing(context):
+    result = simulate.run(context, {"from_seed": True})
+    assert result.status is StageStatus.FAILED
+    assert "seed" in result.error and "author" not in result.error

--- a/tests/test_simulate_stage.py
+++ b/tests/test_simulate_stage.py
@@ -1,0 +1,99 @@
+"""The `simulate` stage — the room becoming a MuJoCo scene, and saying what it had to invent."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from litereality_agent.pipeline import simulate
+from litereality_agent.pipeline.context import RunContext
+from litereality_agent.pipeline.result import StageStatus
+from litereality_agent.settings import LiteRealitySettings
+
+
+@pytest.fixture
+def context(tmp_path: Path) -> RunContext:
+    settings = LiteRealitySettings(repo_root=tmp_path, output_root=tmp_path / "run")
+    return RunContext("scan", tmp_path / "capture", tmp_path / "run" / "scan",
+                      tmp_path / "run", settings=settings)
+
+
+def _built_room(context: RunContext) -> None:
+    context.authored_room.mkdir(parents=True, exist_ok=True)
+    (context.authored_room / "Room.py").write_text("SHELL = {}\n")
+    context.preview_dir.mkdir(parents=True, exist_ok=True)
+    (context.preview_dir / "Room.glb").write_bytes(b"glTF")
+
+
+def _exports(context: RunContext, report: dict):
+    """Stand in for the exporter: write the scene and the report it would have written."""
+    def fake(_context, _module, _args=(), *, log_name=None):
+        out = simulate.scene_dir(context)
+        out.mkdir(parents=True, exist_ok=True)
+        (out / "scene.xml").write_text("<mujoco/>")
+        (out / "export_report.json").write_text(json.dumps(report))
+        return 0, out / "log"
+    return fake
+
+
+def test_it_refuses_a_room_that_was_never_built(context, monkeypatch):
+    """The export reads `Room.glb` and `room_layout.json`; without them it would fail deep inside
+    trimesh with something that does not name the missing step."""
+    context.authored_room.mkdir(parents=True, exist_ok=True)
+    (context.authored_room / "Room.py").write_text("SHELL = {}\n")
+    result = simulate.run(context, {})
+    assert result.status is StageStatus.FAILED
+    assert "publish" in result.error
+
+
+def test_objects_without_compiled_physics_are_reported_not_buried(context, monkeypatch):
+    """Falling back to the category table is a worse scene, not a broken one — but it IS the
+    difference between physics that came from the assets and physics invented at export time."""
+    _built_room(context)
+    monkeypatch.setattr(simulate, "run_module",
+                        _exports(context, {"from_sidecar": ["Table0"],
+                                           "no_sidecar": ["Mug0", "Cable0"],
+                                           "placement_rejected": ["Chair1: colliders land 0.4 m"],
+                                           "structure": 12, "free": 4, "attached": 2,
+                                           "articulated": 1, "colliders": 40}))
+    result = simulate.run(context, {})
+    assert result.status is StageStatus.COMPLETED
+    assert result.details["from_sidecar"] == 1
+    joined = " ".join(result.warnings)
+    assert "no compiled physics" in joined and "Mug0" in joined
+    assert "rejected as mis-placed" in joined
+
+
+def test_a_clean_export_warns_about_nothing(context, monkeypatch):
+    _built_room(context)
+    monkeypatch.setattr(simulate, "run_module",
+                        _exports(context, {"from_sidecar": ["Table0", "Chair0"],
+                                           "structure": 12, "free": 4, "attached": 2,
+                                           "articulated": 1, "colliders": 40}))
+    result = simulate.run(context, {})
+    assert result.status is StageStatus.COMPLETED
+    assert result.warnings == []
+    assert simulate.complete(context)
+
+
+def test_the_shake_is_opt_in_because_it_is_a_measurement_and_costs_minutes(context, monkeypatch):
+    _built_room(context)
+    calls: list[str] = []
+
+    def record(_context, module, args=(), *, log_name=None):
+        calls.append(module)
+        out = simulate.scene_dir(context)
+        out.mkdir(parents=True, exist_ok=True)
+        (out / "scene.xml").write_text("<mujoco/>")
+        (out / "export_report.json").write_text("{}")
+        return 0, out / "log"
+
+    monkeypatch.setattr(simulate, "run_module", record)
+    simulate.run(context, {})
+    assert calls == ["litereality_agent.room_ops.export.mujoco_scene"]
+
+    calls.clear()
+    simulate.run(context, {"shake": True})
+    assert calls[-1] == "litereality_agent.room_ops.export.mujoco_shake"


### PR DESCRIPTION
**WIP — not ready to merge.** Opening it now so the approach and the measurements are visible. See *Known gaps* at the bottom for what is still open.

`Room.glb` is a picture of a room: one file, everything baked in, no notion of what is furniture and what is wall, no mass, no joints. This turns it into a MuJoCo scene of **bodies** — structure as exact boxes from the `SHELL` with the openings cut out, free bodies for the things that can be knocked over, static geometry for what is fixed to the fabric, and a hinge or slide for every part a build recipe said could move.

## Where the physics comes from

The point of this PR is that **nothing invents a physical number the assets already state**. Since #42 every generated object leaves a `sim/<name>.physics.json` beside its GLB — mass split across links by volume, inertia, per-material friction, convex colliders, joint axes, pivots and limits — compiled from the mesh the recipe actually built and gated by a solver before it was ever placed in a room. The room export now reads that instead of re-deriving everything from a category table at the last moment:

- the **pivot** of a hinge is the one `object.py` placed, not one inferred from the shape of the leaf;
- **mass** is the object's own, so a desk's lift top weighs 16.7 kg instead of the whole desk weighing 0.14 kg, which is what a category table produced for Office-Elliott's `Table1` — a desk lighter than the mug on it;
- **friction** is per material, per link: 0.42 steel, 0.30 glazing, 0.55 wood, rather than one number for the building;
- **colliders** are already decomposed, so they are read rather than recomputed.

An object is *fitted* into its RoomPlan box — a yaw and a per-axis scale — so all of that travels through one affine, recovered exactly as `T_room(node) · T_object(node)⁻¹` from any node in both files. trimesh renames duplicated nodes on every load, so an object the room places more than once (four chairs from one cluster) has no name left to match; those solve the same affine from the two bounding boxes and the SHELL's yaw. Either way the result is **checked** — placed colliders must land on the placed mesh — and anything that fails, or has no sidecar, falls back to the old path and is named in `export_report.json`.

## Making it stand still

An exported scene used to come apart the moment it was stepped. Office-Elliott: 13 of 25 free bodies moved, 13 867 mm over 5 s, worst 3.1 m. Three causes, all here rather than in MuJoCo.

**Collide the parts, not their union.** A shelving unit is five boards, each already convex. Concatenating them and handing CoACD one carcass makes it *fill* the thing: `Shelving1` came back as four hulls, one 2.4 m tall with the shelves solid inside it, so six props standing on those shelves started 200 mm **inside** their own support and were ejected metres.

**The collider budget used the wrong volume.** `DENSITY` is kg per m³ of *bounding box* — it says so where it is defined — and `_part_budget` multiplied it by *mesh* volume, so anything hollow weighed nothing and got the minimum four hulls.

**Floor-standing furniture is scenery.** `rests_on` is only ever written by `group_fixture`, so furniture that came from the scan carries neither it nor `attached_to`; `Table0` was 27.8 kg on a free joint for that reason, while the identical `Table1` was static purely by accident because it has a lift top. Chairs and stools are deliberately *not* pinned.

```
as before               45 deep overlaps   13/25 moved >10 mm   13867 mm
+ scenery pinned        41                 13/24                12349 mm
+ part-wise colliders   12                  6/24                  350 mm
```

## Does it blow up?

`scripts/simready/stability.py` — 30 s × 8 randomised resets per scene, checking MuJoCo's own warning counters, peak `|qacc|`, penetration at t=0, and whether anything leaves the building.

| room | warnings | escaped | starts interpenetrating |
|---|---|---|---|
| fallside-kitchen | none | none | — **PASS** |
| Office-Elliott | none | none | `Chair0` 28 mm into `Table0` |
| fallside-office | none | none | `Chair2` 53 mm into `Table1` |
| MIL-Meeting | none | none | `Chair3` 44 mm into `Window1` |

No `BADQACC`/`BADQPOS`/`BADQVEL`, no dropped contacts, no NaN, nothing left the room in 32 runs. **They do not blow up.** But three of four begin with a chair pressed into a table, which is stored energy.

Voxelising visual meshes against colliders splits that in two: MIL-Meeting's chair overlaps its window by 474 cm³ of *real geometry* — it was scanned there, and belongs in layout repair. fallside-office's chair overlaps its table by 7 cm³ of geometry and 83 cm³ of *collider*, twelve times more, because `_part_budget` gives a 7 kg chair eight hulls and eight hulls fill the gap between seat and back. That one is ours.

## Also fixed

A silent data-loss bug in #42: a generative object is a bare glb at the top of `reconstruct/`, so `sim/` is **shared** by every TRELLIS chair. Both chairs have a `base_link` and both wrote `base_link_col0.obj`. `ChairCluster0.physics.json` recorded eight colliders whose volumes were its own and whose files held ChairCluster1's geometry — and nothing reports it, because each object passed its own gate before the other overwrote it.

## Known gaps

- **Chair collider resolution.** Eight hulls is too few for a chair; measuring 8/16/24/32 before changing the number.
- **Scanned interpenetration** (MIL-Meeting `Chair3`) is untouched and belongs upstream in layout repair.
- The **authoring brief** that writes `rests_on`/`attached_to` and the small objects is deliberately *not* in this PR — separate piece of work. Without it the exporter falls back to inferring support from geometry.
- `build_room.py`'s `group_fixture(rests_on=, attached_to=)` is kept because ten authored rooms in `run/` already call it that way and raise `TypeError` on the old signature.
- Validated on four scans (Office-Elliott, fallside-kitchen, fallside-office, MIL-Meeting). 613 tests pass, ruff clean.
