### PR TITLE
The `open` authoring profile: GPT-6's freedom on the infra's evidence, materials and gate

### DIFF
--- a/src/litereality_agent/agent/author.py
+++ b/src/litereality_agent/agent/author.py
@@ -526,11 +526,13 @@ async def run(room: Path, surface_ref: Path, scan: Path, model: str, max_turns: 
     evidence: Path | None = None
     if profile == "open":
         from litereality_agent.agent import evidence_pack
-        evidence = evidence_pack.build(room.parent, Path(scan), surface_ref)
+        # room = <scene>/realism_authoring/room, so the scene package is two levels up.
+        evidence = evidence_pack.build(room.parent, Path(scan), surface_ref, scene_dir=room.parents[1])
         if provider is None and not (os.environ.get("LR_AUTHOR_PROVIDER") or os.environ.get("LR_AGENT_PROVIDER")):
             provider = "codex"       # the brief was written for, and measured on, gpt-6 via Codex
     fills = dict(stitch_lines=stitch_lines, scan=scan, surface_list=", ".join(surfaces), rhythm=RHYTHM,
-                 evidence=str(evidence) if evidence else "", n_frames=_n_frames(Path(scan)),
+                 evidence=str(evidence) if evidence else "",
+                 n_frames=_n_frames(evidence / "scan" if evidence else Path(scan)),
                  python=sys.executable, blender=_blender_bin(),
                  scratch=str(scratch_at) if scratch_at else str(room.parent / "_scratch"))
     prompt = PROFILES.get(profile, PROMPT).format(**fills)

--- a/src/litereality_agent/agent/author.py
+++ b/src/litereality_agent/agent/author.py
@@ -327,8 +327,14 @@ good spread of frames before job 4, and again while you work through it.
 TOOLS — use them, they are not decoration:
 - `fetch_material(query, name, color_hex, pattern_strength)` — real Poly Haven PBR (diffuse +
   roughness + normal) LAB-recoloured to your measured colour, saved into `materials/` +
-  `textures.json` with a wiring snippet. Prefer it over flat colour for any patterned surface. The
-  code-native alternative for carpet/fabric/plaster/tile/brick/wood:
+  `textures.json` with a wiring snippet.
+  CALL IT. Every surface with any visible texture — carpet, fabric, wood, tile, brick, plaster
+  grain, painted blockwork — gets a fetched PBR set, not a flat RGB and not a shell command that
+  writes one. Only genuinely flat modern paint may stay a plain colour, and you must be able to
+  say WHY from the photograph. This is a tool call: it downloads real captured maps and returns
+  the three paths plus the code to wire them. You cannot do it with `sed`, and a room whose
+  surfaces are all flat colours is the single biggest gap between this render and the photo.
+  The code-native alternative, for procedural weave/grain only:
   `from litereality_agent.room_ops.procedural_materials import make`.
 - `render(target)` — render `Room.py` for 'room' or a wall, paired with the real photo. READ the
   returned PNG with your own eyes and correct what is wrong. Render after LIGHT, and again after

--- a/src/litereality_agent/agent/author.py
+++ b/src/litereality_agent/agent/author.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
+import sys
 import time
 from pathlib import Path
 
@@ -354,7 +356,120 @@ fixtures, and a list of every small object with what it rests on or is attached 
 """
 
 
-PROFILES = {"base": PROMPT, "detail": DETAIL_PROMPT, "simulation": SIMULATION_PROMPT}
+# The `open` profile — a BRIEF, not a script. Written after measuring what a one-shot GPT-6 run did
+# with nothing but the raw scan and a page of intent: it reviewed every photograph first, measured
+# desk and shelf heights from the depth maps, triangulated chair positions from silhouettes,
+# rebuilt after its own intersection/contact audit, and came back closer to the photos on layout
+# and fixtures than our scripted pass — which had told it what to read, in what order, and what
+# not to touch. The three profiles above prescribe a cadence because a step-budgeted model on
+# Claude Code banked cheap calls and edited at the end; that is a harness problem, not a modelling
+# one, and it is solved here by GATES on the result rather than rules on the process. What the
+# infra still contributes, and the brief leans on: the pipeline's reconstructed and articulated
+# assets, `fetch_material`'s photo-matched PBR library, the render-vs-photo tool, and the
+# validation gate. What the model gets that it did not have: the evidence pack (raw frames, depth,
+# point cloud, RoomPlan usdz, stitches) with measurement helpers, and the freedom to use them.
+OPEN_PROMPT = """\
+You are rebuilding a REAL room from a phone scan, alone and self-paced, and the result has to
+pass two tests: a person who was in the room would recognise it from your renders, and a physics
+engine could pick it up and simulate it without being told anything else.
+
+THE ROOM. `Room.py` in your working directory builds it: a deterministic assembler plus a `SHELL`
+dict (walls, openings, floor/ceiling heights, one measured box per piece of furniture) and the
+pipeline's reconstructed assets — some are neural meshes of the actual objects, some are
+procedural and ARTICULATED (doors, windows, lift tops with real joints). Read `Room.md` first: it
+explains the helper API, `group_fixture(name, category, parts, rests_on=…, attached_to=…)`, and
+how materials are assigned. Build it once before you change anything, and render it from a few
+capture cameras so you know your starting point.
+
+THE EVIDENCE — `{evidence}/` beside the room. READ ITS README FIRST; it states every data format
+and the coordinate conventions once.
+  contact_sheets/   every photograph, upright. Look at ALL of them before you build anything and
+                    write down what the room contains — the scan's boxes say where the big pieces
+                    are; the photographs say what is actually there (the coat on the door, the
+                    heater under the desk, what is on each shelf).
+  stitches/         one head-on image per wall/floor/ceiling: the material references.
+  scan/             the raw capture: {n_frames} RGB frames with poses and intrinsics, LiDAR depth
+                    and confidence per frame, the point cloud, RoomPlan's room.usdz.
+  helpers/          plain python you import in your own scripts (`sys.path.insert(0, "{evidence}/helpers")`):
+                    `measure.probe_depth` (the 3D point under a photo pixel), `measure.triangulate`
+                    (a feature clicked in 2+ photos), `measure.height_profile` (the horizontal
+                    surfaces inside a footprint — desk and shelf heights), `measure.pcd_slice` (a
+                    plan of everything at one height), `rectify.rectify_region` (a screen, board or
+                    picture lifted out of a photo as a texture), and `arkit_cameras` (inside
+                    Blender: the capture cameras, already present in Room.py as cam_NNNNN).
+Measure, don't guess: a desk height, a shelf elevation, a table diameter, a monitor width are all
+in the depth maps and the cloud. Where LiDAR fails (dark fabric, glass, thin legs) triangulate
+from two photographs.
+
+WHAT A FINISHED ROOM HAS. Everything below is an observation to make from the photographs, not a
+thing to invent — author what THIS room contains.
+• The shell right: walls, openings, floor and ceiling heights corrected where the scan is clearly
+  wrong against the photos and the measurements. Conservative and metric.
+• Every surface with the material the photographs show. Use `fetch_material` for anything with
+  visible texture — carpet, wood, tile, fabric, brick, plaster grain, acoustic tile: it returns
+  a REAL captured PBR set (diffuse/roughness/normal) recoloured to your measured colour, and it
+  is the single biggest difference between a render and a photograph. Flat colour only for
+  genuinely flat modern paint, and you should be able to say why from the photo.
+• The real light: the luminaires you can see (geometry AND a Blender light, matched on colour
+  temperature and intensity) and the window as a light if it is one. Render and look — a first
+  guess at light is usually a stop out.
+• The fixtures the scan cannot see: sockets, switches, trunking, radiators and heaters, boards,
+  shelves and what sits on them, blinds, hooks and what hangs on them, the air conditioner,
+  cables. Multi-part, at their measured positions, never flush slabs; you may lift screens,
+  boards and pictures out of the photographs with `rectify_region`.
+• The small objects on every placeable surface, in roughly the positions the photographs show,
+  at real sizes, not tidied — axis-alignment is the giveaway of a generated room.
+• The pipeline's assets kept: do not delete or flatten an articulated object or replace a
+  reconstructed mesh with a box. You MAY correct a furniture box's position, size or yaw when
+  your measurements show the scan got it wrong — say so in your summary with the measurement.
+
+SIMULATION READINESS is not an extra. Every object you add is ONE named group with a declared
+support — `rests_on="Table1"` / `rests_on="Floor0"` / `attached_to="Wall3"` — and the claim must be
+true in the geometry: the underside on the surface, read from the support's top, not placed by
+eye. Nothing interpenetrates anything.
+
+THE GATE. Before you finish, build the room and run
+    {python} -m litereality_agent.pipeline.room_qc.validate --room .
+It checks every support claim against the geometry, the real-mesh contacts, and that the
+articulated objects survived. Fix what it reports and run it again; the harness runs it once
+more after you and records the verdict. A room that fails the gate is not finished.
+
+TOOLS. `fetch_material(query, name, color_hex, pattern_strength)`; `render(target)` for 'room' or
+a wall, paired with the real photo — look at it; `critic(images, goal)`; `select_views(target)`;
+`check_collisions()`. Beyond the tools you have a shell, Blender
+(`{blender}`, headless: `blender -b --python script.py`) and python with numpy/PIL/open3d/
+trimesh; write whatever scripts you need under `{scratch}` — measurement, comparison, contact
+sheets of your own renders next to the photographs. Everything that changes the room goes into
+`Room.py` (and its `materials/`), so a fresh rebuild reproduces it; helper scripts do not.
+
+HOW YOU WORK IS YOURS to decide, with two conditions: `Room.py` must compile after every save, and
+save as you go — a run that stops keeps only what is on disk. Finish with a summary: what you
+measured and what it changed, the material per surface, the lights, the fixtures and objects with
+their supports, the gate's verdict, and what you could not do.
+"""
+
+PROFILES = {"base": PROMPT, "detail": DETAIL_PROMPT, "simulation": SIMULATION_PROMPT, "open": OPEN_PROMPT}
+
+# Budgets the open brief needs: the one-shot run that motivated it took 69 tool calls to a finished,
+# self-audited room, and our scripted pass was cut at 56 by a quota. 300 with a 400-turn backstop
+# is room to measure, build, render, gate and fix; the profile does not micromanage the cadence, so
+# it must not starve it either.
+OPEN_STEP_BUDGET = 300
+OPEN_MAX_TURNS = 400
+
+
+def _n_frames(scan: Path) -> int:
+    try:
+        return sum(1 for f in os.listdir(scan) if f.startswith("frame_") and f.endswith(".json"))
+    except OSError:
+        return 0
+
+
+def _blender_bin() -> str:
+    d = os.environ.get("LITEREALITY_BLENDER", "")
+    if d:
+        return str(Path(d) / "blender")
+    return shutil.which("blender") or "blender"
 
 
 def room_compiles(room: Path) -> str:
@@ -403,11 +518,22 @@ async def run(room: Path, surface_ref: Path, scan: Path, model: str, max_turns: 
     surfaces = surfaces_for(room)
     stitches = [surface_ref / f"{s}_stitched.jpg" for s in surfaces]
     stitch_lines = "\n".join(f"  - {s} (head-on): {p}" for s, p in zip(surfaces, stitches) if p.is_file())
-    prompt = PROFILES.get(profile, PROMPT).format(stitch_lines=stitch_lines, scan=scan,
-                                                  surface_list=", ".join(surfaces), rhythm=RHYTHM)
     # Images the model MAKES to look at are evidence; give it somewhere durable to put them.
     from litereality_agent.agent import scratch
     scratch_at = scratch.bind(near=room)
+    # The open brief hands the model the whole capture plus measurement helpers, packed once
+    # beside the room (see evidence_pack). The other profiles keep to stitches + raw frames.
+    evidence: Path | None = None
+    if profile == "open":
+        from litereality_agent.agent import evidence_pack
+        evidence = evidence_pack.build(room.parent, Path(scan), surface_ref)
+        if provider is None and not (os.environ.get("LR_AUTHOR_PROVIDER") or os.environ.get("LR_AGENT_PROVIDER")):
+            provider = "codex"       # the brief was written for, and measured on, gpt-6 via Codex
+    fills = dict(stitch_lines=stitch_lines, scan=scan, surface_list=", ".join(surfaces), rhythm=RHYTHM,
+                 evidence=str(evidence) if evidence else "", n_frames=_n_frames(Path(scan)),
+                 python=sys.executable, blender=_blender_bin(),
+                 scratch=str(scratch_at) if scratch_at else str(room.parent / "_scratch"))
+    prompt = PROFILES.get(profile, PROMPT).format(**fills)
     prompt += scratch.prompt_line()
     from litereality_agent.agent.tool_narration import describe_tools_line
     prompt += describe_tools_line()
@@ -419,6 +545,9 @@ async def run(room: Path, surface_ref: Path, scan: Path, model: str, max_turns: 
             str(os.path.realpath(surface_ref))}
     if scratch_at is not None:
         dirs.add(str(scratch_at))
+    if evidence is not None:
+        dirs.add(str(evidence))
+        dirs.add(str(os.path.realpath(scan)))
     # Step budget: a graceful landing at `step_budget` tool-calls (wind-down then stop). The Claude
     # Code harness enforces it with a PreToolUse hook; Codex has no such hook and degrades to a hard
     # stop (`providers.describe` says which you got). `--max-turns` is the backstop below it.
@@ -461,8 +590,13 @@ async def run(room: Path, surface_ref: Path, scan: Path, model: str, max_turns: 
     tr = AgentTrace("author", room=room, scan=os.environ.get("LITEREALITY_SCAN"))
     # The prompt is the other half of "what happened": a tool choice only makes sense
     # against what the session was actually asked to do, and profiles change that.
-    tr.start(model=model, room=str(room), profile=profile, stitches=len(present),
-             max_turns=max_turns, scratch=str(scratch_at) if scratch_at else None, prompt=prompt)
+    # `model` is the ROLE's Claude-vocabulary name; what actually ran is the harness's business
+    # (Codex takes its own). Record both, or a gpt-6 session is filed under claude-opus-5 — which is
+    # exactly what happened to the Office_room run this profile was measured against.
+    used = harness.effective_model(spec) if hasattr(harness, "effective_model") else model
+    tr.start(model=used, role_model=model, room=str(room), profile=profile, stitches=len(present),
+             max_turns=max_turns, scratch=str(scratch_at) if scratch_at else None, prompt=prompt,
+             evidence=str(evidence) if evidence else None, provider=harness.name)
     # Kept OUTSIDE the room: the room dir is copied and scanned wholesale downstream, and a
     # stray second Room-ish file in it is a trap.
     last_good = room.parent / ".room_checkpoint.py"
@@ -510,6 +644,18 @@ async def run(room: Path, surface_ref: Path, scan: Path, model: str, max_turns: 
             stopped = m.stopped
             if m.is_error:
                 terminal_error = result_text or "provider reported a terminal error"
+            # The harness's own transcript, kept with ours: the normalised trace records what
+            # it could see, and on Codex that is not everything (file reads are internal, and
+            # the images shown to the model only appear in the rollout).
+            rollout = (m.raw or {}).get("rollout") if isinstance(m.raw, dict) else None
+            if rollout and tr.ok and tr.path:
+                try:
+                    dst = tr.path.parent / f"{tr.path.stem}.codex_rollout.jsonl"
+                    dst.write_bytes(Path(rollout).read_bytes())
+                    print(f"   codex rollout → {dst}", flush=True)
+                    tr.think(f"[codex rollout] {dst}")
+                except OSError as exc:
+                    print(f"   ⚠ could not keep the codex rollout ({exc})", flush=True)
     except Exception as exc:  # noqa: BLE001 — including the SDK's turn-cap Exception
         # Running out of turns is not a failed run. `Room.py` is edited IN PLACE, so by this
         # point the session's work is already on disk; raising here threw it away, because

--- a/src/litereality_agent/agent/author.py
+++ b/src/litereality_agent/agent/author.py
@@ -230,7 +230,125 @@ When done, summarise per wall: each fixture, its GROUP NAME (e.g. `Radiator0`), 
 it from, and note which walls you render-verified.
 """
 
-PROFILES = {"base": PROMPT, "detail": DETAIL_PROMPT}
+
+# "simulation" profile — the room as a place, not a shell: real light, real clutter, and every
+# object stating what holds it up. The base profile stops at materials and wall fixtures, which is
+# what makes a render read as a MODEL of a room rather than a room: the surfaces are right and the
+# room is empty. A desk with nothing on it is the single strongest cue that a scene is synthetic,
+# and a scene whose objects do not say what they rest on cannot be simulated no matter how good it
+# looks. Both are asked for here, explicitly, because a self-paced model under a budget will always
+# spend it on the surfaces it was told about first.
+SIMULATION_PROMPT = """\
+You are rebuilding a REAL room as an editable Python program, self-paced (no fixed steps), and the
+bar THIS run is a room a person would believe they had walked into — and that a physics engine
+could pick up and simulate without being told anything else.
+
+{rhythm}
+
+The room is `Room.py` in your working directory: a builder + a `SHELL` dict (walls, openings,
+object boxes). FIRST Read `Room.md` and `Room.py` IN FULL to learn the helper API. Then edit
+`Room.py` IN PLACE. LOOK AT THE PHOTOGRAPHS PROPERLY — read the head-on stitches AND a good spread
+of the raw frames, and keep going back to them. Everything below is an observation to be made from
+those images, not a thing to be invented: author what THIS room contains, not what a room like it
+usually contains.
+
+FOUR JOBS, IN THIS ORDER. Do not start one before the previous is done.
+
+1) SHELL STRUCTURE + MATERIALS — the foundation.
+   • Fix clear scan errors in `SHELL` first: a missing or spurious wall, wrong endpoints, a
+     door/window at the wrong offset/width/sill, a wrong floor/ceiling height. Conservative,
+     evidence-based, metric. Do NOT move or resize the furniture object boxes.
+   • Then every surface ({surface_list}) in the order FLOOR -> WALLS -> CEILING: base colour,
+     finish, pattern. Save after each. Use `fetch_material` or the procedural materials for
+     anything patterned; flat colour only for plain paint.
+
+2) LIGHT. A room lit by a default lamp reads as a render of a room no matter how good the
+   materials are, and every material judgement you make afterwards is made under the wrong light.
+   • Put the REAL luminaires in, where the photos show them: ceiling panels, downlights, pendants,
+     desk and floor lamps, under-cabinet strips. Geometry AND an actual Blender light — the fitting
+     you can see, and the light it casts.
+   • Match what the photographs show: colour temperature (warm domestic ~2700-3000K, office
+     fluorescent/LED ~4000-5000K, daylight through a window ~6500K), rough intensity, and the
+     direction the shadows in the photo tell you. If a window is the dominant source, light it as a
+     window — the frames will show you whether it is blown out or soft.
+   • Emissive material on the visible fitting so it reads as ON in a render if the photo shows it on.
+   • `render` after the lighting pass and LOOK at it against the photo. Light is the one thing
+     where your first guess is usually a stop or two out, and it is cheap to correct.
+
+3) FIXTURES the scan missed but the photos show — sockets, switches, trunking, boards, signs,
+   radiators, shelves, skirting, ceiling vents, rugs, blinds/curtains, door furniture. Simple
+   procedural geometry flush to the wall, anchored to the SHELL's opening offsets and wall lengths.
+   Never over a Door/Window opening.
+
+4) THE SMALL OBJECTS. This is the job that decides whether the room is believable, and it is the
+   one you must NOT run out of budget before reaching — start it while you still have room to work.
+   An empty desk is the loudest possible statement that a scene is synthetic. Real rooms are full
+   of small, specific, slightly untidy things, and the photographs are full of them: mugs, glasses,
+   bottles, papers, folders, notebooks, pens and pen pots, books, laptops, monitors, keyboards,
+   mice, cables and chargers, phones, boxes, bins, bags, plants and pots, cushions, throws, remote
+   controls, tissue boxes, jars, bowls, fruit, cleaning bottles, chopping boards, kettles, toasters.
+   • Work SURFACE BY SURFACE. For each placeable surface in the room (the desks, tables, counters,
+     shelves, cabinet tops) find it in the photos and author WHAT IS ACTUALLY ON IT, in roughly the
+     positions the photos show.
+   • Build them as small multi-part procedural geometry — a mug is a cylinder plus a handle, a
+     laptop is a base plus a screen at an angle, a plant is a pot plus foliage. They are small in
+     frame, so simple honest shapes at the right SIZE, COLOUR and POSITION beat detailed shapes at
+     the wrong ones. Metric: a mug is ~8 cm across and ~10 cm tall, an A4 sheet is 210x297 mm, a
+     laptop is ~32 cm wide.
+   • Do not tidy the room. Things sit at angles, papers overlap, cables trail, a chair is pushed
+     out. Alignment to the axes is the giveaway of a generated scene — rotate them.
+   • Do not invent a prop you cannot point at in a photograph. A believable room is a SPECIFIC
+     room; generic clutter is just a different kind of wrong.
+
+SIMULATION READINESS — REQUIRED FOR EVERY OBJECT YOU ADD, NOT AN EXTRA.
+The room has to be something a physics engine can accept, and that needs two things from you:
+• GROUP each object as ONE unit with `group_fixture(name, category, parts, rests_on=..., attached_to=...)`
+  (near the collection helpers in `Room.py`). Collect the parts of ONE object into a list and pass
+  them. Name them like the furniture handles — `Mug0`, `Laptop0`, `Plant0`, `Radiator0`, `Lamp0`
+  (increment per instance). A loose pile of boxes is not an object.
+• STATE WHAT HOLDS IT UP. `rests_on="Table0"` for anything standing on a surface, `rests_on="Floor0"`
+  for anything on the floor, `attached_to="Wall3"` (or `"Ceiling0"`) for anything fixed to the
+  structure. Every single added object gets one or the other — no exceptions, no guesses left
+  implicit. It is written into the object and comes back out in `room_layout.json`, which is what a
+  simulator reads.
+• AND MAKE IT TRUE GEOMETRICALLY. An object that says it rests on `Table0` must actually have its
+  underside ON that table's top surface — not 2 cm above it, not sunk 1 cm into it. Read the
+  table's top from the SHELL / the object's own bbox and place the prop from that number rather
+  than by eye. A prop that floats is a prop that will fall on the first simulated frame, and a prop
+  that intersects is one the engine will fire across the room.
+• Nothing may interpenetrate anything else. Use `check_collisions` to verify, and fix what it
+  reports.
+
+The DECISIVE references are the HEAD-ON STITCHES (each shows one surface square-on). Read every one:
+{stitch_lines}
+The raw frames in {scan} are where the SMALL OBJECTS are legible — the stitches flatten them. Read a
+good spread of frames before job 4, and again while you work through it.
+
+TOOLS — use them, they are not decoration:
+- `fetch_material(query, name, color_hex, pattern_strength)` — real Poly Haven PBR (diffuse +
+  roughness + normal) LAB-recoloured to your measured colour, saved into `materials/` +
+  `textures.json` with a wiring snippet. Prefer it over flat colour for any patterned surface. The
+  code-native alternative for carpet/fabric/plaster/tile/brick/wood:
+  `from litereality_agent.room_ops.procedural_materials import make`.
+- `render(target)` — render `Room.py` for 'room' or a wall, paired with the real photo. READ the
+  returned PNG with your own eyes and correct what is wrong. Render after LIGHT, and again after
+  the props are in.
+- `critic(images, goal)` — a strict second opinion when you want one.
+- `select_views(target)` — best frames for a target.
+- `check_collisions()` — REQUIRED once the props are in. Nothing may interpenetrate.
+
+Constraints:
+- Edit ONLY `Room.py`; it MUST stay valid Python that compiles. You MAY correct SHELL structure
+  (walls, openings, floor/ceiling height) conservatively. Do NOT move or resize the furniture
+  object boxes (Table*/Chair*/reconstructed objects) — those are measured and already corrected.
+- Everything in CODE, so a fresh rebuild reproduces it exactly.
+
+Finish with a summary: the material per surface, the lights (type, colour temperature, where), the
+fixtures, and a list of every small object with what it rests on or is attached to.
+"""
+
+
+PROFILES = {"base": PROMPT, "detail": DETAIL_PROMPT, "simulation": SIMULATION_PROMPT}
 
 
 def room_compiles(room: Path) -> str:

--- a/src/litereality_agent/agent/evidence_pack.py
+++ b/src/litereality_agent/agent/evidence_pack.py
@@ -148,8 +148,8 @@ def build(authoring_root: Path, scan_dir: Path, surface_ref: Path | None, *, she
         try:
             import sys
             sys.path.insert(0, str(helpers))
-            from read_scan import Scan  # type: ignore
             import contact_sheets  # type: ignore
+            from read_scan import Scan  # type: ignore
             contact_sheets.build(Scan(str(scan_dir)), str(pack / "contact_sheets"))
             shutil.rmtree(helpers / "__pycache__", ignore_errors=True)
         except Exception as exc:  # noqa: BLE001 — sheets are a convenience, never a reason to fail

--- a/src/litereality_agent/agent/evidence_pack.py
+++ b/src/litereality_agent/agent/evidence_pack.py
@@ -20,6 +20,7 @@ not a symlink, so a run directory stays self-describing after the package moves 
 """
 from __future__ import annotations
 
+import json
 import os
 import shutil
 from pathlib import Path
@@ -67,14 +68,67 @@ Every photograph, upright, numbered — look at all of them before building anyt
 """
 
 
+def has_capture(d: Path) -> bool:
+    """A raw RoomPlan capture: frame_NNNNN.jpg + .json pairs (depth, cloud and usdz beside them)."""
+    try:
+        return any(f.startswith("frame_") and f.endswith(".json") for f in os.listdir(d))
+    except OSError:
+        return False
+
+
+def resolve_scan(scan_dir: Path, scene_dir: Path | None = None) -> Path:
+    """The RAW capture for a scene — which is not always what the pipeline calls the capture.
+
+    `scene.json`'s `capture` link can point at the usdz-only input dir (Office_room's does:
+    `input/usdz_files`, one file), and `input/rgbd/` is the pipeline's own split layout
+    (image/ depth/ intrinsic/ extrinsic/), not the frame_NNNNN.* the kit reads. The raw scan
+    lives under the scans root recorded in scene.json (`roots.scans/<scan>`), or wherever
+    `LITEREALITY_SCAN` points. A pack without frames is worse than no pack — the brief promises
+    depth and a cloud — so this raises rather than linking whatever it was handed."""
+    tried = []
+    for cand in _scan_candidates(Path(scan_dir), scene_dir):
+        tried.append(str(cand))
+        if has_capture(cand):
+            return cand
+    raise FileNotFoundError(
+        "no raw capture (frame_NNNNN.json) found for the evidence pack; looked in: " + ", ".join(tried))
+
+
+def _scan_candidates(scan_dir: Path, scene_dir: Path | None):
+    yield scan_dir
+    env = os.environ.get("LITEREALITY_SCAN")
+    if env:
+        yield Path(env)
+    if scene_dir is not None:
+        sj = Path(scene_dir) / "scene.json"
+        try:
+            meta = json.loads(sj.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            meta = {}
+        name = meta.get("scan") or Path(scene_dir).name
+        root = (meta.get("roots") or {}).get("scans")
+        if root:
+            yield Path(root) / name
+        src = (meta.get("capture") or {}).get("source")
+        if src:
+            yield Path(src)
+            yield Path(src).parent / name
+    try:
+        from litereality_agent.settings import settings
+        yield settings.resolved_scans_dir() / (Path(scene_dir).name if scene_dir else scan_dir.name)
+    except Exception:  # noqa: BLE001 — settings are optional here
+        pass
+
+
 def build(authoring_root: Path, scan_dir: Path, surface_ref: Path | None, *, sheets: bool = True,
-          force: bool = False) -> Path:
+          force: bool = False, scene_dir: Path | None = None) -> Path:
     """Create `<authoring_root>/evidence` and return it. Idempotent unless `force`."""
     from litereality_agent import evidence_kit
 
     pack = Path(authoring_root) / "evidence"
-    if pack.is_dir() and not force and (pack / "README.md").is_file():
+    if pack.is_dir() and not force and (pack / "README.md").is_file() and has_capture(pack / "scan"):
         return pack
+    scan_dir = resolve_scan(Path(scan_dir), scene_dir)
     pack.mkdir(parents=True, exist_ok=True)
 
     _link(pack / "scan", Path(scan_dir))

--- a/src/litereality_agent/agent/evidence_pack.py
+++ b/src/litereality_agent/agent/evidence_pack.py
@@ -1,0 +1,140 @@
+"""The evidence pack: everything an authoring model may look at or measure, in ONE directory.
+
+    evidence/
+      README.md          the data formats and coordinate conventions, stated once
+      scan/         ->   the capture (frame_*.jpg/json, depth_*.png, conf_*.png, pointcloud.pcd, room.usdz)
+      stitches/     ->   the head-on per-surface stitches (surface_ref)
+      helpers/           a COPY of litereality_agent.evidence_kit — read_scan, measure, rectify,
+                         contact_sheets, arkit_cameras — importable with sys.path.insert(0, "evidence/helpers")
+      contact_sheets/    every photograph, upright, a dozen per sheet
+
+Why a directory of files rather than more MCP tools: a tool answers one question the way its
+author framed it; a helper is a function the model combines in a script of its own. The measured
+GPT-6 one-shot run got its proportions right by probing depth, slicing the point cloud and
+triangulating pixels in numpy — none of which a tool offered — and the `open` authoring profile
+is built around giving the model that freedom with the infra's evidence, materials and gates.
+
+The pack lives BESIDE the room (`<authoring_root>/evidence`), never inside it: the room dir is
+copied and scanned wholesale downstream and a stray file in it is a trap. `helpers/` is a copy,
+not a symlink, so a run directory stays self-describing after the package moves on.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+README = """\
+# Evidence pack — {scan_name}
+
+All units metres. Two world frames appear in this data:
+* **ARKit world** (Y up): `frame_NNNNN.json["cameraPoseARFrame"]` (row-major 4x4 camera->world),
+  `pointcloud.pcd`, `room.usdz`.
+* **Blender world** (Z up), which `Room.py` and every helper output use:
+  `world_blender = Rx(+90) @ world_arkit`  (y_arkit -> z_blender, z_arkit -> -y_blender).
+The ARKit camera looks down its local -Z with +Y up — Blender's camera convention — so a photo's
+Blender camera matrix is simply `Rx(90) @ cameraPoseARFrame`. `helpers/arkit_cameras.py` builds
+those cameras inside Blender; `Room.py` already carries them as `cam_NNNNN`.
+
+## scan/
+* `frame_NNNNN.jpg` — {n_frames} photographs, stored LANDSCAPE ({w}x{h}); the phone was held
+  portrait so they look rotated. Pixel (u right, v down) coordinates in the helpers refer to
+  this stored image. `frame_NNNNN.json` — its pose and 3x3 `intrinsics` (fx 0 cx / 0 fy cy / 0 0 1).
+* `depth_NNNNN.png` — 16-bit LiDAR depth in millimetres at {dw}x{dh}, same field of view as the jpg
+  (scale the intrinsics by {dw}/{w}). `conf_NNNNN.png` — ARKit confidence 0..2 per depth pixel.
+* `pointcloud.pcd` — {n_points} ARKit-world points. `room.usdz` — RoomPlan's walls, openings and
+  one oriented box per detected furniture item (already turned into `SHELL` in `Room.py`).
+
+## stitches/
+One head-on (rectified) image per wall/floor/ceiling plus an unknown-mask (white = not observed).
+Furniture smears onto the plane; the material is what is behind it.
+
+## helpers/  (`import sys; sys.path.insert(0, "evidence/helpers")`)
+```python
+from read_scan import Scan; import measure, rectify, contact_sheets
+S = Scan("evidence/scan")
+measure.probe_depth(S, 12, 960, 720)                 # LiDAR point under a jpg pixel -> Blender xyz
+measure.triangulate(S, [(12, (u, v)), (14, (u, v))]) # same feature in 2+ photos -> xyz (for what LiDAR misses)
+measure.height_profile(S, (x0, y0, x1, y1), floor_z=SHELL["floor_z"])   # peaks = horizontal surfaces
+measure.pcd_slice(S, 0.70, 0.80, out_png="slice.png", floor_z=SHELL["floor_z"])  # a plan at one height
+rectify.rectify_region(S, 12, quad_px, "textures/monitor.png", (1024, 640))     # photo quad -> texture
+```
+The cloud's own floor estimate is ±3 cm; `SHELL["floor_z"]` from `Room.py` is RoomPlan's and better.
+`arkit_cameras.py` runs inside Blender only (`blender -b Room.blend --python your_script.py`).
+
+## contact_sheets/
+Every photograph, upright, numbered — look at all of them before building anything.
+"""
+
+
+def build(authoring_root: Path, scan_dir: Path, surface_ref: Path | None, *, sheets: bool = True,
+          force: bool = False) -> Path:
+    """Create `<authoring_root>/evidence` and return it. Idempotent unless `force`."""
+    from litereality_agent import evidence_kit
+
+    pack = Path(authoring_root) / "evidence"
+    if pack.is_dir() and not force and (pack / "README.md").is_file():
+        return pack
+    pack.mkdir(parents=True, exist_ok=True)
+
+    _link(pack / "scan", Path(scan_dir))
+    if surface_ref is not None and Path(surface_ref).is_dir():
+        _link(pack / "stitches", Path(surface_ref))
+
+    helpers = pack / "helpers"
+    if helpers.exists():
+        shutil.rmtree(helpers)
+    shutil.copytree(Path(evidence_kit.__file__).parent, helpers,
+                    ignore=shutil.ignore_patterns("__pycache__", "*.pyc"))
+
+    facts = _facts(Path(scan_dir))
+    (pack / "README.md").write_text(README.format(scan_name=Path(scan_dir).name, **facts), encoding="utf-8")
+
+    if sheets:
+        try:
+            import sys
+            sys.path.insert(0, str(helpers))
+            from read_scan import Scan  # type: ignore
+            import contact_sheets  # type: ignore
+            contact_sheets.build(Scan(str(scan_dir)), str(pack / "contact_sheets"))
+            shutil.rmtree(helpers / "__pycache__", ignore_errors=True)
+        except Exception as exc:  # noqa: BLE001 — sheets are a convenience, never a reason to fail
+            (pack / "contact_sheets.SKIPPED").write_text(f"{type(exc).__name__}: {exc}\n")
+    return pack
+
+
+def _link(link: Path, target: Path) -> None:
+    if link.is_symlink() or link.exists():
+        if link.is_symlink() or link.is_file():
+            link.unlink()
+        else:
+            shutil.rmtree(link)
+    os.symlink(os.path.realpath(target), link)
+
+
+def _facts(scan_dir: Path) -> dict:
+    """Numbers the README quotes — read from the files, never assumed."""
+    facts = {"n_frames": 0, "w": "?", "h": "?", "dw": "?", "dh": "?", "n_points": "?"}
+    try:
+        from PIL import Image
+        jsons = sorted(f for f in os.listdir(scan_dir) if f.startswith("frame_") and f.endswith(".json"))
+        facts["n_frames"] = len(jsons)
+        if jsons:
+            i = jsons[0][6:11]
+            with Image.open(scan_dir / f"frame_{i}.jpg") as im:
+                facts["w"], facts["h"] = im.size
+            dp = scan_dir / f"depth_{i}.png"
+            if dp.is_file():
+                with Image.open(dp) as im:
+                    facts["dw"], facts["dh"] = im.size
+        pcd = scan_dir / "pointcloud.pcd"
+        if pcd.is_file():
+            with open(pcd, "rb") as fh:
+                for _ in range(12):
+                    line = fh.readline().decode("ascii", errors="replace")
+                    if line.startswith("POINTS"):
+                        facts["n_points"] = int(line.split()[1])
+                        break
+    except Exception:  # noqa: BLE001 — a README with '?' beats no pack
+        pass
+    return facts

--- a/src/litereality_agent/agent/providers/codex.py
+++ b/src/litereality_agent/agent/providers/codex.py
@@ -58,6 +58,13 @@ from litereality_agent.agent.providers.base import (
 _EDIT_TOOL = "Edit"
 _SHELL_TOOL = "Bash"
 
+# One `codex exec --json` event is one line, and an event carries whole command output — a
+# `cat Room.py` or a stitch listing runs to hundreds of KB. asyncio's StreamReader defaults to a
+# 64 KiB line cap and raises `ValueError: Separator is found, but chunk is longer than limit` on
+# the first line over it, which killed the session a couple of tool calls in and reported success.
+# The cap has to clear the largest event a session can emit, not the typical one.
+_EVENT_LINE_LIMIT = 64 * 1024 * 1024
+
 
 def _toml(value) -> str:
     """A TOML scalar/array literal for `codex -c key=<value>`. JSON is valid TOML for these."""
@@ -275,6 +282,7 @@ class CodexHarness:
             stdin=asyncio.subprocess.DEVNULL,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            limit=_EVENT_LINE_LIMIT,
         )
 
         counter: dict = {}

--- a/src/litereality_agent/agent/providers/codex.py
+++ b/src/litereality_agent/agent/providers/codex.py
@@ -41,6 +41,7 @@ import json
 import os
 import shutil
 import sys
+from pathlib import Path
 from collections.abc import AsyncIterator
 
 from litereality_agent.agent.providers.base import (
@@ -293,6 +294,7 @@ class CodexHarness:
         unparsed = 0
         matched = 0
         usage: dict = {}
+        thread_id = ""
 
         assert proc.stdout is not None
         while True:
@@ -313,6 +315,8 @@ class CodexHarness:
             if event.get("type") == "turn.completed":
                 turns += 1
                 usage = event.get("usage") or usage
+            if event.get("type") == "thread.started":
+                thread_id = str(event.get("thread_id") or "")
             blocks = _normalise(event, counter)
             if blocks:
                 matched += 1
@@ -357,6 +361,10 @@ class CodexHarness:
                 "returncode": proc.returncode,
                 "usage": usage,
                 "stderr": err.decode(errors="replace")[-2000:],
+                "thread_id": thread_id,
+                # Codex's own transcript: every message, tool call, tool output and — unlike our
+                # normalised view — every image content item the model was actually shown.
+                "rollout": rollout_path(thread_id),
             },
         )
 
@@ -365,6 +373,17 @@ def _effort() -> str:
     # Higher reasoning effort is noticeably better on geometry/material work — see the note in
     # models/object_generation/generate.py where this default came from.
     return os.environ.get("LR_CODEX_EFFORT", "high")
+
+
+def rollout_path(thread_id: str) -> str | None:
+    """Codex writes `~/.codex/sessions/YYYY/MM/DD/rollout-<stamp>-<thread_id>.jsonl`. Find it."""
+    if not thread_id:
+        return None
+    root = Path(os.environ.get("CODEX_HOME") or Path.home() / ".codex") / "sessions"
+    if not root.is_dir():
+        return None
+    hits = sorted(root.glob(f"*/*/*/rollout-*-{thread_id}.jsonl"))
+    return str(hits[-1]) if hits else None
 
 
 def _codex_model() -> str | None:

--- a/src/litereality_agent/agent/providers/codex.py
+++ b/src/litereality_agent/agent/providers/codex.py
@@ -41,8 +41,8 @@ import json
 import os
 import shutil
 import sys
-from pathlib import Path
 from collections.abc import AsyncIterator
+from pathlib import Path
 
 from litereality_agent.agent.providers.base import (
     AgentMessage,

--- a/src/litereality_agent/cli.py
+++ b/src/litereality_agent/cli.py
@@ -175,9 +175,11 @@ def _add_author_options(parser: argparse.ArgumentParser) -> None:
              "a low value returns an unfinished room and says so",
     )
     parser.add_argument(
-        "--author-profile", choices=["base", "detail", "simulation"],
+        "--author-profile", choices=["base", "detail", "simulation", "open"],
         help="authoring brief: base (materials + wall fixtures), detail (multi-part fixtures), "
-             "simulation (adds real lighting, small objects, and support declarations)",
+             "simulation (adds real lighting, small objects, and support declarations), "
+             "open (a goal brief with the full evidence pack + measurement helpers and the validation "
+             "gate; defaults to the codex/gpt-6 harness)",
     )
     parser.add_argument("--author-turns", type=int, help="authoring hard turn backstop (default 140)")
 

--- a/src/litereality_agent/cli.py
+++ b/src/litereality_agent/cli.py
@@ -125,6 +125,31 @@ def _author_options(args) -> dict:
     return opts
 
 
+def _reconstruct_options(args) -> dict:
+    """Options for the reconstruct stage.
+
+    `chair_qc` gates `mesh_qc.chair_repair`, which is the only thing that looks at what TRELLIS
+    actually produced: it flags fused floor slabs, squat blobs and floating fragments, then repairs
+    a bad cluster by regenerating its reference image and re-running TRELLIS. The stage has always
+    forwarded `--chair-qc` to `scene_init.flow`, but nothing here ever set it, so every chair went
+    into a room ungated. It is ON by default — the checks are local geometry and cost nothing, and
+    only a cluster that FAILS pays for a regeneration.
+    """
+    return {"chair_qc": getattr(args, "chair_qc", True)}
+
+
+def _add_reconstruct_options(parser: argparse.ArgumentParser) -> None:
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--chair-qc", dest="chair_qc", action="store_true", default=True,
+        help="QC generated chair meshes and regenerate the ones that fail (default)",
+    )
+    group.add_argument(
+        "--no-chair-qc", dest="chair_qc", action="store_false",
+        help="skip chair mesh QC — a bad chair then ships as-is",
+    )
+
+
 def _add_author_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--polish",
@@ -281,7 +306,8 @@ def _run(args) -> int:
             through=args.through,
             force=set(args.force or ()),
             strict=args.strict,
-            options={"author": _author_options(args), "publish": _publish_options(args),
+            options={"reconstruct": _reconstruct_options(args),
+                     "author": _author_options(args), "publish": _publish_options(args),
                      "simulate": _simulate_options(args)},
         )
         rc = _print_results(results)
@@ -301,6 +327,7 @@ def _stage(args) -> int:
             strict=args.strict,
             options={
                 "skip_image_generation": args.skip_image_generation,
+                **_reconstruct_options(args),
                 **_author_options(args),
                 **_publish_options(args),
                 **_simulate_options(args),
@@ -386,6 +413,7 @@ def _parser() -> argparse.ArgumentParser:
     run.add_argument("--force", action="append", choices=stages)
     run.add_argument("--strict", action="store_true")
     run.add_argument("--output-root")
+    _add_reconstruct_options(run)
     _add_author_options(run)
     _add_live_options(run)
     _add_publish_options(run)
@@ -399,6 +427,7 @@ def _parser() -> argparse.ArgumentParser:
     stage.add_argument("--strict", action="store_true")
     stage.add_argument("--skip-image-generation", action="store_true")
     stage.add_argument("--output-root")
+    _add_reconstruct_options(stage)
     _add_author_options(stage)
     _add_live_options(stage)
     _add_publish_options(stage)

--- a/src/litereality_agent/cli.py
+++ b/src/litereality_agent/cli.py
@@ -116,9 +116,12 @@ def _author_options(args) -> dict:
         "materials": polish or getattr(args, "materials", False),
         "quality_pass": getattr(args, "quality_pass", False),
     }
-    steps = getattr(args, "author_steps", None)
-    if steps:
-        opts["step_budget"] = steps
+    # Only pass what was actually given, so the stage keeps its own defaults for the rest.
+    for name, key in (("author_profile", "profile"), ("author_steps", "step_budget"),
+                      ("author_turns", "max_turns")):
+        value = getattr(args, name, None)
+        if value:
+            opts[key] = value
     return opts
 
 
@@ -146,6 +149,12 @@ def _add_author_options(parser: argparse.ArgumentParser) -> None:
         help="tool-call budget for the authoring session (default 100); "
              "a low value returns an unfinished room and says so",
     )
+    parser.add_argument(
+        "--author-profile", choices=["base", "detail", "simulation"],
+        help="authoring brief: base (materials + wall fixtures), detail (multi-part fixtures), "
+             "simulation (adds real lighting, small objects, and support declarations)",
+    )
+    parser.add_argument("--author-turns", type=int, help="authoring hard turn backstop (default 140)")
 
 
 def _simulate_options(args) -> dict:

--- a/src/litereality_agent/evidence_kit/__init__.py
+++ b/src/litereality_agent/evidence_kit/__init__.py
@@ -1,0 +1,20 @@
+"""The evidence kit — plain-python helpers handed to an authoring model as FILES, not tools.
+
+A tool answers one question the way its author framed it. A helper is a function the model can
+combine, loop over and adapt. The kit exists because the measured GPT-6 one-shot run got its
+proportions right by probing depth, slicing the point cloud and triangulating photo pixels — none
+of which our tool set offered — and it did all of that with numpy in a scratch script. So the kit
+is what that script needed: readers for the scan, measurement helpers, a photo→texture rectifier,
+contact sheets, and the ARKit→Blender camera math.
+
+`evidence_pack.build()` copies this package next to the room as `evidence/helpers/` (a copy, so the
+run record is self-contained), alongside links to the scan and the stitches and a README that
+states the data formats and coordinate conventions once.
+
+Modules (none import Blender except `arkit_cameras`, which only runs inside `bpy`):
+  read_scan        Scan(dir): frames, poses, intrinsics, RGB, depth (m), confidence, point cloud
+  measure          probe_depth, pcd_slice, height_profile, triangulate — all in Blender Z-up metres
+  rectify          rectify_region: a photo quad → a straight-on texture image (screens, boards)
+  contact_sheets   every frame on a few sheets, so the whole capture is seen before anything is built
+  arkit_cameras    (bpy) one Blender camera per photograph; render the scene from them
+"""

--- a/src/litereality_agent/evidence_kit/arkit_cameras.py
+++ b/src/litereality_agent/evidence_kit/arkit_cameras.py
@@ -1,0 +1,79 @@
+"""ARKit capture cameras -> Blender cameras.  Run INSIDE Blender (bpy).
+
+    import sys; sys.path.insert(0, "evidence/helpers"); import arkit_cameras
+    cams = arkit_cameras.add_cameras("evidence/scan")          # one Blender camera per evidence/scan/frame_NNNNN.json
+    arkit_cameras.render(cams, "out/renders", frames=[4, 12, 25, 36], res_div=2)
+
+Conventions (verified against this dataset):
+  * evidence/scan/frame_NNNNN.json["cameraPoseARFrame"] is a ROW-MAJOR 4x4 camera->world matrix in ARKit
+    world coordinates (Y up, metres). Translation is the last column.
+  * pointcloud.pcd and the RoomPlan usdz share that same ARKit world frame.
+  * Blender is Z-up: world_blender = Rx(+90deg) @ world_arkit.   (y_arkit -> z_blender, z_arkit -> -y_blender)
+  * ARKit camera looks down its local -Z with +Y up, which is exactly Blender's camera convention,
+    so the Blender camera matrix is simply  Rx(90) @ pose.
+  * "intrinsics" is row-major 3x3 [fx 0 cx; 0 fy cy; 0 0 1] for the LANDSCAPE 1920x1440 jpg.
+    (The phone was held portrait, so the jpgs look rotated; cx~960, cy~720 confirms landscape storage.)
+If you build the scene in the ARKit frame instead, apply the same Rx(90) to your geometry, or set
+C = Matrix.Identity(4) below — just be consistent, the renders must line up with the photographs.
+"""
+import json, math, os, re
+import bpy
+from mathutils import Matrix
+
+SENSOR_W = 36.0
+C = Matrix.Rotation(math.radians(90), 4, "X")   # ARKit (Y-up) -> Blender (Z-up)
+
+
+def pose_matrix(flat16):
+    return Matrix((flat16[0:4], flat16[4:8], flat16[8:12], flat16[12:16]))
+
+
+def image_size(scan_dir):
+    for f in sorted(os.listdir(scan_dir)):
+        if re.match(r"frame_\d+\.jpg$", f):
+            img = bpy.data.images.load(os.path.join(scan_dir, f))
+            w, h = img.size
+            bpy.data.images.remove(img)
+            return w, h
+    return 1920, 1440
+
+
+def add_cameras(scan_dir="evidence/scan", collection="ARKitCameras"):
+    """Create cam_NNNNN for every frame json. Returns {frame_index: camera_object}."""
+    w, h = image_size(scan_dir)
+    coll = bpy.data.collections.get(collection) or bpy.data.collections.new(collection)
+    if coll.name not in bpy.context.scene.collection.children:
+        bpy.context.scene.collection.children.link(coll)
+    cams = {}
+    for f in sorted(os.listdir(scan_dir)):
+        if not re.match(r"frame_\d+\.json$", f):
+            continue
+        d = json.load(open(os.path.join(scan_dir, f)))
+        idx = d.get("frame_index", int(re.search(r"\d+", f).group()))
+        fx, _, cx, _, fy, cy, _, _, _ = d["intrinsics"]
+        cd = bpy.data.cameras.new(f"cam_{idx:05d}")
+        cd.sensor_fit = "HORIZONTAL"
+        cd.sensor_width = SENSOR_W
+        cd.lens = fx * SENSOR_W / w
+        cd.shift_x = (w * 0.5 - cx) / w
+        cd.shift_y = (cy - h * 0.5) / w
+        cd.clip_start, cd.clip_end = 0.01, 100.0
+        ob = bpy.data.objects.new(cd.name, cd)
+        ob.matrix_world = C @ pose_matrix(d["cameraPoseARFrame"])
+        coll.objects.link(ob)
+        cams[idx] = ob
+    bpy.context.scene.render.resolution_x, bpy.context.scene.render.resolution_y = w, h
+    return cams
+
+
+def render(cams, out_dir="out/renders", frames=(4, 12, 25, 36), res_div=2):
+    """Render the current scene from the given capture frames (landscape, same size as the jpgs / res_div)."""
+    os.makedirs(out_dir, exist_ok=True)
+    sc = bpy.context.scene
+    sc.render.resolution_percentage = max(1, int(100 / res_div))
+    for fi in frames:
+        sc.camera = cams[fi]
+        sc.render.filepath = os.path.join(out_dir, f"frame_{fi:05d}.png")
+        bpy.ops.render.render(write_still=True)
+        print("rendered", sc.render.filepath)
+    sc.render.resolution_percentage = 100

--- a/src/litereality_agent/evidence_kit/arkit_cameras.py
+++ b/src/litereality_agent/evidence_kit/arkit_cameras.py
@@ -16,7 +16,11 @@ Conventions (verified against this dataset):
 If you build the scene in the ARKit frame instead, apply the same Rx(90) to your geometry, or set
 C = Matrix.Identity(4) below — just be consistent, the renders must line up with the photographs.
 """
-import json, math, os, re
+import json
+import math
+import os
+import re
+
 import bpy
 from mathutils import Matrix
 

--- a/src/litereality_agent/evidence_kit/contact_sheets.py
+++ b/src/litereality_agent/evidence_kit/contact_sheets.py
@@ -1,0 +1,40 @@
+"""Every photograph of the capture on a handful of sheets, upright, numbered by frame index.
+
+    import contact_sheets; contact_sheets.build(S, "evidence/contact_sheets")   -> [sheet paths]
+
+Look at ALL of them before building anything: the scan's boxes say where the big furniture is,
+the photographs say what the room actually contains (the coat on the door, the heater, the mug)."""
+from __future__ import annotations
+
+import os
+
+from PIL import Image, ImageDraw
+
+
+def build(S, out_dir: str, per_sheet: int = 12, cols: int = 4, thumb_w: int = 360,
+          rotate_cw: bool = True) -> list[str]:
+    os.makedirs(out_dir, exist_ok=True)
+    idx = S.indices()
+    paths = []
+    for s in range(0, len(idx), per_sheet):
+        chunk = idx[s:s + per_sheet]
+        thumbs = []
+        for i in chunk:
+            im = Image.open(S.rgb_path(i)).convert("RGB")
+            if rotate_cw:
+                im = im.rotate(-90, expand=True)
+            im.thumbnail((thumb_w, thumb_w * 2))
+            d = ImageDraw.Draw(im)
+            d.rectangle([0, 0, 96, 22], fill=(0, 0, 0))
+            d.text((4, 4), f"frame {i:05d}", fill=(255, 255, 255))
+            thumbs.append(im)
+        tw = max(t.width for t in thumbs)
+        th = max(t.height for t in thumbs)
+        rows = (len(thumbs) + cols - 1) // cols
+        sheet = Image.new("RGB", (cols * (tw + 6), rows * (th + 6)), (24, 24, 24))
+        for n, t in enumerate(thumbs):
+            sheet.paste(t, ((n % cols) * (tw + 6), (n // cols) * (th + 6)))
+        p = os.path.join(out_dir, f"sheet_{s // per_sheet:02d}_frames_{chunk[0]:05d}-{chunk[-1]:05d}.jpg")
+        sheet.save(p, quality=85)
+        paths.append(p)
+    return paths

--- a/src/litereality_agent/evidence_kit/measure.py
+++ b/src/litereality_agent/evidence_kit/measure.py
@@ -1,0 +1,158 @@
+"""Measure the room from the scan. Everything returned is in BLENDER world (Z up), metres.
+
+    from read_scan import Scan; import measure
+    S = Scan("evidence/scan")
+    measure.probe_depth(S, 12, 960, 700)        -> {"point": [x,y,z], "depth_m": 1.83, "conf": 2}
+    measure.triangulate(S, [(12, (960,700)), (14, (1010,650))])   -> {"point": [...], "residual_m": 0.01}
+    measure.pcd_slice(S, z0=0.70, z1=0.80)       -> occupancy map of everything between two heights
+    measure.height_profile(S, (x0,y0,x1,y1))     -> histogram of point heights inside a footprint
+
+Pixel coordinates are in the STORED landscape jpg (u right, v down, e.g. 1920x1440). A pixel in a
+contact-sheet thumbnail must be scaled back to the full frame first.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+
+def _floor_z(S, bin_m: float = 0.02) -> float | None:
+    """Height of the floor plane from the cloud: the strongest band in the lowest dense 15 cm.
+
+    LiDAR leaves stray returns well below the real floor (Office_room: 30 cm under it) and the
+    floor band itself is ~±3 cm wide, so neither the lowest point nor a low percentile works. The
+    floor is the largest plane in the room, so it is the strongest bin near the bottom. Expect
+    ±3 cm; when Room.py's `SHELL["floor_z"]` (RoomPlan's floor) is available, prefer it and pass
+    it as `floor_z=` to the helpers below."""
+    p = S.pcd_blender()
+    if len(p) < 100:
+        return None
+    z = p[:, 2]
+    edges = np.arange(float(z.min()), float(z.max()) + bin_m, bin_m)
+    hist, _ = np.histogram(z, bins=edges)
+    dense = np.flatnonzero(hist >= 0.10 * hist.max())
+    if not len(dense):
+        return float(np.percentile(z, 1.0))
+    lo = dense[0]
+    hi = min(len(hist), lo + int(round(0.15 / bin_m)))
+    j = lo + int(np.argmax(hist[lo:hi]))
+    a, b = max(0, j - 1), min(len(hist), j + 2)
+    w = hist[a:b].astype(float)
+    centres = edges[a:b] + bin_m / 2
+    return float((w * centres).sum() / w.sum())
+
+
+def floor_z(S) -> float:
+    """Blender-world z of the floor, estimated from the point cloud (±3 cm)."""
+    return _floor_z(S) or 0.0
+
+
+def probe_depth(S, i: int, u: float, v: float, radius_px: int = 2) -> dict:
+    """The 3D point the LiDAR saw at jpg pixel (u, v) of frame i (median over a small window)."""
+    d = S.depth(i)
+    c = S.conf(i)
+    rgb_h, rgb_w = S.rgb(i).shape[:2]
+    h, w = d.shape
+    du, dv = u * w / rgb_w, v * h / rgb_h
+    ui, vi = int(round(du)), int(round(dv))
+    u0, u1 = max(0, ui - radius_px), min(w, ui + radius_px + 1)
+    v0, v1 = max(0, vi - radius_px), min(h, vi + radius_px + 1)
+    win = d[v0:v1, u0:u1]
+    cw = c[v0:v1, u0:u1]
+    ok = win > 0
+    if not ok.any():
+        return {"point": None, "depth_m": None, "conf": None, "note": "no depth at this pixel"}
+    z = float(np.median(win[ok]))
+    k = S.K_depth(i)
+    x = (du - k[0, 2]) / k[0, 0] * z
+    y = (dv - k[1, 2]) / k[1, 1] * z
+    cam = np.array([x, -y, -z, 1.0])
+    P = (S.pose_blender(i) @ cam)[:3]
+    return {"point": [round(float(a), 4) for a in P], "depth_m": round(z, 4),
+            "conf": int(cw[ok].min()), "frame": i, "pixel": [u, v]}
+
+
+def ray(S, i: int, u: float, v: float) -> tuple[np.ndarray, np.ndarray]:
+    """(origin, unit direction) of the pixel ray in Blender world."""
+    k = S.K(i)
+    dcam = np.array([(u - k[0, 2]) / k[0, 0], -(v - k[1, 2]) / k[1, 1], -1.0])
+    M = S.pose_blender(i)
+    dw = M[:3, :3] @ dcam
+    return M[:3, 3].copy(), dw / np.linalg.norm(dw)
+
+
+def triangulate(S, observations: list[tuple[int, tuple[float, float]]]) -> dict:
+    """Least-squares intersection of the pixel rays [(frame, (u, v)), ...] from 2+ frames.
+
+    Use it for things LiDAR misses (dark fabric, glass, thin legs): click the same feature in two
+    or more photos. `residual_m` is the RMS distance from the point to the rays — above ~5 cm the
+    clicks probably do not show the same feature."""
+    if len(observations) < 2:
+        raise ValueError("triangulate needs the same feature in at least two frames")
+    A = np.zeros((3, 3))
+    b = np.zeros(3)
+    rays = []
+    for i, (u, v) in observations:
+        o, d = ray(S, i, u, v)
+        rays.append((o, d))
+        P = np.eye(3) - np.outer(d, d)
+        A += P
+        b += P @ o
+    X = np.linalg.lstsq(A, b, rcond=None)[0]
+    res = [float(np.linalg.norm((np.eye(3) - np.outer(d, d)) @ (X - o))) for o, d in rays]
+    return {"point": [round(float(a), 4) for a in X],
+            "residual_m": round(float(np.sqrt(np.mean(np.square(res)))), 4),
+            "n_rays": len(rays)}
+
+
+def pcd_slice(S, z0: float, z1: float, cell_m: float = 0.02, floor_relative: bool = True,
+              out_png: str | None = None, floor_z: float | None = None) -> dict:
+    """Occupancy map of the point cloud between heights z0..z1 (metres above the floor by default).
+
+    Returns {"grid": HxW uint8 counts, "x0","y0","cell_m", "floor_z"} and optionally writes a PNG
+    (white = points). A slice at tabletop height draws every tabletop; at 0.05-0.30 m it draws
+    legs and plinths; a thin slice just under a shelf finds its underside."""
+    p = S.pcd_blender()
+    fz = (floor_z if floor_z is not None else _floor_z(S)) if floor_relative else 0.0
+    fz = fz or 0.0
+    sel = p[(p[:, 2] >= fz + z0) & (p[:, 2] <= fz + z1)]
+    x0, y0 = float(p[:, 0].min()), float(p[:, 1].min())
+    W = int(np.ceil((p[:, 0].max() - x0) / cell_m)) + 1
+    H = int(np.ceil((p[:, 1].max() - y0) / cell_m)) + 1
+    grid = np.zeros((H, W), dtype=np.uint16)
+    if len(sel):
+        ix = ((sel[:, 0] - x0) / cell_m).astype(int)
+        iy = ((sel[:, 1] - y0) / cell_m).astype(int)
+        np.add.at(grid, (iy, ix), 1)
+    out = {"grid": grid, "x0": x0, "y0": y0, "cell_m": cell_m, "floor_z": fz, "n_points": int(len(sel)),
+           "note": "grid[row, col]: row = y index (world y = y0 + row*cell), col = x index"}
+    if out_png:
+        from PIL import Image
+        img = (np.clip(grid, 0, 1) * 255).astype(np.uint8)[::-1]  # y up on the page
+        Image.fromarray(img).save(out_png)
+        out["png"] = out_png
+    return out
+
+
+def height_profile(S, footprint_xy: tuple[float, float, float, float], bin_m: float = 0.02,
+                   floor_z: float | None = None) -> dict:
+    """Histogram of point heights (above the floor) inside the footprint (x0, y0, x1, y1).
+
+    Peaks are horizontal surfaces: a desk shows one at ~0.72-0.76 m, a shelf unit one per board.
+    Pass `floor_z=SHELL["floor_z"]` from Room.py when you have it; the cloud's own estimate is ±3 cm.
+    `surfaces_m` lists the peak heights, strongest first."""
+    p = S.pcd_blender()
+    fz = floor_z if floor_z is not None else (_floor_z(S) or 0.0)
+    x0, y0, x1, y1 = footprint_xy
+    sel = p[(p[:, 0] >= min(x0, x1)) & (p[:, 0] <= max(x0, x1)) & (p[:, 1] >= min(y0, y1)) & (p[:, 1] <= max(y0, y1))]
+    if not len(sel):
+        return {"surfaces_m": [], "hist": [], "floor_z": fz, "n_points": 0}
+    h = sel[:, 2] - fz
+    edges = np.arange(0.0, float(h.max()) + bin_m, bin_m)
+    hist, _ = np.histogram(h, bins=edges)
+    peaks = []
+    for j in range(1, len(hist) - 1):
+        if hist[j] >= hist[j - 1] and hist[j] >= hist[j + 1] and hist[j] > max(5, 0.05 * hist.max()):
+            peaks.append((int(hist[j]), round(float(edges[j] + bin_m / 2), 3)))
+    peaks.sort(reverse=True)
+    return {"surfaces_m": [z for _, z in peaks[:8]], "counts": [n for n, _ in peaks[:8]],
+            "hist": hist.tolist(), "bin_m": bin_m, "floor_z": fz, "n_points": int(len(sel))}

--- a/src/litereality_agent/evidence_kit/read_scan.py
+++ b/src/litereality_agent/evidence_kit/read_scan.py
@@ -1,0 +1,128 @@
+"""Read a RoomPlan/ARKit capture directory without Blender.
+
+    from read_scan import Scan
+    S = Scan("evidence/scan")
+    S.indices()            -> [0, 1, ...]           every frame_NNNNN.json
+    S.rgb(i)               -> HxWx3 uint8 (stored LANDSCAPE, e.g. 1920x1440; the phone was portrait)
+    S.depth(i)             -> hxw float32 metres     (256x192 LiDAR; same field of view as the jpg)
+    S.conf(i)              -> hxw uint8 0..2         (ARKit confidence; 2 = high)
+    S.K(i)                 -> 3x3 intrinsics for the jpg;  S.K_depth(i) scaled for the depth map
+    S.pose(i)              -> 4x4 camera->world, ARKit world (Y up)
+    S.pose_blender(i)      -> 4x4 camera->world, Blender world (Z up) = Rx(90) @ pose
+    S.pcd()                -> Nx3 float32 ARKit-world points;  S.pcd_blender() in Blender world
+
+Frames: `cameraPoseARFrame` is ROW-MAJOR 4x4 camera->world (translation in the last column). The
+camera looks down its local -Z with +Y up — Blender's camera convention — so the same matrix
+rotated into Z-up IS the Blender camera matrix. All units metres.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+
+import numpy as np
+
+# ARKit (Y-up) -> Blender (Z-up): y -> z, z -> -y.
+C_ARKIT_TO_BLENDER = np.array([[1, 0, 0, 0], [0, 0, -1, 0], [0, 1, 0, 0], [0, 0, 0, 1]], dtype=np.float64)
+
+
+class Scan:
+    def __init__(self, scan_dir: str):
+        self.dir = os.path.abspath(scan_dir)
+        if not os.path.isdir(self.dir):
+            raise FileNotFoundError(self.dir)
+        self._pcd = None
+
+    # -- frames -------------------------------------------------------------------------------
+    def indices(self) -> list[int]:
+        return sorted(int(m.group(1)) for f in os.listdir(self.dir)
+                      if (m := re.match(r"frame_(\d+)\.json$", f)))
+
+    def frame(self, i: int) -> dict:
+        with open(os.path.join(self.dir, f"frame_{i:05d}.json")) as fh:
+            return json.load(fh)
+
+    def rgb_path(self, i: int) -> str:
+        return os.path.join(self.dir, f"frame_{i:05d}.jpg")
+
+    def rgb(self, i: int) -> np.ndarray:
+        from PIL import Image
+        return np.asarray(Image.open(self.rgb_path(i)).convert("RGB"))
+
+    def depth(self, i: int) -> np.ndarray:
+        from PIL import Image
+        return np.asarray(Image.open(os.path.join(self.dir, f"depth_{i:05d}.png")), dtype=np.float32) / 1000.0
+
+    def conf(self, i: int) -> np.ndarray:
+        from PIL import Image
+        return np.asarray(Image.open(os.path.join(self.dir, f"conf_{i:05d}.png")))
+
+    def K(self, i: int) -> np.ndarray:
+        return np.array(self.frame(i)["intrinsics"], dtype=np.float64).reshape(3, 3)
+
+    def K_depth(self, i: int) -> np.ndarray:
+        """Intrinsics rescaled to the depth map's resolution (same field of view as the jpg)."""
+        k = self.K(i).copy()
+        d = self.depth(i)
+        r = self.rgb(i)
+        sx, sy = d.shape[1] / r.shape[1], d.shape[0] / r.shape[0]
+        k[0, :] *= sx
+        k[1, :] *= sy
+        return k
+
+    def pose(self, i: int) -> np.ndarray:
+        return np.array(self.frame(i)["cameraPoseARFrame"], dtype=np.float64).reshape(4, 4)
+
+    def pose_blender(self, i: int) -> np.ndarray:
+        return C_ARKIT_TO_BLENDER @ self.pose(i)
+
+    # -- point cloud --------------------------------------------------------------------------
+    def pcd(self) -> np.ndarray:
+        if self._pcd is None:
+            self._pcd = _read_pcd(os.path.join(self.dir, "pointcloud.pcd"))
+        return self._pcd
+
+    def pcd_blender(self) -> np.ndarray:
+        p = self.pcd()
+        return p @ C_ARKIT_TO_BLENDER[:3, :3].T
+
+    # -- geometry -----------------------------------------------------------------------------
+    def unproject_depth(self, i: int, min_conf: int = 1) -> np.ndarray:
+        """Every depth pixel of frame i as an Nx3 point in Blender world (Z up)."""
+        d = self.depth(i)
+        c = self.conf(i)
+        k = self.K_depth(i)
+        h, w = d.shape
+        v, u = np.mgrid[0:h, 0:w]
+        ok = (d > 0) & (c >= min_conf)
+        z = d[ok]
+        x = (u[ok] - k[0, 2]) / k[0, 0] * z
+        y = (v[ok] - k[1, 2]) / k[1, 1] * z
+        # camera looks down -Z with +Y up: image v grows downward, so flip y and z
+        cam = np.stack([x, -y, -z, np.ones_like(z)], axis=1)
+        return (self.pose_blender(i) @ cam.T).T[:, :3].astype(np.float32)
+
+
+def _read_pcd(path: str) -> np.ndarray:
+    """ASCII or binary `.pcd` with at least x y z fields (open3d if present, else a small parser)."""
+    try:
+        import open3d as o3d  # type: ignore
+        return np.asarray(o3d.io.read_point_cloud(path).points, dtype=np.float32)
+    except Exception:  # noqa: BLE001 — open3d is optional
+        pass
+    with open(path, "rb") as fh:
+        header, fields, data = [], [], "ascii"
+        while True:
+            line = fh.readline().decode("ascii", errors="replace").strip()
+            header.append(line)
+            if line.startswith("FIELDS"):
+                fields = line.split()[1:]
+            if line.startswith("DATA"):
+                data = line.split()[1]
+                break
+        if data != "ascii":
+            raise ValueError(f"{path}: binary PCD needs open3d")
+        arr = np.loadtxt(fh, dtype=np.float32)
+    ix = [fields.index(a) for a in ("x", "y", "z")]
+    return arr[:, ix]

--- a/src/litereality_agent/evidence_kit/rectify.py
+++ b/src/litereality_agent/evidence_kit/rectify.py
@@ -1,0 +1,41 @@
+"""Lift a planar region out of a photograph as a straight-on texture.
+
+    import rectify
+    rectify.rectify_region(S, 12, [(880,300),(1310,290),(1320,560),(875,570)], "textures/monitor.png",
+                           size_px=(1024, 640))
+
+`quad_px` is the region's four corners in the STORED jpg, in order top-left, top-right,
+bottom-right, bottom-left AS THE OBJECT IS ORIENTED (the phone was held portrait, so 'top' of a
+monitor is usually the jpg's left or right edge — pick the corners by what they are on the object,
+not on the page). Use the result for screens, notice boards, pictures, labels and the view through
+a window; keep the aspect of `size_px` close to the object's real aspect so it is not stretched."""
+from __future__ import annotations
+
+import os
+
+import numpy as np
+
+
+def _homography(src, dst):
+    A = []
+    for (x, y), (u, v) in zip(src, dst):
+        A.append([x, y, 1, 0, 0, 0, -u * x, -u * y, -u])
+        A.append([0, 0, 0, x, y, 1, -v * x, -v * y, -v])
+    _, _, vt = np.linalg.svd(np.array(A, dtype=np.float64))
+    H = vt[-1].reshape(3, 3)
+    return H / H[2, 2]
+
+
+def rectify_region(S, i: int, quad_px, out_path: str, size_px=(1024, 1024)) -> str:
+    """Warp the quad of frame i to a size_px image and save it. Returns out_path."""
+    from PIL import Image
+    img = Image.open(S.rgb_path(i)).convert("RGB")
+    W, Hh = size_px
+    dst = [(0, 0), (W - 1, 0), (W - 1, Hh - 1), (0, Hh - 1)]
+    # PIL's PERSPECTIVE wants the inverse map (output -> input) as 8 coefficients
+    Hm = _homography(dst, [tuple(map(float, p)) for p in quad_px])
+    coeffs = (Hm / Hm[2, 2]).flatten()[:8]
+    out = img.transform((W, Hh), Image.PERSPECTIVE, tuple(coeffs), Image.BICUBIC)
+    os.makedirs(os.path.dirname(os.path.abspath(out_path)) or ".", exist_ok=True)
+    out.save(out_path)
+    return out_path

--- a/src/litereality_agent/pipeline/realism_authoring/author/__init__.py
+++ b/src/litereality_agent/pipeline/realism_authoring/author/__init__.py
@@ -39,9 +39,11 @@ def run(context: RunContext, options: dict) -> StageResult:
         "--surface-ref", context.authoring_root / "surface_ref",
         "--scan", context.capture_dir,
         "--profile", options.get("profile", "base"),
-        "--max-turns", options.get("max_turns", 140),
-        "--step-budget", options.get("step_budget", 100),
     ]
+    # Budgets only when asked for: the entrypoint knows each profile's own defaults.
+    for key, flag in (("max_turns", "--max-turns"), ("step_budget", "--step-budget")):
+        if options.get(key):
+            args += [flag, options[key]]
     rc, log = run_module(
         context,
         "litereality_agent.pipeline.realism_authoring.author.entrypoint",
@@ -72,6 +74,10 @@ def run(context: RunContext, options: dict) -> StageResult:
             f"Raise it with --author-steps."
         )
 
+    # THE GATE. Whatever the brief asked for, the question at the end is the same: could a physics
+    # engine take this room? Answered from the build and written down beside it. It cannot run
+    # before a compile has produced room_preview/, and the polish passes below rebuild, so it runs
+    # last (see the end of this function).
     passes: list[tuple[str, str, list[object]]] = []
     if options.get("refine_objects"):
         refine_args: list[object] = [
@@ -130,4 +136,38 @@ def run(context: RunContext, options: dict) -> StageResult:
     refinement = context.authoring_root / "obj_refine"
     if refinement.is_dir():
         result.artifacts["object_refinement"] = str(refinement)
+
+    preview = context.authoring_root / "room_preview"
+    # The gate reads the BUILD. A session that rendered has one; a session that stopped early
+    # or only edited may not, and an unbuilt room is exactly the one whose claims nobody checked.
+    # `Room.py` is valid Python here (author.run guarantees it), so build it once (~1-2 min).
+    if not (preview / "room_layout.json").is_file() or \
+            (preview / "room_layout.json").stat().st_mtime < (context.authored_room / "Room.py").stat().st_mtime:
+        build_rc, build_log = run_module(
+            context, "litereality_agent.room_ops.compile.build_from_room",
+            ["--room", context.authored_room, "--out", preview],
+            log_name="author_build",
+        )
+        if build_rc:
+            result.warnings.append(f"could not build the authored room for the validation gate (exit {build_rc}); see {build_log}")
+    if (preview / "room_layout.json").is_file():
+        gate_rc, gate_log = run_module(
+            context,
+            "litereality_agent.pipeline.room_qc.validate",
+            ["--room", context.authored_room, "--preview", preview],
+            log_name="validate",
+        )
+        report = preview / "validation.json"
+        if report.is_file():
+            result.artifacts["validation"] = str(report)
+        if gate_rc == 2:
+            try:
+                n = len(json.loads(report.read_text(encoding="utf-8")).get("failing", []))
+            except (OSError, ValueError):
+                n = "?"
+            result.warnings.append(
+                f"validation gate FAILED with {n} blocking finding(s) — floating/sunk objects, "
+                f"undeclared supports, mesh clashes or lost articulation; see {report}")
+        elif gate_rc:
+            result.warnings.append(f"validation gate could not run (exit {gate_rc}); see {gate_log}")
     return result

--- a/src/litereality_agent/pipeline/realism_authoring/author/entrypoint.py
+++ b/src/litereality_agent/pipeline/realism_authoring/author/entrypoint.py
@@ -41,7 +41,12 @@ def main() -> None:
         default=int(os.environ.get("AUTHOR_STEP_RESERVE", "15")),
         help="steps reserved for final edits after self-check tools switch off",
     )
-    parser.add_argument("--profile", default="base", choices=list(PROFILES))
+    # `simulation` is the default because it is the brief that produces a room worth
+    # judging: lights that actually emit, objects on the surfaces, and every added object
+    # grouped with `rests_on`/`attached_to` so a physics engine can read it. `base` stops
+    # after shell + materials + wall fixtures, which is why rooms authored with it came
+    # back with three empty tables and no light datablocks.
+    parser.add_argument("--profile", default="simulation", choices=list(PROFILES))
     parser.add_argument(
         "--provider",
         default=None,

--- a/src/litereality_agent/pipeline/realism_authoring/author/entrypoint.py
+++ b/src/litereality_agent/pipeline/realism_authoring/author/entrypoint.py
@@ -8,7 +8,7 @@ import os
 from pathlib import Path
 
 from litereality_agent.agent import scratch
-from litereality_agent.agent.author import PROFILES, run
+from litereality_agent.agent.author import OPEN_MAX_TURNS, OPEN_STEP_BUDGET, PROFILES, run
 from litereality_agent.pipeline.realism_authoring import arguments as stage_args
 
 
@@ -26,14 +26,14 @@ def main() -> None:
     parser.add_argument(
         "--max-turns",
         type=int,
-        default=140,
-        help="hard SDK backstop; the step budget lands the run before this",
+        default=None,
+        help="hard SDK backstop; the step budget lands the run before this (default 140; open: 400)",
     )
     parser.add_argument(
         "--step-budget",
         type=int,
-        default=int(os.environ.get("AUTHOR_STEPS", "100")),
-        help="tool-call budget with graceful wind-down (0 disables)",
+        default=None,
+        help="tool-call budget with graceful wind-down (0 disables; default $AUTHOR_STEPS or 100; open: 300)",
     )
     parser.add_argument(
         "--step-reserve",
@@ -54,6 +54,13 @@ def main() -> None:
         help="agent harness (default: $LR_AUTHOR_PROVIDER, else $LR_AGENT_PROVIDER, else claude)",
     )
     args = stage_args.bind(parser.parse_args(), need=("room", "surface_ref", "scan"))
+    # The open brief does not pace the model, so it must not be starved either: its defaults are
+    # the budgets a finished, self-audited one-shot room actually needed, not the scripted pass's.
+    if args.max_turns is None:
+        args.max_turns = OPEN_MAX_TURNS if args.profile == "open" else 140
+    if args.step_budget is None:
+        env = os.environ.get("AUTHOR_STEPS")
+        args.step_budget = int(env) if env else (OPEN_STEP_BUDGET if args.profile == "open" else 100)
 
     try:
         rc = asyncio.run(

--- a/src/litereality_agent/pipeline/room_qc/validate.py
+++ b/src/litereality_agent/pipeline/room_qc/validate.py
@@ -48,8 +48,10 @@ def _load(preview: Path) -> tuple[list[dict], dict, dict]:
 
 def _footprint_overlap(a: dict, b: dict) -> float:
     """Fraction of a's xy footprint that lies over b's."""
-    ax0, ay0 = a["bbox_min"][:2]; ax1, ay1 = a["bbox_max"][:2]
-    bx0, by0 = b["bbox_min"][:2]; bx1, by1 = b["bbox_max"][:2]
+    ax0, ay0 = a["bbox_min"][:2]
+    ax1, ay1 = a["bbox_max"][:2]
+    bx0, by0 = b["bbox_min"][:2]
+    bx1, by1 = b["bbox_max"][:2]
     ox = max(0.0, min(ax1, bx1) - max(ax0, bx0))
     oy = max(0.0, min(ay1, by1) - max(ay0, by0))
     area = max(1e-9, (ax1 - ax0) * (ay1 - ay0))

--- a/src/litereality_agent/pipeline/room_qc/validate.py
+++ b/src/litereality_agent/pipeline/room_qc/validate.py
@@ -1,0 +1,264 @@
+"""validate — is the built room a room a physics engine could accept? A GATE, not an opinion.
+
+    python -m litereality_agent.pipeline.room_qc.validate --room <room_dir> [--preview <room_preview>] [--json out]
+
+Reads what the build wrote (`room_preview/room_layout.json`, `Room.glb`, `manifest.json`) and
+checks the claims the author made against the geometry:
+
+  support     every object that says `rests_on=X` actually has its underside on X's top surface
+              (within +1 cm above / -2 cm into it) and over X's footprint; floor-standing furniture
+              stands on the floor.
+  declared    every added object states `rests_on` or `attached_to` — an object that says neither
+              is one nobody can simulate.
+  clash       no two objects share volume — the real-mesh contact report from `check_collisions`
+              (python-fcl). The axis-aligned overlap list is ADVISORY: a chair tucked under a table
+              overlaps its box legitimately, so boxes are a review list, never a verdict.
+  articulated the manifest's articulated objects (doors, windows, lift tops …) still reach the
+              build as multi-part objects — an authoring pass must not flatten them.
+  manifold    open boundary edges per mesh — reported, not failed: reconstructed meshes are not
+              always closed and that is a decomposition problem, not an authoring one.
+
+Exit 0 when the gate passes, 2 when it does not, 1 when it could not run. The JSON report is
+written next to the layout as `validation.json` (or to --json) so the stage summary, the trace and
+the model itself can read the same verdict. The GPT-6 one-shot run rebuilt until its own audit
+of exactly these things passed; this makes that audit part of the harness.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+STRUCTURE_CATS = {"wall", "floor", "ceiling", "door", "window", "opening", "room_shell", "shell"}
+FLOOR_STANDING = {"table", "chair", "sofa", "storage", "desk", "cabinet", "bed", "refrigerator",
+                  "stove", "sink", "toilet", "bathtub", "bookshelf", "wardrobe"}
+FLOAT_TOL, SINK_TOL, OVERLAP_SLACK = 0.010, 0.020, 0.010
+
+
+def _load(preview: Path) -> tuple[list[dict], dict, dict]:
+    layout = json.loads((preview / "room_layout.json").read_text(encoding="utf-8"))
+    objs = layout["objects"] if isinstance(layout["objects"], list) else list(layout["objects"].values())
+    manifest = {}
+    mp = preview / "manifest.json"
+    if mp.is_file():
+        manifest = json.loads(mp.read_text(encoding="utf-8"))
+    return objs, layout, manifest
+
+
+def _footprint_overlap(a: dict, b: dict) -> float:
+    """Fraction of a's xy footprint that lies over b's."""
+    ax0, ay0 = a["bbox_min"][:2]; ax1, ay1 = a["bbox_max"][:2]
+    bx0, by0 = b["bbox_min"][:2]; bx1, by1 = b["bbox_max"][:2]
+    ox = max(0.0, min(ax1, bx1) - max(ax0, bx0))
+    oy = max(0.0, min(ay1, by1) - max(ay0, by0))
+    area = max(1e-9, (ax1 - ax0) * (ay1 - ay0))
+    return ox * oy / area
+
+
+def check_support(objs: list[dict], floor_z: float) -> list[dict]:
+    by_id = {o["id"]: o for o in objs}
+    findings = []
+    for o in objs:
+        cat = (o.get("category") or "").lower()
+        if cat in STRUCTURE_CATS:
+            continue
+        sup = o.get("rests_on")
+        att = o.get("attached_to")
+        bottom = o["bbox_min"][2]
+        if sup:
+            if sup.lower().startswith("floor"):
+                top, over = floor_z, 1.0
+            elif sup in by_id:
+                s = by_id[sup]
+                top, over = s.get("top_z", s["bbox_max"][2]), _footprint_overlap(o, s)
+            else:
+                findings.append({"id": o["id"], "kind": "unknown_support", "rests_on": sup,
+                                 "detail": f"{o['id']} rests_on {sup!r}, which is not in the layout"})
+                continue
+            gap = bottom - top
+            if gap > FLOAT_TOL:
+                findings.append({"id": o["id"], "kind": "floating", "rests_on": sup, "gap_m": round(gap, 4),
+                                 "detail": f"{o['id']} is {gap*100:.1f} cm above {sup} — drop it by that much"})
+            elif gap < -SINK_TOL:
+                findings.append({"id": o["id"], "kind": "sunk", "rests_on": sup, "gap_m": round(gap, 4),
+                                 "detail": f"{o['id']} is {-gap*100:.1f} cm into {sup} — raise it by that much"})
+            if over < 0.5 and not sup.lower().startswith("floor"):
+                findings.append({"id": o["id"], "kind": "off_support", "rests_on": sup, "overlap": round(over, 2),
+                                 "detail": f"only {over*100:.0f}% of {o['id']}'s footprint is over {sup}"})
+        elif att:
+            continue
+        elif cat in FLOOR_STANDING or o.get("source_glb"):
+            gap = bottom - floor_z
+            if gap > 0.05:
+                findings.append({"id": o["id"], "kind": "floating", "rests_on": "floor", "gap_m": round(gap, 4),
+                                 "detail": f"{o['id']} ({cat}) floats {gap*100:.1f} cm above the floor"})
+            elif gap < -0.05:
+                findings.append({"id": o["id"], "kind": "sunk", "rests_on": "floor", "gap_m": round(gap, 4),
+                                 "detail": f"{o['id']} ({cat}) is {-gap*100:.1f} cm into the floor"})
+        else:
+            findings.append({"id": o["id"], "kind": "undeclared_support",
+                             "detail": f"{o['id']} ({cat or 'no category'}) states neither rests_on nor attached_to"})
+    return findings
+
+
+def check_overlaps(objs: list[dict]) -> list[dict]:
+    items = [o for o in objs if (o.get("category") or "").lower() not in STRUCTURE_CATS]
+    findings = []
+    for i, a in enumerate(items):
+        for b in items[i + 1:]:
+            if a.get("rests_on") == b["id"] or b.get("rests_on") == a["id"]:
+                continue
+            if a.get("attached_to") == b["id"] or b.get("attached_to") == a["id"]:
+                continue
+            ov = [min(a["bbox_max"][k], b["bbox_max"][k]) - max(a["bbox_min"][k], b["bbox_min"][k]) for k in range(3)]
+            if all(v > OVERLAP_SLACK for v in ov):
+                findings.append({"id": a["id"], "with": b["id"], "kind": "aabb_overlap",
+                                 "overlap_m": [round(v, 3) for v in ov],
+                                 "detail": f"{a['id']} and {b['id']} share {min(ov)*100:.1f} cm of volume "
+                                           f"(bounding boxes; confirm on the meshes)"})
+    return findings
+
+
+def check_articulated(manifest: dict, glb: Path) -> list[dict]:
+    """Each articulated asset must reach the build as a handle with 2+ mesh parts under it."""
+    wanted = [(a["object"], a.get("maps_to_prim") or a["object"])
+              for a in manifest.get("assets", []) if a.get("kind") == "articulated"]
+    if not wanted or not glb.is_file():
+        return []
+    try:
+        import networkx as nx
+        import trimesh
+        scene = trimesh.load(str(glb), force="scene")
+        G = scene.graph.to_networkx()
+        geo = set(scene.graph.nodes_geometry)
+    except Exception as exc:  # noqa: BLE001
+        return [{"kind": "articulated_unchecked", "detail": f"could not open {glb.name}: {exc}"}]
+    findings = []
+    for name, handle in wanted:
+        if handle not in G:
+            findings.append({"id": name, "kind": "articulation_lost",
+                             "detail": f"{name} is articulated in the manifest but its handle {handle!r} "
+                                       f"is not in Room.glb"})
+            continue
+        parts = [n for n in nx.descendants(G, handle) if n in geo]
+        if len(parts) < 2:
+            findings.append({"id": name, "kind": "articulation_lost",
+                             "detail": f"{name} ({handle}) reaches Room.glb as {len(parts)} mesh part(s) — "
+                                       f"its moving/fixed split is gone"})
+    return findings
+
+
+def check_manifold(glb: Path, limit: int = 12) -> list[dict]:
+    if not glb.is_file():
+        return []
+    try:
+        import trimesh
+        scene = trimesh.load(str(glb), force="scene")
+    except Exception:  # noqa: BLE001
+        return []
+    rows = []
+    for name, geom in scene.geometry.items():
+        try:
+            if geom.is_watertight:
+                continue
+            edges = int(len(trimesh.grouping.group_rows(geom.edges_sorted, require_count=1)))
+        except Exception:  # noqa: BLE001
+            continue
+        if edges:
+            rows.append({"mesh": name, "open_edges": edges})
+    rows.sort(key=lambda r: -r["open_edges"])
+    return rows[:limit]
+
+
+def mesh_clashes(room: Path, glb: Path) -> list[dict] | None:
+    """The real-mesh report from check_collisions, when its dependencies are available."""
+    try:
+        from litereality_agent.agent.tools.check_collisions.source import collision_mesh as cm
+        from litereality_agent.agent.tools.check_collisions.source.geometry import _extract_shell
+        shell = _extract_shell((room / "Room.py").read_text(encoding="utf-8"))
+        bodies = cm.build_bodies(glb, shell)
+        out = cm.check_all(bodies, shell)
+        out += [{"id": w["id"], "kind": "open_swing_blocked", "opening": w["opening"], "detail": w["detail"]}
+                for w in cm.open_clearance(bodies, shell)]
+        return out
+    except ImportError:
+        return None
+    except Exception as exc:  # noqa: BLE001 — a mesh hiccup is a note, not a verdict
+        return [{"kind": "mesh_check_failed", "detail": f"{type(exc).__name__}: {exc}"}]
+
+
+def validate(room: Path, preview: Path | None = None) -> dict:
+    room = Path(room)
+    preview = Path(preview) if preview else room.parent / "room_preview"
+    if not (preview / "room_layout.json").is_file():
+        return {"ok": False, "error": f"no build to validate: {preview / 'room_layout.json'} missing "
+                                      f"(compile the room first)", "pass": False}
+    objs, layout, manifest = _load(preview)
+    floor_z = float(layout.get("bounds", {}).get("min", [0, 0, 0])[2])
+    for o in objs:
+        if (o.get("category") or "").lower() == "floor":
+            floor_z = float(o.get("top_z", floor_z))
+            break
+    glb = preview / "Room.glb"
+    support = check_support(objs, floor_z)
+    overlaps = check_overlaps(objs)
+    articulated = check_articulated(manifest, glb)
+    manifold = check_manifold(glb)
+    clashes = mesh_clashes(room, glb)
+    # Bounding boxes cannot tell a chair tucked under a table from a chair through it, so the AABB
+    # list is a REVIEW list; only the real-mesh contacts (python-fcl) block.
+    failing = [f for f in support if f["kind"] in ("floating", "sunk", "undeclared_support", "unknown_support")]
+    failing += [f for f in articulated if f["kind"] == "articulation_lost"]
+    if clashes:
+        failing += [c for c in clashes if c.get("kind") in ("object_clash", "wall_clash", "opening_blocked")]
+    n_decl = sum(1 for o in objs if o.get("rests_on") or o.get("attached_to"))
+    report = {
+        "ok": True, "pass": not failing, "room": str(room), "preview": str(preview),
+        "floor_z": round(floor_z, 4), "objects": len(objs), "declared_support": n_decl,
+        "counts": {"support": len(support), "overlap": len(overlaps), "articulation": len(articulated),
+                   "mesh_clash": (len(clashes) if clashes is not None else None), "open_meshes": len(manifold)},
+        "support": support, "overlap": overlaps, "articulation": articulated,
+        "mesh_clash": clashes, "manifold": manifold,
+        "failing": failing,
+    }
+    return report
+
+
+def summary(report: dict) -> str:
+    if not report.get("ok"):
+        return f"validate: could not run — {report.get('error')}"
+    c = report["counts"]
+    verdict = "PASS" if report["pass"] else f"FAIL ({len(report['failing'])} blocking finding(s))"
+    lines = [f"validate: {verdict} — {report['objects']} objects, {report['declared_support']} with a declared support; "
+             f"support {c['support']}, articulation {c['articulation']}, "
+             f"mesh clashes {c['mesh_clash'] if c['mesh_clash'] is not None else 'n/a (no python-fcl)'}, "
+             f"open meshes {c['open_meshes']}; {c['overlap']} box overlaps to review"]
+    for f in report["failing"][:25]:
+        lines.append(f"  ✗ {f.get('kind')}: {f.get('detail')}")
+    if len(report["failing"]) > 25:
+        lines.append(f"  … {len(report['failing']) - 25} more in validation.json")
+    return "\n".join(lines)
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--room", required=True, type=Path, help="room dir (Room.py)")
+    ap.add_argument("--preview", type=Path, default=None, help="built room dir (default: ../room_preview)")
+    ap.add_argument("--json", type=Path, default=None, help="where to write the report (default: <preview>/validation.json)")
+    a = ap.parse_args(argv)
+    rep = validate(a.room, a.preview)
+    out = a.json or (Path(rep.get("preview", a.room.parent / "room_preview")) / "validation.json")
+    try:
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(rep, indent=1), encoding="utf-8")
+    except OSError:
+        pass
+    print(summary(rep))
+    if rep.get("ok"):
+        print(f"  report → {out}")
+    return 0 if rep.get("pass") else (2 if rep.get("ok") else 1)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_author_resilience.py
+++ b/tests/test_author_resilience.py
@@ -236,9 +236,14 @@ def test_polish_passes_remain_in_the_author_flow(tmp_path: Path, monkeypatch):
     )
 
     assert result.ok
-    assert [module for module, _, _ in calls] == [
+    modules = [module for module, _, _ in calls]
+    assert modules[:4] == [
         "litereality_agent.pipeline.realism_authoring.author.entrypoint",
         "litereality_agent.pipeline.realism_authoring.author.refine_objects",
         "litereality_agent.pipeline.realism_authoring.author.materials",
         "litereality_agent.pipeline.realism_authoring.author.quality",
     ]
+    # After the passes, the gate: a build (nothing here produced room_preview/) so it has
+    # something to judge. The gate itself only runs once a layout exists, which the fake
+    # build does not write — so the build is the last call here.
+    assert modules[4:] == ["litereality_agent.room_ops.compile.build_from_room"]

--- a/tests/test_evidence_kit.py
+++ b/tests/test_evidence_kit.py
@@ -154,3 +154,23 @@ def test_evidence_pack_is_self_contained(scan, tmp_path):
     assert "2 photographs" in (pack / "README.md").read_text()
     # idempotent: a second build keeps the pack
     assert evidence_pack.build(tmp_path / "authoring", scan, stitches) == pack
+
+
+def test_the_pack_finds_the_raw_capture_behind_a_usdz_only_link(scan, tmp_path):
+    """scene.json's capture link can be the usdz-only input dir; the frames are under roots.scans."""
+    from litereality_agent.agent import evidence_pack
+    scene = tmp_path / "Office"; scene.mkdir()
+    usdz_only = scene / "usdz_files"; usdz_only.mkdir(); (usdz_only / "room.usdz").write_bytes(b"")
+    scans_root = tmp_path / "scans_uploaded"; scans_root.mkdir()
+    (scans_root / "Office").symlink_to(scan)
+    (scene / "scene.json").write_text(json.dumps({"scan": "Office", "roots": {"scans": str(scans_root)}}))
+    assert evidence_pack.resolve_scan(usdz_only, scene) == scans_root / "Office"
+    pack = evidence_pack.build(scene / "realism_authoring", usdz_only, None, scene_dir=scene, sheets=False)
+    assert (pack / "scan" / "frame_00000.json").is_file()
+
+
+def test_a_pack_without_frames_is_refused(tmp_path):
+    from litereality_agent.agent import evidence_pack
+    empty = tmp_path / "usdz_only"; empty.mkdir()
+    with pytest.raises(FileNotFoundError):
+        evidence_pack.build(tmp_path / "a", empty, None, sheets=False)

--- a/tests/test_evidence_kit.py
+++ b/tests/test_evidence_kit.py
@@ -1,0 +1,156 @@
+"""The evidence kit measures the scan the way the one-shot run did by hand — and gets the same numbers.
+
+A synthetic capture with known geometry: a flat floor at z=0 and a 0.75 m desk slab, seen by two
+cameras with ARKit conventions (Y up, camera looks down -Z). Every helper is checked against the
+truth it was built from, not against itself.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from litereality_agent import evidence_kit
+
+KIT = Path(evidence_kit.__file__).parent
+sys.path.insert(0, str(KIT))
+from read_scan import Scan  # noqa: E402
+import measure  # noqa: E402
+import rectify  # noqa: E402
+import contact_sheets  # noqa: E402
+
+W, H, DW, DH = 640, 480, 160, 120
+FX = 500.0
+DESK_Z_ARKIT = 0.75  # metres above the floor; ARKit Y-up, so this is the y coordinate
+
+
+def _pose_looking_down(x: float, z: float, height: float) -> np.ndarray:
+    """A camera at (x, height, z) in ARKit world looking straight down (-Y), image 'up' = -Z."""
+    M = np.eye(4)
+    # camera axes in world: right=+X, up=-Z, forward(-Zcam)=-Y  => Zcam = +Y
+    M[:3, 0] = [1, 0, 0]
+    M[:3, 1] = [0, 0, -1]
+    M[:3, 2] = [0, 1, 0]
+    M[:3, 3] = [x, height, z]
+    return M
+
+
+def _render_depth(pose: np.ndarray, K: np.ndarray, size) -> np.ndarray:
+    """Ray-cast the synthetic world: floor at y=0, a desk slab (top y=0.75) over x∈[0,1.6], z∈[0,0.8]."""
+    w, h = size
+    v, u = np.mgrid[0:h, 0:w]
+    d = np.stack([(u - K[0, 2]) / K[0, 0], -(v - K[1, 2]) / K[1, 1], -np.ones_like(u, dtype=float)], -1)
+    dw = d @ pose[:3, :3].T
+    o = pose[:3, 3]
+    out = np.zeros((h, w), dtype=np.float32)
+    for plane_y, box in ((DESK_Z_ARKIT, ((0.0, 1.6), (0.0, 0.8))), (0.0, None)):
+        t = (plane_y - o[1]) / dw[..., 1]
+        pts = o + t[..., None] * dw
+        ok = (t > 0) & (out == 0)
+        if box:
+            ok &= (pts[..., 0] >= box[0][0]) & (pts[..., 0] <= box[0][1]) & (pts[..., 2] >= box[1][0]) & (pts[..., 2] <= box[1][1])
+        depth = -(np.linalg.inv(pose) @ np.concatenate([pts, np.ones_like(t)[..., None]], -1)[..., None])[..., 2, 0]
+        out[ok] = depth[ok]
+    return out
+
+
+@pytest.fixture(scope="module")
+def scan(tmp_path_factory) -> Path:
+    d = tmp_path_factory.mktemp("scan")
+    K = np.array([[FX, 0, W / 2], [0, FX, H / 2], [0, 0, 1]])
+    rng = np.random.default_rng(0)
+    for i, (x, z) in enumerate([(0.8, 0.4), (1.1, 0.6)]):
+        pose = _pose_looking_down(x, z, 2.4)
+        (d / f"frame_{i:05d}.json").write_text(json.dumps({
+            "frame_index": i, "cameraPoseARFrame": pose.flatten().tolist(), "intrinsics": K.flatten().tolist()}))
+        Image.fromarray(rng.integers(0, 255, (H, W, 3), dtype=np.uint8)).save(d / f"frame_{i:05d}.jpg")
+        kd = K.copy(); kd[0, :] *= DW / W; kd[1, :] *= DH / H
+        depth = _render_depth(pose, kd, (DW, DH))
+        Image.fromarray((depth * 1000).astype(np.uint16)).save(d / f"depth_{i:05d}.png")
+        Image.fromarray(np.full((DH, DW), 2, dtype=np.uint8)).save(d / f"conf_{i:05d}.png")
+    # point cloud: floor + desk top, ARKit frame
+    floor = np.c_[rng.uniform(-1, 3, 4000), rng.normal(0, 0.005, 4000), rng.uniform(-1, 3, 4000)]
+    desk = np.c_[rng.uniform(0, 1.6, 1500), DESK_Z_ARKIT + rng.normal(0, 0.005, 1500), rng.uniform(0, 0.8, 1500)]
+    pts = np.vstack([floor, desk])
+    with open(d / "pointcloud.pcd", "w") as fh:
+        fh.write("# .PCD v0.7\nVERSION 0.7\nFIELDS x y z\nSIZE 4 4 4\nTYPE F F F\nCOUNT 1 1 1\n"
+                 f"WIDTH {len(pts)}\nHEIGHT 1\nVIEWPOINT 0 0 0 1 0 0 0\nPOINTS {len(pts)}\nDATA ascii\n")
+        np.savetxt(fh, pts, fmt="%.4f")
+    return d
+
+
+def test_scan_reads_frames_poses_and_the_cloud(scan):
+    S = Scan(str(scan))
+    assert S.indices() == [0, 1]
+    assert S.rgb(0).shape == (H, W, 3)
+    assert S.depth(0).shape == (DH, DW) and S.depth(0).max() > 2.0
+    assert S.pcd().shape[1] == 3 and len(S.pcd()) == 5500
+    # ARKit y (height) becomes Blender z
+    assert np.allclose(S.pcd_blender()[:, 2], S.pcd()[:, 1])
+
+
+def test_probe_depth_lands_on_the_desk_top(scan):
+    S = Scan(str(scan))
+    # camera 0 is above (0.8, 0.4): the image centre looks straight down onto the desk
+    p = measure.probe_depth(S, 0, W / 2, H / 2)
+    assert p["point"] is not None
+    assert p["point"][2] == pytest.approx(DESK_Z_ARKIT, abs=0.01)     # Blender z = height
+    assert p["point"][0] == pytest.approx(0.8, abs=0.01)
+
+
+def test_triangulate_recovers_a_point_seen_twice(scan):
+    S = Scan(str(scan))
+    X = np.array([0.5, 0.3, DESK_Z_ARKIT])   # Blender world (x, y=-z_arkit, z=height)
+    obs = []
+    for i in (0, 1):
+        M = np.linalg.inv(S.pose_blender(i)); K = S.K(i)
+        c = M @ np.append(X, 1.0)
+        obs.append((i, (K[0, 0] * c[0] / -c[2] + K[0, 2], K[1, 1] * -c[1] / -c[2] + K[1, 2])))
+    t = measure.triangulate(S, obs)
+    assert np.allclose(t["point"], X, atol=1e-3) and t["residual_m"] < 1e-3
+
+
+def test_height_profile_finds_the_desk_and_floor(scan):
+    S = Scan(str(scan))
+    assert measure.floor_z(S) == pytest.approx(0.0, abs=0.02)
+    prof = measure.height_profile(S, (0.0, -0.8, 1.6, 0.0), floor_z=0.0)   # desk footprint (Blender y = -z_arkit)
+    assert any(abs(h - DESK_Z_ARKIT) < 0.02 for h in prof["surfaces_m"][:2])
+
+
+def test_pcd_slice_draws_only_the_desk_at_desk_height(scan, tmp_path):
+    S = Scan(str(scan))
+    sl = measure.pcd_slice(S, 0.70, 0.80, floor_z=0.0, out_png=str(tmp_path / "s.png"))
+    assert sl["n_points"] > 1000 and (tmp_path / "s.png").is_file()
+    rows, cols = np.nonzero(sl["grid"])
+    xs = sl["x0"] + cols * sl["cell_m"]
+    assert xs.min() > -0.1 and xs.max() < 1.7           # the desk's x extent, nothing else
+
+
+def test_rectify_writes_a_texture_of_the_requested_size(scan, tmp_path):
+    S = Scan(str(scan))
+    out = rectify.rectify_region(S, 0, [(100, 100), (300, 110), (290, 300), (110, 290)], str(tmp_path / "t.png"), (256, 200))
+    assert Image.open(out).size == (256, 200)
+
+
+def test_contact_sheets_cover_every_frame(scan, tmp_path):
+    S = Scan(str(scan))
+    sheets = contact_sheets.build(S, str(tmp_path / "cs"), per_sheet=1)
+    assert len(sheets) == 2 and all(Path(p).is_file() for p in sheets)
+
+
+def test_evidence_pack_is_self_contained(scan, tmp_path):
+    from litereality_agent.agent import evidence_pack
+    stitches = tmp_path / "surface_ref"; stitches.mkdir()
+    pack = evidence_pack.build(tmp_path / "authoring", scan, stitches)
+    assert (pack / "README.md").is_file() and "Rx(+90)" in (pack / "README.md").read_text()
+    assert (pack / "scan").is_symlink() and (pack / "scan" / "pointcloud.pcd").is_file()
+    assert (pack / "helpers" / "measure.py").is_file() and not (pack / "helpers").is_symlink()
+    assert len(list((pack / "contact_sheets").glob("*.jpg"))) == 1
+    assert "2 photographs" in (pack / "README.md").read_text()
+    # idempotent: a second build keeps the pack
+    assert evidence_pack.build(tmp_path / "authoring", scan, stitches) == pack

--- a/tests/test_evidence_kit.py
+++ b/tests/test_evidence_kit.py
@@ -19,10 +19,10 @@ from litereality_agent import evidence_kit
 
 KIT = Path(evidence_kit.__file__).parent
 sys.path.insert(0, str(KIT))
-from read_scan import Scan  # noqa: E402
+import contact_sheets  # noqa: E402
 import measure  # noqa: E402
 import rectify  # noqa: E402
-import contact_sheets  # noqa: E402
+from read_scan import Scan  # noqa: E402
 
 W, H, DW, DH = 640, 480, 160, 120
 FX = 500.0
@@ -69,7 +69,9 @@ def scan(tmp_path_factory) -> Path:
         (d / f"frame_{i:05d}.json").write_text(json.dumps({
             "frame_index": i, "cameraPoseARFrame": pose.flatten().tolist(), "intrinsics": K.flatten().tolist()}))
         Image.fromarray(rng.integers(0, 255, (H, W, 3), dtype=np.uint8)).save(d / f"frame_{i:05d}.jpg")
-        kd = K.copy(); kd[0, :] *= DW / W; kd[1, :] *= DH / H
+        kd = K.copy()
+        kd[0, :] *= DW / W
+        kd[1, :] *= DH / H
         depth = _render_depth(pose, kd, (DW, DH))
         Image.fromarray((depth * 1000).astype(np.uint16)).save(d / f"depth_{i:05d}.png")
         Image.fromarray(np.full((DH, DW), 2, dtype=np.uint8)).save(d / f"conf_{i:05d}.png")
@@ -108,7 +110,8 @@ def test_triangulate_recovers_a_point_seen_twice(scan):
     X = np.array([0.5, 0.3, DESK_Z_ARKIT])   # Blender world (x, y=-z_arkit, z=height)
     obs = []
     for i in (0, 1):
-        M = np.linalg.inv(S.pose_blender(i)); K = S.K(i)
+        M = np.linalg.inv(S.pose_blender(i))
+        K = S.K(i)
         c = M @ np.append(X, 1.0)
         obs.append((i, (K[0, 0] * c[0] / -c[2] + K[0, 2], K[1, 1] * -c[1] / -c[2] + K[1, 2])))
     t = measure.triangulate(S, obs)
@@ -145,7 +148,8 @@ def test_contact_sheets_cover_every_frame(scan, tmp_path):
 
 def test_evidence_pack_is_self_contained(scan, tmp_path):
     from litereality_agent.agent import evidence_pack
-    stitches = tmp_path / "surface_ref"; stitches.mkdir()
+    stitches = tmp_path / "surface_ref"
+    stitches.mkdir()
     pack = evidence_pack.build(tmp_path / "authoring", scan, stitches)
     assert (pack / "README.md").is_file() and "Rx(+90)" in (pack / "README.md").read_text()
     assert (pack / "scan").is_symlink() and (pack / "scan" / "pointcloud.pcd").is_file()
@@ -159,9 +163,13 @@ def test_evidence_pack_is_self_contained(scan, tmp_path):
 def test_the_pack_finds_the_raw_capture_behind_a_usdz_only_link(scan, tmp_path):
     """scene.json's capture link can be the usdz-only input dir; the frames are under roots.scans."""
     from litereality_agent.agent import evidence_pack
-    scene = tmp_path / "Office"; scene.mkdir()
-    usdz_only = scene / "usdz_files"; usdz_only.mkdir(); (usdz_only / "room.usdz").write_bytes(b"")
-    scans_root = tmp_path / "scans_uploaded"; scans_root.mkdir()
+    scene = tmp_path / "Office"
+    scene.mkdir()
+    usdz_only = scene / "usdz_files"
+    usdz_only.mkdir()
+    (usdz_only / "room.usdz").write_bytes(b"")
+    scans_root = tmp_path / "scans_uploaded"
+    scans_root.mkdir()
     (scans_root / "Office").symlink_to(scan)
     (scene / "scene.json").write_text(json.dumps({"scan": "Office", "roots": {"scans": str(scans_root)}}))
     assert evidence_pack.resolve_scan(usdz_only, scene) == scans_root / "Office"
@@ -171,6 +179,7 @@ def test_the_pack_finds_the_raw_capture_behind_a_usdz_only_link(scan, tmp_path):
 
 def test_a_pack_without_frames_is_refused(tmp_path):
     from litereality_agent.agent import evidence_pack
-    empty = tmp_path / "usdz_only"; empty.mkdir()
+    empty = tmp_path / "usdz_only"
+    empty.mkdir()
     with pytest.raises(FileNotFoundError):
         evidence_pack.build(tmp_path / "a", empty, None, sheets=False)

--- a/tests/test_open_profile.py
+++ b/tests/test_open_profile.py
@@ -30,6 +30,7 @@ def test_the_scripted_profiles_still_format_with_the_extra_fields():
 
 def test_entrypoint_defaults_budgets_per_profile(monkeypatch):
     import sys
+
     from litereality_agent.pipeline.realism_authoring.author import entrypoint
 
     seen = {}

--- a/tests/test_open_profile.py
+++ b/tests/test_open_profile.py
@@ -1,0 +1,49 @@
+"""The `open` profile: a brief with the evidence pack, its own budgets, and the codex harness by default."""
+
+from __future__ import annotations
+
+from litereality_agent.agent import author
+
+
+def test_open_is_a_registered_profile_with_larger_budgets():
+    assert "open" in author.PROFILES
+    assert author.OPEN_STEP_BUDGET > 100 and author.OPEN_MAX_TURNS > 140
+
+
+def test_the_open_brief_points_at_the_pack_and_the_gate():
+    text = author.OPEN_PROMPT.format(
+        stitch_lines="", scan="/s", surface_list="Wall0", rhythm="", evidence="/a/evidence",
+        n_frames=59, python="/py", blender="/bl", scratch="/sc")
+    assert "/a/evidence/helpers" in text and "measure.probe_depth" in text
+    assert "litereality_agent.pipeline.room_qc.validate" in text and "/py -m" in text
+    assert "rests_on=" in text and "fetch_material" in text
+    # freedom, stated: the process is the model's, the result is gated
+    assert "HOW YOU WORK IS YOURS" in text
+    assert "EDIT `Room.py` AT LEAST ONCE EVERY" not in text
+
+
+def test_the_scripted_profiles_still_format_with_the_extra_fields():
+    for name in ("base", "detail", "simulation"):
+        author.PROFILES[name].format(stitch_lines="", scan="/s", surface_list="Wall0", rhythm=author.RHYTHM,
+                                     evidence="", n_frames=0, python="", blender="", scratch="")
+
+
+def test_entrypoint_defaults_budgets_per_profile(monkeypatch):
+    import sys
+    from litereality_agent.pipeline.realism_authoring.author import entrypoint
+
+    seen = {}
+
+    async def fake_run(room, surface_ref, scan, model, max_turns, profile, **kw):
+        seen.update(max_turns=max_turns, profile=profile, **kw)
+        return 0
+
+    monkeypatch.setattr(entrypoint, "run", fake_run)
+    monkeypatch.delenv("AUTHOR_STEPS", raising=False)
+    for profile, turns, steps in (("open", author.OPEN_MAX_TURNS, author.OPEN_STEP_BUDGET), ("simulation", 140, 100)):
+        monkeypatch.setattr(sys, "argv", ["x", "--room", "/r", "--surface-ref", "/s", "--scan", "/c", "--profile", profile])
+        try:
+            entrypoint.main()
+        except SystemExit:
+            pass
+        assert (seen["max_turns"], seen["step_budget"]) == (turns, steps), profile

--- a/tests/test_validate_gate.py
+++ b/tests/test_validate_gate.py
@@ -1,0 +1,80 @@
+"""The validation gate judges the CLAIMS the author made against the geometry the build wrote."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from litereality_agent.pipeline.room_qc import validate as V
+
+
+def _obj(i, cat, mn, mx, **kw):
+    return {"id": i, "category": cat, "bbox_min": list(mn), "bbox_max": list(mx),
+            "top_z": mx[2], "center": [(a + b) / 2 for a, b in zip(mn, mx)], **kw}
+
+
+def _layout(objs):
+    return {"bounds": {"min": [-3, -3, 0.0], "max": [3, 3, 2.7]}, "objects": objs}
+
+
+FLOOR = _obj("Floor0", "floor", (-3, -3, -0.01), (3, 3, 0.0))
+TABLE = _obj("Table0", "table", (0, 0, 0.0), (1.2, 0.8, 0.75))
+
+
+def test_a_seated_prop_passes():
+    mug = _obj("Mug0", "mug", (0.2, 0.2, 0.75), (0.28, 0.28, 0.85), rests_on="Table0")
+    assert V.check_support([FLOOR, TABLE, mug], 0.0) == []
+
+
+def test_a_floating_prop_is_named_with_the_drop():
+    mug = _obj("Mug0", "mug", (0.2, 0.2, 0.80), (0.28, 0.28, 0.90), rests_on="Table0")
+    f = V.check_support([FLOOR, TABLE, mug], 0.0)
+    assert [x["kind"] for x in f] == ["floating"] and f[0]["gap_m"] == 0.05
+
+
+def test_a_sunk_prop_and_an_undeclared_one_are_both_findings():
+    mug = _obj("Mug0", "mug", (0.2, 0.2, 0.70), (0.28, 0.28, 0.80), rests_on="Table0")
+    lamp = _obj("Lamp0", "lamp", (0.5, 0.5, 0.75), (0.6, 0.6, 1.1))
+    kinds = sorted(x["kind"] for x in V.check_support([FLOOR, TABLE, mug, lamp], 0.0))
+    assert kinds == ["sunk", "undeclared_support"]
+
+
+def test_a_prop_hanging_off_its_support_is_flagged():
+    mug = _obj("Mug0", "mug", (1.15, 0.2, 0.75), (1.35, 0.28, 0.85), rests_on="Table0")
+    assert [x["kind"] for x in V.check_support([FLOOR, TABLE, mug], 0.0)] == ["off_support"]
+
+
+def test_floor_standing_furniture_is_checked_against_the_floor_without_a_claim():
+    chair = _obj("Chair0", "chair", (2, 2, 0.10), (2.5, 2.5, 0.9))
+    f = V.check_support([FLOOR, TABLE, chair], 0.0)
+    assert f and f[0]["kind"] == "floating" and f[0]["rests_on"] == "floor"
+
+
+def test_box_overlaps_are_advisory_and_skip_support_pairs():
+    mug = _obj("Mug0", "mug", (0.2, 0.2, 0.75), (0.28, 0.28, 0.85), rests_on="Table0")
+    chair = _obj("Chair0", "chair", (0.5, 0.3, 0.0), (1.0, 0.9, 0.9))     # tucked under the table
+    ov = V.check_overlaps([FLOOR, TABLE, mug, chair])
+    assert [(o["id"], o["with"]) for o in ov] == [("Table0", "Chair0")]
+
+
+def test_the_verdict_blocks_on_support_but_not_on_boxes(tmp_path: Path):
+    room = tmp_path / "room"; room.mkdir()
+    (room / "Room.py").write_text("SHELL = {}\n")
+    prev = tmp_path / "room_preview"; prev.mkdir()
+    chair = _obj("Chair0", "chair", (0.5, 0.3, 0.0), (1.0, 0.9, 0.9))
+    mug = _obj("Mug0", "mug", (0.2, 0.2, 0.80), (0.28, 0.28, 0.90), rests_on="Table0")
+    (prev / "room_layout.json").write_text(json.dumps(_layout([FLOOR, TABLE, chair, mug])))
+    rep = V.validate(room, prev)
+    assert rep["ok"] and not rep["pass"]
+    assert [f["kind"] for f in rep["failing"]] == ["floating"]
+    assert rep["counts"]["overlap"] == 1                      # reported, not blocking
+    assert V.main(["--room", str(room), "--preview", str(prev)]) == 2
+    assert (prev / "validation.json").is_file()
+    mug["bbox_min"][2], mug["bbox_max"][2] = 0.75, 0.85
+    (prev / "room_layout.json").write_text(json.dumps(_layout([FLOOR, TABLE, chair, mug])))
+    assert V.main(["--room", str(room), "--preview", str(prev)]) == 0
+
+
+def test_no_build_is_a_clear_error_not_a_pass(tmp_path: Path):
+    rep = V.validate(tmp_path / "room", tmp_path / "nowhere")
+    assert not rep["ok"] and not rep["pass"] and "compile" in rep["error"]

--- a/tests/test_validate_gate.py
+++ b/tests/test_validate_gate.py
@@ -58,9 +58,11 @@ def test_box_overlaps_are_advisory_and_skip_support_pairs():
 
 
 def test_the_verdict_blocks_on_support_but_not_on_boxes(tmp_path: Path):
-    room = tmp_path / "room"; room.mkdir()
+    room = tmp_path / "room"
+    room.mkdir()
     (room / "Room.py").write_text("SHELL = {}\n")
-    prev = tmp_path / "room_preview"; prev.mkdir()
+    prev = tmp_path / "room_preview"
+    prev.mkdir()
     chair = _obj("Chair0", "chair", (0.5, 0.3, 0.0), (1.0, 0.9, 0.9))
     mug = _obj("Mug0", "mug", (0.2, 0.2, 0.80), (0.28, 0.28, 0.90), rests_on="Table0")
     (prev / "room_layout.json").write_text(json.dumps(_layout([FLOOR, TABLE, chair, mug])))


### PR DESCRIPTION
## Why

We ran GPT-6 (Codex, `gpt-6-astra`) on Office_room two ways and rendered both from the same 59 capture cameras with the same Cycles setup:

- **GPT-6 alone** — the raw scan (frames, depth, point cloud, `room.usdz`) and a one-page brief, no LiteReality tooling. 37 min, 69 tool calls.
- **GPT-6 on our infra** — the current `simulation` authoring profile over the pipeline's assets.

Our side won clearly on **materials** (`fetch_material`'s photo-matched PBR: carpet pile, wood grain, acoustic tile, the blind's fabric — GPT-6 alone had permission to fetch and still chose flat procedural colour), on real glazing, on reconstructed/articulated assets and on sim export. GPT-6 alone won on **layout and fixtures**: it measured desk and shelf heights from the depth maps, triangulated chair positions from silhouettes, built the heater with fins and dials, the AC louvres, sockets at the measured spacing, the coat on its hooks — and rebuilt until its own contact/intersection audit passed. Our scripted profile tells the model what to read, in what order, and what not to touch; none of that measuring was possible with what it was given.

This PR keeps what the infra does well and gives the model what the one-shot run had.

## What

**`--author-profile open`** — a brief, not a script. It states what a finished room has and how it is judged; "how you work is yours", with two conditions (`Room.py` compiles after every save; save as you go). Furniture boxes may be corrected when a measurement says so; articulated and reconstructed assets must survive. Defaults to the Codex/gpt-6 harness and to budgets the brief needs (300 steps / 400 turns — the one-shot took 69 calls; our last pass was cut at 56).

**Evidence kit + pack** (`evidence_kit/`, `agent/evidence_pack.py`) — plain-python helpers the model imports in its own scripts, laid out beside the room as `evidence/`: contact sheets of every photograph, the stitches, the raw capture, and `measure.probe_depth / triangulate / height_profile / pcd_slice`, `rectify.rectify_region`, `arkit_cameras`. One README states the data formats and the Y-up→Z-up convention once. Verified on Office_room: the cloud's floor within 3 cm of RoomPlan's; desk and meeting table both read **0.75 m** — the numbers GPT-6 measured by hand.

**Validation gate** (`pipeline/room_qc/validate.py`) — every `rests_on` claim measured against its support's top (+1 cm / −2 cm, over its footprint), floor-standing furniture against the floor, undeclared supports, the real-mesh contact report (python-fcl), and whether each articulated asset still reaches the build as a handle with its parts. Box overlaps are advisory (a chair tucked under a table overlaps its box legitimately). `validation.json` beside the layout; exit 0/2. The brief tells the model to run it; the author stage builds the room if the session didn't and runs it again, recording the verdict. Current Office_room build: PASS — 0 clashes, 131 declared supports all seated.

**Trace fixes** the same measurement exposed: the session record carries the model that actually ran (the Office_room gpt-6 session was filed under `claude-opus-5`, the role's name) and the harness; on Codex the raw rollout is copied beside the trace — the only place that says which images the model was actually shown (28, against 84 filename mentions the trace had counted).

**Ported from `zhening/gpt-6`** (never landed on main): the `simulation` profile with `rests_on`/`attached_to` and the `--author-profile/--author-turns` flags, the Codex whole-output fix, and the chair-QC gate in reconstruct.

## Verification

- 631 tests pass; the two failures are the pre-existing environment ones (`test_stdio_bridge_matches_the_registry` — the venv lacks the installed package; `test_reconstruct_resolves_python_from_canonical_repo_root` — a real `scans_uploaded/Office_room` shadows the test's path).
- New tests: the kit on a synthetic capture with known geometry (probe lands on the desk top, triangulation round-trips to 1e-3 m, height profile finds desk + floor, slice draws only the desk); the gate on floating / sunk / undeclared / off-support / tucked-under cases and its exit codes; profile registration, budgets, and that the scripted profiles still format.
- Smoke-tested end to end on Office_room with a 6-call Claude session: pack built, README read first, trace fields present, build + gate PASS.
- A full `open`-profile run on Office_room with gpt-6 is queued for when the Codex quota window reopens; the three-way render comparison (GPT-6 alone / current profile / open) will be posted here.
